### PR TITLE
feat: fetch never-seen URLs before re-verifying (completeness before freshness)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -258,8 +258,12 @@ rebuilding an in-memory BFS each run. Two columns drive it:
   per-tier TTL.
 
 A run: refresh seeds (sitemap → core tier, module roots) → drain all _due_
-resources `ORDER BY priority, nextFetchAt` in batches → each fetch reschedules
-itself and enqueues newly-discovered URLs as due-now → stop when nothing is due.
+resources `ORDER BY (last_fetched_at IS NULL) DESC, priority, nextFetchAt` in
+batches → each fetch reschedules itself and enqueues newly-discovered URLs as
+due-now → stop when nothing is due. The `IS NULL` clause is **completeness before
+freshness**: never-seen URLs (in priority order) are fetched before re-verifying
+ones we already hold — so new content (e.g. thousands of documents) is captured
+before we spend requests re-checking pages we already have.
 
 This gives all four properties at once:
 

--- a/worker/crawl.ts
+++ b/worker/crawl.ts
@@ -467,7 +467,14 @@ export async function executeSync(run: SyncRun): Promise<void> {
 					ne(resource.state, 'gone')
 				)
 			)
-			.orderBy(asc(resource.priority), asc(resource.nextFetchAt))
+			// Completeness before freshness: fetch never-seen URLs first (in priority
+			// order), then re-verify already-have ones. So we capture new content
+			// (e.g. thousands of documents) before re-checking pages we already hold.
+			.orderBy(
+				sql`${resource.lastFetchedAt} is null desc`,
+				asc(resource.priority),
+				asc(resource.nextFetchAt)
+			)
 			.limit(SYNC_BATCH);
 		if (batch.length === 0) break; // caught up
 


### PR DESCRIPTION
Fixes the "Documents bar frozen at 650" issue.

## Root cause
The frontier claimed due work strictly `ORDER BY priority`, so **all pages (tiers 0–1) are fetched before any documents (tiers 2–3)** — including *re-verification* of pages we already hold. After the worker swap, ~1,000 already-archived resources were left with no `next_fetch_at` (so they all look "due"), creating a big re-verify backlog. Result: the **1,862 new DocumentCenter PDFs sat behind ~895 page requests**, and `docFetched` stayed frozen at 650 (the agenda PDFs the old BFS had grabbed).

Live tier breakdown at diagnosis:

| Tier | Fetched | New (waiting) | Re-verify (waiting) |
|---|---|---|---|
| 0 core | 801 | 0 | 278 |
| 1 pages | 143 | 474 | 143 |
| 2 agenda | 649 | 29 | 649 |
| 3 doc-center | **1** | **1,862** | 1 |

## Fix
Add `(last_fetched_at IS NULL) DESC` as the **primary** sort. Never-seen URLs (still in priority order within the group) are fetched first; re-verifications come last. So the crawler captures new content — thousands of documents — before spending requests re-checking pages it already has.

On a **fresh** archive everything is new, so this is a no-op and core-first is preserved; it only reorders the re-verify backlog to the end.

## Verified
`ORDER BY (last_fetched_at IS NULL) DESC, priority, next_fetch_at` returns: `core-new → page-new → doc-new → core-reverify → page-reverify → agenda-reverify`. Bundle, `eslint`, `prettier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)