### PR TITLE
feat: view archived copies from the dashboard

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "orleans",
+      "dependencies": {
+        "aws4fetch": "^1.0.20",
+      },
       "devDependencies": {
         "@better-auth/cli": "~1.4.21",
         "@chromatic-com/storybook": "^5.2.1",
@@ -733,6 +736,8 @@
     "ast-v8-to-istanbul": ["ast-v8-to-istanbul@1.0.4", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA=="],
 
     "async-sema": ["async-sema@3.1.1", "", {}, "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg=="],
+
+    "aws4fetch": ["aws4fetch@1.0.20", "", {}, "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g=="],
 
     "axe-core": ["axe-core@4.12.1", "", {}, "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA=="],
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -122,6 +122,12 @@ bun run worker/sync-blobs.ts --both --dry-run
 Cost-saving workflow: crawl locally (`BLOB_STORE=local`, no R2 usage), then
 `bun run blobs:push` when you want it durable.
 
+**Viewing an archived copy.** The dashboard's content explorer links each stored
+resource to `/dashboard/blob/[id]` (auth-gated). In prod it presigns a short-lived
+R2 GET URL (via `aws4fetch`, portable across Vercel/Cloudflare) and redirects; in
+dev without R2 it streams the file from the local cache. The app reuses the same
+`R2_*` credentials as the worker (see [`src/lib/server/blob.ts`](../src/lib/server/blob.ts)).
+
 ---
 
 ## 6. Migrations (auto-applied — no manual step)
@@ -329,8 +335,6 @@ DocumentCenter index is a React SPA, so its folder listing isn't in the page HTM
 
 ## 15. Open items / future work
 
-- **"View stored copy"** — presign an R2 URL (or serve local blobs) from the
-  content explorer so you can open an archived page/PDF from the dashboard.
 - **Hash normalization** — CivicPlus embeds per-request tokens, so re-fetches
   show false `changed`. Strip volatile markup before hashing to quiet the churn.
 - **Case-duplicate URLs** — `normalize()` lowercases the host but not the path, so

--- a/package.json
+++ b/package.json
@@ -95,5 +95,8 @@
 	"lint-staged": {
 		"*.{js,ts,svelte,json,css,md,html}": "prettier --write --ignore-unknown",
 		"*.{js,ts,svelte}": "eslint --fix"
+	},
+	"dependencies": {
+		"aws4fetch": "^1.0.20"
 	}
 }

--- a/src/env.ts
+++ b/src/env.ts
@@ -75,5 +75,20 @@ export const variables = defineEnvVars({
 		description:
 			'Secret used to sign tokens. For production use 32 characters generated with high entropy. See [Better Auth installation](https://www.better-auth.com/docs/installation).',
 		schema: requiredAtRuntime
+	},
+	// Cloudflare R2 — lets the dashboard presign short-lived URLs to view archived
+	// blobs. Same credentials the worker uses. Optional: without them, the
+	// "view stored copy" endpoint falls back to the local BLOB_DIR (dev only).
+	R2_ENDPOINT: {
+		description: 'R2 S3 endpoint, e.g. https://<acct>.r2.cloudflarestorage.com.',
+		schema: optionalString
+	},
+	R2_BUCKET: { description: 'R2 bucket name holding the archived blobs.', schema: optionalString },
+	R2_ACCESS_KEY_ID: { description: 'R2 API token access key id.', schema: optionalString },
+	R2_SECRET_ACCESS_KEY: { description: 'R2 API token secret access key.', schema: optionalString },
+	BLOB_DIR: {
+		description:
+			'Local blob cache dir for serving archived copies in dev (default `.cache/blobs`).',
+		schema: optionalString
 	}
 });

--- a/src/lib/server/blob.ts
+++ b/src/lib/server/blob.ts
@@ -1,0 +1,55 @@
+// Resolve an archived blob for viewing from the dashboard. In production the
+// bytes live in R2, so we presign a short-lived GET URL (aws4fetch works on
+// Node, Vercel, and Cloudflare Workers). In local dev without R2 we read the
+// file straight from the on-disk cache (BLOB_DIR).
+import { AwsClient } from 'aws4fetch';
+import {
+	R2_ENDPOINT,
+	R2_BUCKET,
+	R2_ACCESS_KEY_ID,
+	R2_SECRET_ACCESS_KEY,
+	BLOB_DIR
+} from '$app/env/private';
+
+export function r2Configured(): boolean {
+	return Boolean(R2_ENDPOINT && R2_BUCKET && R2_ACCESS_KEY_ID && R2_SECRET_ACCESS_KEY);
+}
+
+let client: AwsClient | undefined;
+function getClient(): AwsClient {
+	if (!client) {
+		// Callers gate on r2Configured(), so these are present here.
+		client = new AwsClient({
+			accessKeyId: R2_ACCESS_KEY_ID!,
+			secretAccessKey: R2_SECRET_ACCESS_KEY!,
+			service: 's3',
+			region: 'auto'
+		});
+	}
+	return client;
+}
+
+/** Presigned GET URL for an R2 object key (storage_key), valid for a short time. */
+export async function presignBlob(storageKey: string, expiresSeconds = 300): Promise<string> {
+	// storage_key is `blobs/ab/cd/<sha><ext>` — all URL-safe, keep the slashes.
+	const url = new URL(`${R2_ENDPOINT!.replace(/\/$/, '')}/${R2_BUCKET}/${storageKey}`);
+	url.searchParams.set('X-Amz-Expires', String(expiresSeconds));
+	const signed = await getClient().sign(url.toString(), {
+		method: 'GET',
+		aws: { signQuery: true }
+	});
+	return signed.url;
+}
+
+/** Read a blob from the local cache dir (dev fallback when R2 isn't configured). */
+export async function readLocalBlob(storageKey: string): Promise<ArrayBuffer | null> {
+	try {
+		const { readFile } = await import('node:fs/promises');
+		const { join, resolve } = await import('node:path');
+		const dir = resolve(BLOB_DIR || '.cache/blobs');
+		const buf = await readFile(join(dir, storageKey));
+		return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+	} catch {
+		return null;
+	}
+}

--- a/src/lib/server/sync.ts
+++ b/src/lib/server/sync.ts
@@ -168,6 +168,7 @@ export async function listResources(opts: {
 			state: resource.state,
 			contentType: resource.contentType,
 			sizeBytes: resource.sizeBytes,
+			sha256: resource.sha256,
 			httpStatus: resource.httpStatus,
 			lastFetchedAt: resource.lastFetchedAt,
 			lastChangedAt: resource.lastChangedAt

--- a/src/routes/dashboard/README.md
+++ b/src/routes/dashboard/README.md
@@ -14,6 +14,7 @@ page when there's no session). See the
 | `/dashboard/runs`      | `runs/+page.*`                     | Run history table (click a row → detail)                                                                         |
 | `/dashboard/runs/[id]` | `runs/[id]/+page.*`                | Per-run stats, timing, worker id, and full event log                                                             |
 | `/dashboard/content`   | `content/+page.*`                  | Searchable/filterable resource explorer (by URL/title, kind, state) with pagination                              |
+| `/dashboard/blob/[id]` | `blob/[id]/+server.ts`             | View a resource's archived copy — presigned R2 redirect (prod) or local file (dev)                               |
 
 ## Control plane
 

--- a/src/routes/dashboard/blob/[id]/+server.ts
+++ b/src/routes/dashboard/blob/[id]/+server.ts
@@ -1,0 +1,41 @@
+// View an archived copy of a resource. Resolves the resource's latest stored
+// blob and either redirects to a presigned R2 URL (prod) or streams the local
+// cached file (dev). Auth-gated like the rest of the dashboard.
+import { error, redirect } from '@sveltejs/kit';
+import { eq } from 'drizzle-orm';
+import { db } from '$lib/server/db';
+import { resource, blob } from '$lib/server/db/schema';
+import { presignBlob, r2Configured, readLocalBlob } from '$lib/server/blob';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ params, locals, setHeaders }) => {
+	if (!locals.user) return new Response('Unauthorized', { status: 401 });
+
+	const [res] = await db
+		.select({ sha: resource.sha256, url: resource.url })
+		.from(resource)
+		.where(eq(resource.id, params.id))
+		.limit(1);
+	if (!res) throw error(404, 'Resource not found');
+	if (!res.sha) throw error(404, 'No stored copy — this URL was recorded but never downloaded');
+
+	const [b] = await db
+		.select({ key: blob.storageKey, type: blob.contentType })
+		.from(blob)
+		.where(eq(blob.sha256, res.sha))
+		.limit(1);
+	if (!b) throw error(404, 'Stored copy not found');
+
+	if (r2Configured()) {
+		throw redirect(302, await presignBlob(b.key));
+	}
+
+	// Local dev fallback: stream the cached file.
+	const body = await readLocalBlob(b.key);
+	if (!body) throw error(404, 'Stored copy not found in local cache');
+	setHeaders({
+		'content-type': b.type || 'application/octet-stream',
+		'cache-control': 'private, max-age=60'
+	});
+	return new Response(body);
+};

--- a/src/routes/dashboard/blob/[id]/+server.ts
+++ b/src/routes/dashboard/blob/[id]/+server.ts
@@ -27,7 +27,9 @@ export const GET: RequestHandler = async ({ params, locals, setHeaders }) => {
 	if (!b) throw error(404, 'Stored copy not found');
 
 	if (r2Configured()) {
-		throw redirect(302, await presignBlob(b.key));
+		// The presigned URL is on R2's origin; SvelteKit blocks external redirects
+		// unless explicitly allowed. It's always our own R2 endpoint (see blob.ts).
+		throw redirect(302, await presignBlob(b.key), { external: true });
 	}
 
 	// Local dev fallback: stream the cached file.

--- a/src/routes/dashboard/content/+page.svelte
+++ b/src/routes/dashboard/content/+page.svelte
@@ -70,11 +70,21 @@
 							href={r.url}
 							target="_blank"
 							rel="noreferrer"
-							class="truncate font-mono text-xs text-muted-foreground hover:underline"
+							class="block truncate font-mono text-xs text-muted-foreground hover:underline"
 							title={r.url}
 						>
 							{r.url}
 						</a>
+						{#if r.sha256}
+							<a
+								href={`/dashboard/blob/${r.id}`}
+								target="_blank"
+								rel="noreferrer"
+								class="text-xs text-primary hover:underline"
+							>
+								view archived copy ↗
+							</a>
+						{/if}
 					</Table.Cell>
 					<Table.Cell><Badge variant="outline">{r.kind}</Badge></Table.Cell>
 					<Table.Cell>


### PR DESCRIPTION
Makes the archive **browsable**: the content explorer now links each stored resource to a "view archived copy" endpoint that serves the captured page/PDF.

## How it works
- **Endpoint** `/dashboard/blob/[id]` (auth-gated) resolves the resource → its latest stored blob.
- **Prod (R2)**: presigns a short-lived GET URL with [`aws4fetch`](https://github.com/mhart/aws4fetch) (tiny, works on Node/Vercel/Cloudflare Workers) and 302-redirects — no bytes proxied through the app.
- **Dev (no R2)**: streams the file straight from the local blob cache (`BLOB_DIR`).
- **UI**: a "view archived copy ↗" link appears only when a stored blob exists (probed/metadata-only docs don't get one).
- Exposes the existing `R2_*` (+ `BLOB_DIR`) to the app via `env.ts` — same creds the worker already uses.

## Verified
- **Local path**: 401 unauth → login → **200 `text/html`, 147 KB of the real archived page** → 404 for a bogus id.
- **R2 presign path**: signed + fetched 8/8 real objects from `orleans-storage` → all 200 with correct content-types.
- `svelte-check`, `eslint`, Svelte autofixer, `prettier` all clean.

Independent of #7 (scheduler); branches off `main` after #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)