### PR TITLE
Live activity feed + single-writer worker guard

### DIFF
--- a/src/lib/server/sync.ts
+++ b/src/lib/server/sync.ts
@@ -1,7 +1,7 @@
 // Server-side control plane + read models for the sync dashboard. The web app
 // never talks to the worker directly: it enqueues sync_run rows and writes the
 // `control` column; the worker polls, executes, and writes back progress here.
-import { and, count, desc, eq, inArray, like, or, sql } from 'drizzle-orm';
+import { and, count, desc, eq, inArray, isNotNull, like, or, sql } from 'drizzle-orm';
 import { db } from '$lib/server/db';
 import { blob, crawlEvent, link, resource, resourceVersion, syncRun } from '$lib/server/db/schema';
 
@@ -227,6 +227,77 @@ export async function listResources(opts: {
 
 	const [{ total }] = await db.select({ total: count() }).from(resource).where(where);
 	return { rows, total };
+}
+
+export type ActivityOutcome = 'new' | 'changed' | 'gone' | 'checked';
+
+export interface ActivityItem {
+	id: string;
+	url: string;
+	title: string | null;
+	kind: string;
+	sizeBytes: number | null;
+	fetchedAt: number | null;
+	outcome: ActivityOutcome;
+}
+
+// Whether the newest version row was produced by *this* fetch (its observation
+// lands within a few seconds of lastFetchedAt) vs. an older change.
+const VERSION_MATCH_MS = 5000;
+
+/** Live activity: the most-recently *fetched* resources, newest first. Unlike the
+ *  change feed, this includes unchanged re-verifies (every fetch bumps
+ *  `lastFetchedAt`), so it keeps moving even when nothing is changing — that's the
+ *  point: it shows the worker is doing work. Each row's outcome comes from its
+ *  latest version row (new/changed/gone) when that version was written by this same
+ *  fetch; otherwise the fetch confirmed no change → 'checked'. */
+export async function getRecentActivity(limit = 12): Promise<ActivityItem[]> {
+	const lastKind = sql<string | null>`(
+		select ${resourceVersion.changeKind} from ${resourceVersion}
+		where ${resourceVersion.resourceId} = ${resource.id}
+		order by ${resourceVersion.observedAt} desc limit 1
+	)`;
+	const lastVersionAt = sql<number | null>`(
+		select ${resourceVersion.observedAt} from ${resourceVersion}
+		where ${resourceVersion.resourceId} = ${resource.id}
+		order by ${resourceVersion.observedAt} desc limit 1
+	)`;
+	const rows = await db
+		.select({
+			id: resource.id,
+			url: resource.url,
+			title: resource.title,
+			kind: resource.kind,
+			state: resource.state,
+			sizeBytes: resource.sizeBytes,
+			lastFetchedAt: resource.lastFetchedAt,
+			lastKind,
+			lastVersionAt
+		})
+		.from(resource)
+		.where(isNotNull(resource.lastFetchedAt))
+		.orderBy(desc(resource.lastFetchedAt))
+		.limit(limit);
+
+	return rows.map((r) => {
+		const fetchedAt = r.lastFetchedAt?.getTime() ?? null;
+		const versionAt = r.lastVersionAt != null ? Number(r.lastVersionAt) : null;
+		const fromThisFetch =
+			fetchedAt != null && versionAt != null && Math.abs(fetchedAt - versionAt) < VERSION_MATCH_MS;
+		let outcome: ActivityOutcome = 'checked';
+		if (r.state === 'gone') outcome = 'gone';
+		else if (fromThisFetch && (r.lastKind === 'new' || r.lastKind === 'changed'))
+			outcome = r.lastKind;
+		return {
+			id: r.id,
+			url: r.url,
+			title: r.title,
+			kind: r.kind,
+			sizeBytes: r.sizeBytes,
+			fetchedAt,
+			outcome
+		};
+	});
 }
 
 /** Change feed: recent version rows joined to their resource. */

--- a/src/routes/dashboard/+page.server.ts
+++ b/src/routes/dashboard/+page.server.ts
@@ -1,6 +1,5 @@
 import { fail } from '@sveltejs/kit';
 import type { Actions, PageServerLoad } from './$types';
-import type { SyncRun } from '$lib/server/db/crawl.schema';
 import * as sync from '$lib/server/sync';
 
 export const load: PageServerLoad = async () => {
@@ -28,11 +27,9 @@ export const load: PageServerLoad = async () => {
 		sync.getRecentActivity()
 	]);
 
-	// Worker-health hint: a run is queued/running in the DB, but is anything
-	// actually processing it? If nothing has claimed a queued run, or a running
-	// run's heartbeat has gone stale, the worker probably isn't running.
-	const workerAlert = detectWorkerAlert(active);
-
+	// The worker-health hint (is anything actually processing this run?) is derived
+	// on the client from the live run so it clears the moment a worker starts
+	// heartbeating — a load-time snapshot would go stale. See +page.svelte.
 	return {
 		overview,
 		active,
@@ -43,32 +40,9 @@ export const load: PageServerLoad = async () => {
 		storage,
 		feed,
 		progress,
-		activity,
-		workerAlert
+		activity
 	};
 };
-
-const STALE_HEARTBEAT_MS = 30_000;
-const QUEUE_GRACE_MS = 12_000;
-
-function detectWorkerAlert(active: SyncRun | null): string | null {
-	if (!active) return null;
-	const now = Date.now();
-	if (active.status === 'queued') {
-		if (now - active.requestedAt.getTime() > QUEUE_GRACE_MS) {
-			return 'This run is queued but no worker has claimed it. Start the worker with `bun run worker`.';
-		}
-		return null;
-	}
-	if (active.status === 'running' || active.status === 'paused') {
-		const beat = active.heartbeatAt?.getTime();
-		if (!beat || now - beat > STALE_HEARTBEAT_MS) {
-			const ago = beat ? `${Math.round((now - beat) / 1000)}s ago` : 'never';
-			return `The worker hasn't sent a heartbeat (last: ${ago}) — it may have stopped. Check that \`bun run worker\` is running.`;
-		}
-	}
-	return null;
-}
 
 const MODES = ['sync', 'estimate', 'crawl', 'recrawl'] as const;
 const ACTIONS = ['pause', 'resume', 'cancel'] as const;

--- a/src/routes/dashboard/+page.server.ts
+++ b/src/routes/dashboard/+page.server.ts
@@ -4,18 +4,29 @@ import type { SyncRun } from '$lib/server/db/crawl.schema';
 import * as sync from '$lib/server/sync';
 
 export const load: PageServerLoad = async () => {
-	const [overview, active, recent, lastRun, events, eventCounts, storage, feed, progress] =
-		await Promise.all([
-			sync.getOverview(),
-			sync.getActiveRun(),
-			sync.getRecentRuns(6),
-			sync.getLastCompletedRun(),
-			sync.getEvents({ limit: 10 }),
-			sync.getEventCounts(),
-			sync.getStorageByType(),
-			sync.getChangeFeed(10),
-			sync.getSyncProgress()
-		]);
+	const [
+		overview,
+		active,
+		recent,
+		lastRun,
+		events,
+		eventCounts,
+		storage,
+		feed,
+		progress,
+		activity
+	] = await Promise.all([
+		sync.getOverview(),
+		sync.getActiveRun(),
+		sync.getRecentRuns(6),
+		sync.getLastCompletedRun(),
+		sync.getEvents({ limit: 10 }),
+		sync.getEventCounts(),
+		sync.getStorageByType(),
+		sync.getChangeFeed(10),
+		sync.getSyncProgress(),
+		sync.getRecentActivity()
+	]);
 
 	// Worker-health hint: a run is queued/running in the DB, but is anything
 	// actually processing it? If nothing has claimed a queued run, or a running
@@ -32,6 +43,7 @@ export const load: PageServerLoad = async () => {
 		storage,
 		feed,
 		progress,
+		activity,
 		workerAlert
 	};
 };

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -17,6 +17,8 @@
 	// (and while disconnected) we fall back to the server-loaded values.
 	let streamed = $state<typeof data.active | undefined>(undefined);
 	let streamedProgress = $state<typeof data.progress | undefined>(undefined);
+	let streamedActivity = $state<typeof data.activity | undefined>(undefined);
+	const activity = $derived(streamedActivity ?? data.activity);
 	// New URLs discovered since the last aggregate tick — a nonzero value means the
 	// frontier (and the Overall denominator) is still growing, not converged yet.
 	let recentDelta = $state(0);
@@ -62,6 +64,7 @@
 				recentDelta = Math.max(0, p.progress.totalResources - prev);
 				streamedProgress = p.progress;
 			}
+			if (p?.activity) streamedActivity = p.activity;
 			// When the active run ends, refresh aggregates (tiles, feed, alert).
 			if (wasActive && !run) invalidateAll();
 		});
@@ -83,6 +86,12 @@
 		if (k === 'gone' || k === 'error') return 'destructive';
 		if (k === 'changed') return 'secondary';
 		return 'outline';
+	}
+	function outcomeVariant(o: string): 'default' | 'secondary' | 'destructive' | 'outline' {
+		if (o === 'new') return 'default';
+		if (o === 'gone') return 'destructive';
+		if (o === 'changed') return 'secondary';
+		return 'outline'; // checked (unchanged re-verify)
 	}
 </script>
 
@@ -258,6 +267,40 @@
 				</div>
 			{:else}
 				<p class="text-sm text-muted-foreground">No runs yet. Start one below.</p>
+			{/if}
+		</Card.Content>
+	</Card.Root>
+
+	<!-- Live activity: what the worker is fetching right now ---------------- -->
+	<Card.Root>
+		<Card.Header>
+			<div class="flex items-center justify-between">
+				<Card.Title>Live activity</Card.Title>
+				<span class="text-xs text-muted-foreground">most recently fetched</span>
+			</div>
+		</Card.Header>
+		<Card.Content>
+			{#if activity.length}
+				<ul class="divide-y">
+					{#each activity as a (a.id)}
+						<li class="flex items-center gap-3 py-2 text-sm">
+							<Badge variant={outcomeVariant(a.outcome)} class="w-16 justify-center">
+								{a.outcome}
+							</Badge>
+							<span class="shrink-0 text-xs text-muted-foreground">
+								{a.kind === 'document' ? 'doc' : 'page'}
+							</span>
+							<span class="min-w-0 flex-1 truncate" title={a.url}>
+								{a.title || a.url}
+							</span>
+							<span class="shrink-0 text-xs tabular-nums text-muted-foreground">
+								{formatRelative(a.fetchedAt ? new Date(a.fetchedAt) : null)}
+							</span>
+						</li>
+					{/each}
+				</ul>
+			{:else}
+				<p class="text-sm text-muted-foreground">No fetches yet.</p>
 			{/if}
 		</Card.Content>
 	</Card.Root>

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -55,6 +55,7 @@
 			streamed = run
 				? {
 						...run,
+						requestedAt: run.requestedAt ? new Date(run.requestedAt) : null,
 						heartbeatAt: run.heartbeatAt ? new Date(run.heartbeatAt) : null,
 						startedAt: run.startedAt ? new Date(run.startedAt) : null
 					}
@@ -71,6 +72,31 @@
 		es.onopen = () => (connected = true);
 		es.onerror = () => (connected = false);
 		return () => es.close();
+	});
+
+	// Worker-health hint, derived from the *live* run so it clears the instant a
+	// worker starts heartbeating (a load-time snapshot would linger). Recomputes
+	// each SSE tick, so a stale-heartbeat/unclaimed run surfaces on its own too.
+	const STALE_HEARTBEAT_MS = 30_000;
+	const QUEUE_GRACE_MS = 12_000;
+	const workerAlert = $derived.by(() => {
+		const a = active;
+		if (!a) return null;
+		const now = Date.now();
+		if (a.status === 'queued') {
+			const req = a.requestedAt?.getTime();
+			return req && now - req > QUEUE_GRACE_MS
+				? 'This run is queued but no worker has claimed it. Start the worker with `bun run worker`.'
+				: null;
+		}
+		if (a.status === 'running' || a.status === 'paused') {
+			const beat = a.heartbeatAt?.getTime();
+			if (!beat || now - beat > STALE_HEARTBEAT_MS) {
+				const ago = beat ? `${Math.round((now - beat) / 1000)}s ago` : 'never';
+				return `The worker hasn't sent a heartbeat (last: ${ago}) — it may have stopped. Check that \`bun run worker\` is running.`;
+			}
+		}
+		return null;
 	});
 
 	const maxStorage = $derived(Math.max(1, ...data.storage.map((s) => Number(s.bytes))));
@@ -112,7 +138,7 @@
 
 <div class="space-y-6">
 	<!-- Worker-health alert ----------------------------------------------- -->
-	{#if data.workerAlert}
+	{#if workerAlert}
 		<div
 			class="flex items-start gap-3 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-200"
 			role="alert"
@@ -120,7 +146,7 @@
 			<span aria-hidden="true">⚠️</span>
 			<div>
 				<p class="font-medium">No worker processing this run</p>
-				<p class="text-amber-800 dark:text-amber-300/90">{data.workerAlert}</p>
+				<p class="text-amber-800 dark:text-amber-300/90">{workerAlert}</p>
 			</div>
 		</div>
 	{/if}

--- a/src/routes/dashboard/stream/+server.ts
+++ b/src/routes/dashboard/stream/+server.ts
@@ -31,6 +31,7 @@ function serialize(r: SyncRun) {
 		bytesStored: r.bytesStored,
 		bytesEstimated: r.bytesEstimated,
 		currentUrl: r.currentUrl,
+		requestedAt: r.requestedAt?.getTime() ?? null,
 		heartbeatAt: r.heartbeatAt?.getTime() ?? null,
 		startedAt: r.startedAt?.getTime() ?? null
 	};

--- a/src/routes/dashboard/stream/+server.ts
+++ b/src/routes/dashboard/stream/+server.ts
@@ -60,17 +60,26 @@ export const GET: RequestHandler = async ({ locals, request }) => {
 			// Reconnection delay hint for EventSource.
 			controller.enqueue(encoder.encode('retry: 3000\n\n'));
 
-			// Aggregate progress is heavier than the run row, so refresh it less often.
+			// Aggregate progress + the activity feed are heavier than the run row, so
+			// refresh them less often. `activity` is only included in the payload on
+			// the ticks it's refreshed; the client keeps its last copy otherwise.
 			let lastAgg = 0;
 			let agg: sync.SyncProgress | null = null;
+			let activity: sync.ActivityItem[] = [];
 			const tick = async () => {
 				try {
 					const active = await sync.getActiveRun();
+					let fresh = false;
 					if (Date.now() - lastAgg >= AGG_MS) {
 						lastAgg = Date.now();
-						agg = await sync.getSyncProgress();
+						fresh = true;
+						[agg, activity] = await Promise.all([sync.getSyncProgress(), sync.getRecentActivity()]);
 					}
-					send('progress', { run: active ? serialize(active) : null, progress: agg });
+					send('progress', {
+						run: active ? serialize(active) : null,
+						progress: agg,
+						activity: fresh ? activity : undefined
+					});
 				} catch {
 					// transient DB error — next tick retries
 				}

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -7,7 +7,7 @@
 //   bun run worker/index.ts --mode crawl          # enqueue + run once, then exit
 import { readdirSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { and, asc, desc, eq, inArray, lt } from 'drizzle-orm';
+import { and, asc, desc, eq, gt, inArray, lt } from 'drizzle-orm';
 import { client, db } from './db';
 import { syncRun } from '../src/lib/server/db/schema';
 import type { SyncRun } from '../src/lib/server/db/crawl.schema';
@@ -21,6 +21,7 @@ const MAINTENANCE_INTERVAL_MS = 30_000;
 const ACTIVE = ['queued', 'running', 'paused'] as const;
 
 let stopping = false;
+let standby = false;
 process.on(
 	'SIGINT',
 	() => ((stopping = true), console.log('\nshutting down after current job...'))
@@ -39,6 +40,31 @@ async function ensureSchema(): Promise<void> {
 
 /** Atomically claim the oldest queued run; returns it or null. */
 async function claimNext(): Promise<SyncRun | null> {
+	// Single-writer guard. Two workers iterating the same frontier double-process
+	// every resource — duplicate version rows, double blob writes, and 2× request
+	// load on the (politely rate-limited) target site. If another worker already
+	// owns a live run (fresh heartbeat), stand down. This process becomes a warm
+	// standby: it only starts claiming once that worker dies and its run goes
+	// stale (reaped by reapStaleRuns).
+	const [live] = await db
+		.select({ id: syncRun.id, workerId: syncRun.workerId })
+		.from(syncRun)
+		.where(
+			and(
+				inArray(syncRun.status, ['running', 'paused']),
+				gt(syncRun.heartbeatAt, new Date(Date.now() - STALE_RUN_MS))
+			)
+		)
+		.limit(1);
+	if (live) {
+		if (!standby) {
+			console.log(`another worker (${live.workerId}) owns an active run — standing by`);
+			standby = true;
+		}
+		return null;
+	}
+	standby = false;
+
 	const [queued] = await db
 		.select()
 		.from(syncRun)


### PR DESCRIPTION
## Why

The dashboard's coverage bars sit frozen while the sync fetches thousands of pages before it reaches documents — so it *looks* stuck even though the worker is busy. And running two workers at once (which just happened) silently double-processes the frontier, producing duplicate version rows ~1s apart.

## What

**Live activity feed** — a new card showing the most-recently *fetched* resources, newest first: `page`/`doc`, an accurate outcome badge (`new` / `changed` / `gone` / `checked`), and time. Unlike the change feed it includes unchanged re-verifies, so it keeps moving even when nothing is changing — that's the whole point: you can see the worker working. Seeded on page load, then updated over the existing SSE stream on the aggregate cadence.

The outcome is derived server-side from each resource's latest version row (and whether that version came from *this* fetch), so a first-time capture reads `new`, not a false `changed`.

**Single-writer guard** — `claimNext()` now stands down if another worker already owns a live run (fresh heartbeat). A second worker becomes a warm standby and only starts claiming once the active worker dies and its run goes stale (reaped). This is the root-cause fix for the duplicate rows.

## Files
- `worker/index.ts` — single-writer guard
- `src/lib/server/sync.ts` — `getRecentActivity()`
- `src/routes/dashboard/stream/+server.ts` — stream activity
- `src/routes/dashboard/+page.server.ts` — load activity
- `src/routes/dashboard/+page.svelte` — Live activity card

## Notes
- svelte-check + eslint clean; svelte-autofixer reports no issues.
- Takes effect for the guard once the worker is restarted on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)