### PR TITLE
feat: discovery indicator on the sync status card

### DIFF
--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -17,6 +17,9 @@
 	// (and while disconnected) we fall back to the server-loaded values.
 	let streamed = $state<typeof data.active | undefined>(undefined);
 	let streamedProgress = $state<typeof data.progress | undefined>(undefined);
+	// New URLs discovered since the last aggregate tick — a nonzero value means the
+	// frontier (and the Overall denominator) is still growing, not converged yet.
+	let recentDelta = $state(0);
 	const active = $derived(streamed !== undefined ? streamed : data.active);
 	const progress = $derived(streamedProgress ?? data.progress);
 	let connected = $state(false);
@@ -53,7 +56,11 @@
 						startedAt: run.startedAt ? new Date(run.startedAt) : null
 					}
 				: null;
-			if (p?.progress) streamedProgress = p.progress;
+			if (p?.progress) {
+				const prev = streamedProgress?.totalResources ?? data.progress.totalResources;
+				recentDelta = Math.max(0, p.progress.totalResources - prev);
+				streamedProgress = p.progress;
+			}
 			// When the active run ends, refresh aggregates (tiles, feed, alert).
 			if (wasActive && !run) invalidateAll();
 		});
@@ -168,6 +175,17 @@
 							overallPct,
 							'resources'
 						)}
+						<p class="text-xs text-muted-foreground">
+							{formatNumber(progress.totalResources)} discovered
+							{#if recentDelta > 0}
+								<span class="text-amber-600 dark:text-amber-500">
+									↑ +{formatNumber(recentDelta)} — still finding new URLs (Overall % settles once page
+									crawling finishes)
+								</span>
+							{:else}
+								· settling
+							{/if}
+						</p>
 					</div>
 
 					{#if active.currentUrl}


### PR DESCRIPTION
Addresses the "the long-tail total keeps going up as progress moves" observation.

The Overall bar is `fetched / discovered`, and `discovered` grows while the frontier crawls pages and finds more document links — so the % can stall or dip mid-crawl. Rather than hide that, the card now shows it:

> **N discovered ↑ +delta — still finding new URLs** (when the count grew since the last tick), otherwise **· settling**.

Makes clear the *denominator* is expanding, not the bar being stuck. It converges once page crawling finishes (documents don't link to more documents), after which the Overall bar climbs steadily to 100%.

Verified live against the running sync: discovered ticked 2641 → 2642 over ~11s (nearly settled, as expected with core at 100%). `svelte-check`, `eslint`, autofixer, `prettier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)