### PR TITLE
feat: worker auto-schedule for sync + stale-run reaping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,3 +48,8 @@ R2_SECRET_ACCESS_KEY=""
 # CRAWLER_TTL_DOC_DAYS=180    # DocumentCenter PDFs (near-immutable)
 # CRAWLER_SYNC_BATCH=200      # due-resources claimed per batch
 # CRAWLER_ERROR_BACKOFF_HOURS=6  # re-schedule delay for a failed URL
+#
+# Auto-schedule: an idle worker enqueues a `sync` run this often (0 = disabled,
+# manual/dashboard runs only). Crashed runs are reaped after WORKER_STALE_MINUTES.
+# SYNC_SCHEDULE_MINUTES=60
+# WORKER_STALE_MINUTES=5

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -202,6 +202,7 @@ Full list in [`.env.example`](../.env.example).
 | `CRAWLER_SEEDS`                                                           | worker       | Comma-separated paths/URLs to override the default seeds.          |
 | `CRAWLER_TTL_{CORE,PAGE,AGENDA,DOC}_DAYS`                                 | worker       | `sync` per-tier freshness TTLs (default 7/7/30/180). See §11.      |
 | `CRAWLER_SYNC_BATCH` / `CRAWLER_ERROR_BACKOFF_HOURS`                      | worker       | `sync` claim batch size / failed-URL re-schedule delay.            |
+| `SYNC_SCHEDULE_MINUTES` / `WORKER_STALE_MINUTES`                          | worker       | Auto-enqueue `sync` this often (0=off); reap crashed runs. §11.    |
 
 ---
 
@@ -264,8 +265,13 @@ This gives all four properties at once:
 TTLs are env-tunable per tier (`CRAWLER_TTL_CORE_DAYS`, `_PAGE_`, `_AGENDA_`,
 `_DOC_`; defaults 7/7/30/180); `CRAWLER_SYNC_BATCH` sizes the claim query;
 `CRAWLER_ERROR_BACKOFF_HOURS` re-schedules a failed URL. The BFS `crawl`/`recrawl`
-modes remain for one-shot use. Pair `sync` with a cron (the `schedule` skill) to
-run it automatically.
+modes remain for one-shot use.
+
+**Auto-schedule.** Set `SYNC_SCHEDULE_MINUTES` and an idle worker enqueues a `sync`
+run that often (no external cron — the worker is the always-on component). It skips
+when a run is already active, so runs never stack. It also **reaps stale runs**: a
+`running`/`paused` row whose heartbeat is older than `WORKER_STALE_MINUTES` (default 5) is marked failed, so a crashed worker doesn't block claims or the schedule.
+Scheduler-triggered runs are tagged `requested_by = 'scheduler'` (⏱ in the dashboard).
 
 ---
 
@@ -323,8 +329,6 @@ DocumentCenter index is a React SPA, so its folder listing isn't in the page HTM
 
 ## 15. Open items / future work
 
-- **Scheduling** — wire a cron (the `schedule` skill) to run `sync` automatically
-  (e.g. hourly); it no-ops when nothing is due.
 - **"View stored copy"** — presign an R2 URL (or serve local blobs) from the
   content explorer so you can open an archived page/PDF from the dashboard.
 - **Hash normalization** — CivicPlus embeds per-request tokens, so re-fetches

--- a/src/routes/dashboard/runs/+page.svelte
+++ b/src/routes/dashboard/runs/+page.svelte
@@ -37,7 +37,13 @@
 					class="cursor-pointer"
 					onclick={() => (window.location.href = `/dashboard/runs/${r.id}`)}
 				>
-					<Table.Cell class="font-medium capitalize">{r.mode}</Table.Cell>
+					<Table.Cell class="font-medium capitalize">
+						{r.mode}
+						{#if r.requestedBy === 'scheduler'}<span
+								class="ml-1 text-xs text-muted-foreground"
+								title="Auto-scheduled">⏱</span
+							>{/if}
+					</Table.Cell>
 					<Table.Cell><Badge variant={statusVariant(r.status)}>{r.status}</Badge></Table.Cell>
 					<Table.Cell class="text-right tabular-nums">{formatNumber(r.pages)}</Table.Cell>
 					<Table.Cell class="text-right tabular-nums">{formatNumber(r.documents)}</Table.Cell>

--- a/worker/README.md
+++ b/worker/README.md
@@ -59,6 +59,9 @@ recorded as `probed` (size/etag, no blob); `0` = skip all documents (pages-only)
 # Long-running poll loop (production shape): claims queued runs from the dashboard
 bun run worker
 
+# ...with auto-sync every hour (idle worker enqueues a `sync` run on a schedule)
+SYNC_SCHEDULE_MINUTES=60 bun run worker
+
 # One-shot (ops/testing) — enqueues + runs a single job, then exits
 bun run worker/index.ts --mode estimate --max 80 --once
 bun run worker/index.ts --mode crawl --once

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -105,3 +105,11 @@ export function ttlFor(priority: number): number {
 export const SYNC_BATCH = Number(process.env.CRAWLER_SYNC_BATCH ?? 200);
 export const SYNC_ERROR_BACKOFF_MS =
 	Number(process.env.CRAWLER_ERROR_BACKOFF_HOURS ?? 6) * 3_600_000;
+
+// Auto-schedule: when > 0, an idle worker enqueues a `sync` run this often.
+// 0 / unset = disabled (only manual/dashboard runs). See worker/index.ts.
+export const SYNC_SCHEDULE_MS = Number(process.env.SYNC_SCHEDULE_MINUTES ?? 0) * 60_000;
+
+// A run whose heartbeat is older than this is considered dead and reaped, so a
+// crashed worker doesn't leave a `running` row blocking the schedule forever.
+export const STALE_RUN_MS = Number(process.env.WORKER_STALE_MINUTES ?? 5) * 60_000;

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -7,15 +7,18 @@
 //   bun run worker/index.ts --mode crawl          # enqueue + run once, then exit
 import { readdirSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { and, asc, eq } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, lt } from 'drizzle-orm';
 import { client, db } from './db';
 import { syncRun } from '../src/lib/server/db/schema';
 import type { SyncRun } from '../src/lib/server/db/crawl.schema';
 import { applyMigrations } from '../src/lib/server/db/migrator';
+import { SYNC_SCHEDULE_MS, STALE_RUN_MS } from './config';
 import { executeRun, executeSync } from './crawl';
 
 const WORKER_ID = `${process.env.HOSTNAME ?? 'worker'}-${process.pid}-${crypto.randomUUID().slice(0, 8)}`;
 const POLL_INTERVAL_MS = 3000;
+const MAINTENANCE_INTERVAL_MS = 30_000;
+const ACTIVE = ['queued', 'running', 'paused'] as const;
 
 let stopping = false;
 process.on(
@@ -72,9 +75,53 @@ async function runOne(run: SyncRun): Promise<void> {
 	}
 }
 
+/** Mark crashed runs (running/paused, heartbeat gone stale) as failed, so a dead
+ *  worker doesn't leave an active row blocking claims + the schedule. */
+async function reapStaleRuns(): Promise<void> {
+	const reaped = await db
+		.update(syncRun)
+		.set({ status: 'failed', finishedAt: new Date(), error: 'worker heartbeat timed out (reaped)' })
+		.where(
+			and(
+				inArray(syncRun.status, ['running', 'paused']),
+				lt(syncRun.heartbeatAt, new Date(Date.now() - STALE_RUN_MS))
+			)
+		)
+		.returning({ id: syncRun.id });
+	if (reaped.length) console.log(`reaped ${reaped.length} stale run(s)`);
+}
+
+/** Auto-schedule: enqueue a `sync` run when enabled, idle, and one is due. */
+async function maybeScheduleSync(): Promise<void> {
+	if (SYNC_SCHEDULE_MS <= 0) return;
+	const [active] = await db
+		.select({ id: syncRun.id })
+		.from(syncRun)
+		.where(inArray(syncRun.status, [...ACTIVE]))
+		.limit(1);
+	if (active) return; // don't stack runs
+	const [last] = await db
+		.select({ at: syncRun.requestedAt })
+		.from(syncRun)
+		.where(eq(syncRun.mode, 'sync'))
+		.orderBy(desc(syncRun.requestedAt))
+		.limit(1);
+	const dueAt = last ? last.at.getTime() + SYNC_SCHEDULE_MS : 0;
+	if (Date.now() < dueAt) return;
+	await db.insert(syncRun).values({ mode: 'sync', status: 'queued', requestedBy: 'scheduler' });
+	console.log('scheduled sync enqueued');
+}
+
 async function pollLoop(): Promise<void> {
-	console.log(`sync worker ${WORKER_ID} polling (every ${POLL_INTERVAL_MS}ms)`);
+	const sched = SYNC_SCHEDULE_MS > 0 ? `; auto-sync every ${SYNC_SCHEDULE_MS / 60_000}m` : '';
+	console.log(`sync worker ${WORKER_ID} polling (every ${POLL_INTERVAL_MS}ms${sched})`);
+	let lastMaintenance = 0;
 	while (!stopping) {
+		if (Date.now() - lastMaintenance > MAINTENANCE_INTERVAL_MS) {
+			lastMaintenance = Date.now();
+			await reapStaleRuns();
+			await maybeScheduleSync();
+		}
 		const run = await claimNext();
 		if (run) await runOne(run);
 		else await Bun.sleep(POLL_INTERVAL_MS);


### PR DESCRIPTION
Makes freshness hands-off. The always-on worker becomes its own scheduler — no external cron, no serverless timers.

## What it does
- **Auto-schedule**: set `SYNC_SCHEDULE_MINUTES` and an idle worker enqueues a `sync` run that often (`0`/unset = disabled, manual runs only). Since `sync` only fetches what's *due*, a scheduled run no-ops cheaply when nothing changed, or drains the backlog when it has.
- **No stacking**: skips if a run is already `queued`/`running`/`paused`, and won't re-enqueue until the interval has elapsed since the last sync.
- **Stale-run reaping**: a `running`/`paused` row whose heartbeat is older than `WORKER_STALE_MINUTES` (default 5) is marked `failed` — so a crashed worker doesn't leave a zombie run blocking claims or the schedule. Also runs on the poll loop's maintenance tick (every 30s).
- **Tagging**: scheduled runs are `requested_by = 'scheduler'`, shown with a ⏱ in the dashboard runs table.

## Usage
```bash
SYNC_SCHEDULE_MINUTES=60 bun run worker   # sync hourly, hands-off
```

## Verified
Functional test of the scheduler/reaper against a scratch DB: enqueues when due → skips while a run is active → reaps a stale run → correctly declines to re-enqueue before the interval. `svelte-check`, `eslint`, and `prettier` clean.

Docs updated (ARCHITECTURE §11 + env table, `.env.example`, worker README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)