### PR TITLE
feat: normalize HTML before hashing to kill false-changed churn

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -76,6 +76,13 @@ size/etag (estimate) to the resource's stored fingerprint → decides
 new/changed/unchanged/probed. Only new/changed/probed/gone/error write a
 `resource_version`; unchanged 304s just bump `last_fetched_at`.
 
+**HTML is normalized before hashing** (`normalizeHtml` in `worker/http.ts`): CivicPlus
+re-renders per-request junk on every load — ASP.NET `__VIEWSTATE`, randomized element
+ids, and a rotating photo carousel — which would otherwise produce endless false
+`changed` versions and near-duplicate blobs. The normalizer strips exactly those
+(content, links, and text are untouched), so an unchanged page hashes identically and
+dedupes. The stored blob is the normalized copy — the tradeoff for R2 dedup.
+
 ---
 
 ## 4. Run modes
@@ -335,8 +342,6 @@ DocumentCenter index is a React SPA, so its folder listing isn't in the page HTM
 
 ## 15. Open items / future work
 
-- **Hash normalization** — CivicPlus embeds per-request tokens, so re-fetches
-  show false `changed`. Strip volatile markup before hashing to quiet the churn.
 - **Case-duplicate URLs** — `normalize()` lowercases the host but not the path, so
   `/AgendaCenter` and `/agendacenter` become two resources for the same content.
   Lowercasing paths would dedupe them (safe for this IIS/CivicPlus target) but is a

--- a/worker/crawl.ts
+++ b/worker/crawl.ts
@@ -33,6 +33,7 @@ import {
 	hostOf,
 	inScope,
 	normalize,
+	normalizeHtml,
 	pageTitle,
 	parseSitemap,
 	parseSitemapEntries,
@@ -191,17 +192,14 @@ async function ingestResponse(resp: Response, ctx: IngestCtx): Promise<string[]>
 		if (mode === 'estimate') {
 			stats.bytesEstimated += size;
 		} else {
-			sha = sha256Hex(text);
-			stats.bytesDownloaded += size;
+			// Hash + store the normalized HTML so re-fetches of an unchanged page
+			// don't produce false `changed` versions or near-duplicate blobs.
+			const normalized = normalizeHtml(text);
+			sha = sha256Hex(normalized);
+			stats.bytesDownloaded += size; // bytes actually fetched (original)
 			if (sha !== prevSha) {
-				blobSha = await ensureBlob(
-					sha,
-					'.html',
-					new TextEncoder().encode(text),
-					ctype,
-					size,
-					stats
-				);
+				const bytes = new TextEncoder().encode(normalized);
+				blobSha = await ensureBlob(sha, '.html', bytes, ctype, bytes.byteLength, stats);
 			}
 		}
 		const resourceId = await recordObservation({

--- a/worker/http.ts
+++ b/worker/http.ts
@@ -105,6 +105,55 @@ export function parseSitemapEntries(xml: string): SitemapEntry[] {
 	return out;
 }
 
+/** Remove the full `<div …>…</div>` block starting at the first match of `openRe`,
+ *  balancing nested divs (which regex can't). Recurses to strip every occurrence. */
+function stripDivBlock(html: string, openRe: RegExp): string {
+	const m = openRe.exec(html);
+	if (!m) return html;
+	const scan = /<div\b|<\/div>/gi;
+	scan.lastIndex = m.index;
+	let depth = 0;
+	let t: RegExpExecArray | null;
+	while ((t = scan.exec(html))) {
+		if (t[0][1] === '/') {
+			if (--depth === 0) {
+				return stripDivBlock(html.slice(0, m.index) + html.slice(scan.lastIndex), openRe);
+			}
+		} else {
+			depth++;
+		}
+	}
+	return html; // unbalanced — leave it
+}
+
+// CivicPlus rotating photo carousel: the whole widget (slides, nav dots, image
+// selection, per-request ids) differs every request. Stable pages don't have it.
+const SLIDESHOW_OPEN = /<div class="widget slideShow\b/i;
+
+/**
+ * Strip per-request volatile bits from CivicPlus/ASP.NET HTML so re-fetches of an
+ * unchanged page hash identically — no false `changed` versions, and identical
+ * pages dedupe to one blob. Only junk is removed (ASP.NET WebForms state tokens,
+ * randomized ids, and the rotating slideshow); visible content/links/text stay.
+ */
+export function normalizeHtml(html: string): string {
+	return (
+		stripDivBlock(html, SLIDESHOW_OPEN)
+			// ASP.NET hidden fields (__VIEWSTATE, __VIEWSTATEGENERATOR, *Token, …): blank the value
+			.replace(
+				/(<input\b[^>]*\bname="(?:__[A-Za-z]+|[^"]*Token[^"]*)"[^>]*\bvalue=")[^"]*(")/gi,
+				'$1$2'
+			)
+			// …and the value-before-name attribute ordering
+			.replace(
+				/(<input\b[^>]*\bvalue=")[^"]*("[^>]*\bname="(?:__[A-Za-z]+|[^"]*Token[^"]*)")/gi,
+				'$1$2'
+			)
+			// CivicPlus per-request random element ids: anch<hex> / row<hex> (id="" or href="#…")
+			.replace(/\b(anch|row)[0-9a-f]{6,}\b/gi, '$1_')
+	);
+}
+
 export function extractLinks(baseUrl: string, html: string): string[] {
 	const out: string[] = [];
 	for (const m of html.matchAll(HREF_RE)) {


### PR DESCRIPTION
CivicPlus re-renders per-request junk on every page load, so re-fetching an **unchanged** page produced a different `sha256` every time → endless false `changed` versions in the change feed, and a fresh near-duplicate blob written to R2 on every recrawl.

## What churns (found by diffing two live fetches)
- **ASP.NET `__VIEWSTATE` / `__VIEWSTATEGENERATOR`** hidden-input values (`.aspx` module pages)
- **Randomized `anch…`/`row…` element ids** (AgendaCenter)
- **A rotating photo carousel** — different images, order, and per-request ids (many content pages) — the dominant source

## Fix
`normalizeHtml` (`worker/http.ts`) strips exactly those before hashing **and** storing:
- blanks ASP.NET state-token values
- collapses the random `anch/row` ids
- removes the whole `<div class="widget slideShow …">` widget via a small **stack scanner** (regex can't balance nested divs)

Visible content, links, and text are untouched. The worker now hashes + stores the *normalized* HTML, so an unchanged page hashes identically → no version churn, and blobs dedupe. Storing normalized is the tradeoff that makes R2 dedup possible (the removed bits are per-request junk; the carousel photos live in `/ImageRepository` and are archived separately).

## Verified
- Two live fetches of viewstate / AgendaCenter / carousel pages now hash **identically** (`SAME`); stable pages untouched (**0%** stripped — no over-normalization).
- `crawl → recrawl` of those pages: **0 changed / 0 new blobs**, where before every recrawl churned.
- `svelte-check`, `eslint`, `prettier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)