### PR TITLE
feat: live coverage % + archive stats in the sync status card

### DIFF
--- a/src/lib/server/sync.ts
+++ b/src/lib/server/sync.ts
@@ -94,6 +94,46 @@ export async function getRecentRuns(limit = 10) {
 	return db.select().from(syncRun).orderBy(desc(syncRun.requestedAt)).limit(limit);
 }
 
+export interface SyncProgress {
+	totalResources: number;
+	fetched: number;
+	dueRemaining: number;
+	coreTotal: number;
+	coreFetched: number;
+	documents: number;
+	blobObjects: number;
+	storedBytes: number;
+}
+
+/** Live archive progress, for the sync status card. Core coverage is the headline
+ *  (fetched sitemap pages / total core); `dueRemaining` is the frontier work left. */
+export async function getSyncProgress(): Promise<SyncProgress> {
+	const now = Date.now();
+	const [r] = await db
+		.select({
+			total: count(),
+			fetched: sql<number>`sum(case when ${resource.lastFetchedAt} is not null then 1 else 0 end)`,
+			dueRemaining: sql<number>`sum(case when ${resource.state} != 'gone' and (${resource.nextFetchAt} is null or ${resource.nextFetchAt} <= ${now}) then 1 else 0 end)`,
+			coreTotal: sql<number>`sum(case when ${resource.priority} = 0 then 1 else 0 end)`,
+			coreFetched: sql<number>`sum(case when ${resource.priority} = 0 and ${resource.lastFetchedAt} is not null then 1 else 0 end)`,
+			documents: sql<number>`sum(case when ${resource.kind} = 'document' and ${resource.lastFetchedAt} is not null then 1 else 0 end)`
+		})
+		.from(resource);
+	const [b] = await db
+		.select({ objects: count(), bytes: sql<number>`coalesce(sum(${blob.sizeBytes}), 0)` })
+		.from(blob);
+	return {
+		totalResources: r?.total ?? 0,
+		fetched: Number(r?.fetched ?? 0),
+		dueRemaining: Number(r?.dueRemaining ?? 0),
+		coreTotal: Number(r?.coreTotal ?? 0),
+		coreFetched: Number(r?.coreFetched ?? 0),
+		documents: Number(r?.documents ?? 0),
+		blobObjects: b?.objects ?? 0,
+		storedBytes: Number(b?.bytes ?? 0)
+	};
+}
+
 export async function getLastCompletedRun() {
 	const [row] = await db
 		.select()

--- a/src/routes/dashboard/+page.server.ts
+++ b/src/routes/dashboard/+page.server.ts
@@ -4,8 +4,8 @@ import type { SyncRun } from '$lib/server/db/crawl.schema';
 import * as sync from '$lib/server/sync';
 
 export const load: PageServerLoad = async () => {
-	const [overview, active, recent, lastRun, events, eventCounts, storage, feed] = await Promise.all(
-		[
+	const [overview, active, recent, lastRun, events, eventCounts, storage, feed, progress] =
+		await Promise.all([
 			sync.getOverview(),
 			sync.getActiveRun(),
 			sync.getRecentRuns(6),
@@ -13,16 +13,27 @@ export const load: PageServerLoad = async () => {
 			sync.getEvents({ limit: 10 }),
 			sync.getEventCounts(),
 			sync.getStorageByType(),
-			sync.getChangeFeed(10)
-		]
-	);
+			sync.getChangeFeed(10),
+			sync.getSyncProgress()
+		]);
 
 	// Worker-health hint: a run is queued/running in the DB, but is anything
 	// actually processing it? If nothing has claimed a queued run, or a running
 	// run's heartbeat has gone stale, the worker probably isn't running.
 	const workerAlert = detectWorkerAlert(active);
 
-	return { overview, active, recent, lastRun, events, eventCounts, storage, feed, workerAlert };
+	return {
+		overview,
+		active,
+		recent,
+		lastRun,
+		events,
+		eventCounts,
+		storage,
+		feed,
+		progress,
+		workerAlert
+	};
 };
 
 const STALE_HEARTBEAT_MS = 30_000;

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -13,27 +13,49 @@
 	const o = $derived(data.overview);
 	const dedupSavings = $derived(Math.max(0, o.logicalBytes - o.storedBytes));
 
-	// Live active-run state. `streamed` is fed by the SSE stream; until the first
-	// event arrives (and while disconnected) we fall back to the server-loaded
-	// value, so the status card reflects progress without a page reload.
+	// Live state fed by the SSE stream (`{ run, progress }`); until the first event
+	// (and while disconnected) we fall back to the server-loaded values.
 	let streamed = $state<typeof data.active | undefined>(undefined);
+	let streamedProgress = $state<typeof data.progress | undefined>(undefined);
 	const active = $derived(streamed !== undefined ? streamed : data.active);
+	const progress = $derived(streamedProgress ?? data.progress);
 	let connected = $state(false);
+
+	// Core coverage % (headline), request rate, and ETA for the remaining frontier.
+	const corePct = $derived(
+		progress.coreTotal > 0 ? Math.round((progress.coreFetched / progress.coreTotal) * 100) : 0
+	);
+	// Overall = the long tail: fetched / everything known (grows as documents are discovered).
+	const overallPct = $derived(
+		progress.totalResources > 0 ? Math.round((progress.fetched / progress.totalResources) * 100) : 0
+	);
+	const ratePerMin = $derived.by(() => {
+		if (!active?.startedAt) return 0;
+		const min = (Date.now() - active.startedAt.getTime()) / 60000;
+		return min > 0.05 ? Math.round(active.requestsMade / min) : 0;
+	});
+	const etaText = $derived.by(() => {
+		if (!active || ratePerMin <= 0 || progress.dueRemaining <= 0) return null;
+		const m = Math.ceil(progress.dueRemaining / ratePerMin);
+		return m >= 60 ? `~${Math.floor(m / 60)}h ${m % 60}m` : `~${m}m`;
+	});
 
 	onMount(() => {
 		const es = new EventSource('/dashboard/stream');
 		es.addEventListener('progress', (e) => {
 			const p = JSON.parse((e as MessageEvent).data);
 			const wasActive = !!active;
-			streamed = p
+			const run = p?.run ?? null;
+			streamed = run
 				? {
-						...p,
-						heartbeatAt: p.heartbeatAt ? new Date(p.heartbeatAt) : null,
-						startedAt: p.startedAt ? new Date(p.startedAt) : null
+						...run,
+						heartbeatAt: run.heartbeatAt ? new Date(run.heartbeatAt) : null,
+						startedAt: run.startedAt ? new Date(run.startedAt) : null
 					}
 				: null;
+			if (p?.progress) streamedProgress = p.progress;
 			// When the active run ends, refresh aggregates (tiles, feed, alert).
-			if (wasActive && !p) invalidateAll();
+			if (wasActive && !run) invalidateAll();
 		});
 		es.onopen = () => (connected = true);
 		es.onerror = () => (connected = false);
@@ -55,6 +77,21 @@
 		return 'outline';
 	}
 </script>
+
+{#snippet coverageBar(label: string, done: number, total: number, pct: number, unit: string)}
+	<div class="space-y-1">
+		<div class="flex justify-between text-xs">
+			<span class="font-medium">{label}</span>
+			<span class="text-muted-foreground">
+				{pct}% · {formatNumber(done)}/{formatNumber(total)}
+				{unit}
+			</span>
+		</div>
+		<div class="h-2 w-full overflow-hidden rounded-full bg-muted">
+			<div class="h-full rounded-full bg-primary transition-all" style="width:{pct}%"></div>
+		</div>
+	</div>
+{/snippet}
 
 <div class="space-y-6">
 	<!-- Worker-health alert ----------------------------------------------- -->
@@ -101,9 +138,6 @@
 		</Card.Header>
 		<Card.Content>
 			{#if active}
-				{@const pct = active.maxPages
-					? Math.min(100, Math.round((active.requestsMade / active.maxPages) * 100))
-					: null}
 				<div class="space-y-3">
 					<div class="flex flex-wrap items-baseline gap-x-6 gap-y-1 text-sm">
 						<span class="font-medium capitalize">{active.mode} run</span>
@@ -111,19 +145,30 @@
 							{formatNumber(active.requestsMade)} requests
 							{#if active.maxPages}/ {formatNumber(active.maxPages)} cap{/if}
 						</span>
-						<span class="text-muted-foreground">
-							heartbeat {formatRelative(active.heartbeatAt)}
-						</span>
+						<span class="text-muted-foreground">heartbeat {formatRelative(active.heartbeatAt)}</span
+						>
 						<span class="text-muted-foreground">
 							running {formatDuration(active.startedAt?.getTime())}
 						</span>
 					</div>
 
-					{#if pct !== null}
-						<div class="h-2 w-full overflow-hidden rounded-full bg-muted">
-							<div class="h-full rounded-full bg-primary transition-all" style="width:{pct}%"></div>
-						</div>
-					{/if}
+					<!-- Coverage: core (the site's pages) + overall (long tail incl. documents) -->
+					<div class="space-y-2">
+						{@render coverageBar(
+							'Core site coverage',
+							progress.coreFetched,
+							progress.coreTotal,
+							corePct,
+							'pages'
+						)}
+						{@render coverageBar(
+							'Overall (incl. documents)',
+							progress.fetched,
+							progress.totalResources,
+							overallPct,
+							'resources'
+						)}
+					</div>
 
 					{#if active.currentUrl}
 						<p class="truncate font-mono text-xs text-muted-foreground" title={active.currentUrl}>
@@ -132,19 +177,17 @@
 					{/if}
 
 					<div class="grid grid-cols-2 gap-2 text-xs sm:grid-cols-4">
-						<div><span class="text-muted-foreground">pages</span> {formatNumber(active.pages)}</div>
-						<div>
-							<span class="text-muted-foreground">docs</span>
-							{formatNumber(active.documents)}
-						</div>
-						<div>
-							<span class="text-muted-foreground">changed</span>
-							{formatNumber(active.newCount + active.changedCount)}
-						</div>
-						<div>
-							<span class="text-muted-foreground">errors</span>
-							{formatNumber(active.errorCount)}
-						</div>
+						{#snippet stat(label: string, value: string)}
+							<div><span class="text-muted-foreground">{label}</span> {value}</div>
+						{/snippet}
+						{@render stat('archived', formatNumber(progress.fetched))}
+						{@render stat('documents', formatNumber(progress.documents))}
+						{@render stat('stored', formatBytes(progress.storedBytes))}
+						{@render stat('due', formatNumber(progress.dueRemaining))}
+						{@render stat('rate', ratePerMin ? `${ratePerMin}/min` : '—')}
+						{@render stat('eta', etaText ?? '—')}
+						{@render stat('changed', formatNumber(active.newCount + active.changedCount))}
+						{@render stat('errors', formatNumber(active.errorCount))}
 					</div>
 
 					<div class="flex gap-2 pt-1">
@@ -166,12 +209,34 @@
 					</div>
 				</div>
 			{:else if data.lastRun}
-				<p class="text-sm text-muted-foreground">
-					No active run. Last run: <span class="capitalize">{data.lastRun.mode}</span>
-					<Badge variant={statusVariant(data.lastRun.status)}>{data.lastRun.status}</Badge>
-					· {formatRelative(data.lastRun.finishedAt)} ·
-					{formatNumber(data.lastRun.pages)} pages, {formatNumber(data.lastRun.documents)} docs
-				</p>
+				<div class="space-y-3">
+					<p class="text-sm text-muted-foreground">
+						No active run. Last run: <span class="capitalize">{data.lastRun.mode}</span>
+						<Badge variant={statusVariant(data.lastRun.status)}>{data.lastRun.status}</Badge>
+						· {formatRelative(data.lastRun.finishedAt)}
+					</p>
+					<div class="space-y-2">
+						{@render coverageBar(
+							'Core site coverage',
+							progress.coreFetched,
+							progress.coreTotal,
+							corePct,
+							'pages'
+						)}
+						{@render coverageBar(
+							'Overall (incl. documents)',
+							progress.fetched,
+							progress.totalResources,
+							overallPct,
+							'resources'
+						)}
+					</div>
+					<p class="text-xs text-muted-foreground">
+						{formatNumber(progress.fetched)} archived · {formatNumber(progress.documents)} documents ·
+						{formatBytes(progress.storedBytes)} stored
+						{#if progress.dueRemaining > 0}· {formatNumber(progress.dueRemaining)} due{/if}
+					</p>
+				</div>
 			{:else}
 				<p class="text-sm text-muted-foreground">No runs yet. Start one below.</p>
 			{/if}

--- a/src/routes/dashboard/stream/+server.ts
+++ b/src/routes/dashboard/stream/+server.ts
@@ -10,6 +10,7 @@ import type { SyncRun } from '$lib/server/db/crawl.schema';
 import * as sync from '$lib/server/sync';
 
 const POLL_MS = 1500;
+const AGG_MS = 4500; // refresh the heavier progress aggregates less often than the run row
 const MAX_DURATION_MS = 5 * 60 * 1000;
 
 function serialize(r: SyncRun) {
@@ -59,10 +60,17 @@ export const GET: RequestHandler = async ({ locals, request }) => {
 			// Reconnection delay hint for EventSource.
 			controller.enqueue(encoder.encode('retry: 3000\n\n'));
 
+			// Aggregate progress is heavier than the run row, so refresh it less often.
+			let lastAgg = 0;
+			let agg: sync.SyncProgress | null = null;
 			const tick = async () => {
 				try {
 					const active = await sync.getActiveRun();
-					send('progress', active ? serialize(active) : null);
+					if (Date.now() - lastAgg >= AGG_MS) {
+						lastAgg = Date.now();
+						agg = await sync.getSyncProgress();
+					}
+					send('progress', { run: active ? serialize(active) : null, progress: agg });
 				} catch {
 					// transient DB error — next tick retries
 				}


### PR DESCRIPTION
Answers "how complete is the archive?" at a glance, live.

## What's new
The **Sync status** card now shows real completion, streamed live (SSE):

- **Core site coverage** bar — fetched sitemap pages / ~808 (the site's authored pages).
- **Overall (incl. documents)** bar — fetched / everything known. This is the *long tail*: once core hits 100%, this bar keeps moving as the thousands of PDFs come in.
- **Stats**: archived resources, documents, stored bytes, due-remaining (frontier work left), request **rate**, and **ETA**.
- Shown when idle too, as the archive's standing completeness.

## How
- `getSyncProgress()` (in `sync.ts`) computes the aggregates from the `resource`/`blob` tables.
- The SSE endpoint now streams `{ run, progress }`; the run row updates every 1.5s, the heavier aggregates every ~4.5s to keep Turso load low.

## Verified live
Against the running sync: SSE emitted the new shape with real numbers — **core 801/801 = 100%**, overall ~68% (1,594 / 2,333), 454 MB stored, ETA derived from due-remaining ÷ rate. `svelte-check`, `eslint`, Svelte autofixer, `prettier` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)