### PR TITLE
chore: issue-driven workflow scaffolding

### DIFF
--- a/.claude/commands/dispatch-ready-issues.md
+++ b/.claude/commands/dispatch-ready-issues.md
@@ -1,0 +1,73 @@
+---
+description: Claim the oldest ready-for-agent issue and dispatch a worktree agent to implement it (one issue per run; drive with /loop)
+allowed-tools: Bash, Read, Task, Agent
+---
+
+# Dispatch ready-for-agent issues
+
+Pick up **one** fully-specified issue and hand it to an isolated agent. Designed to
+be driven on a recurring interval: `/loop 10m /dispatch-ready-issues`. Each run
+claims at most one issue, so successive loop ticks drain the queue without ever
+double-claiming.
+
+Follow the conventions in `CLAUDE.md` → **Issue-driven workflow**. The `/triage`
+skill owns the label vocabulary; this command only consumes the `ready-for-agent`
+shelf it produces.
+
+## Steps
+
+1. **Find the next issue.** Query the oldest open issue that is `ready-for-agent`
+   and NOT already `in-progress` or assigned:
+
+   ```bash
+   gh issue list --state open --label ready-for-agent --json number,title,labels,assignees,createdAt \
+     --jq '[.[] | select((.labels | map(.name) | index("in-progress") | not) and (.assignees | length == 0))] | sort_by(.createdAt) | .[0]'
+   ```
+
+   If the result is empty, report **"ready-for-agent queue is empty"** and stop.
+   Do not fabricate work.
+
+2. **Claim it first (single-writer guard).** Before reading the brief or writing
+   any code, atomically mark the issue as taken so a concurrent loop tick can't
+   grab it:
+
+   ```bash
+   gh issue edit <n> --add-label in-progress --remove-label ready-for-agent --add-assignee @me
+   ```
+
+   Re-run the step-1 query afterward and confirm the issue is no longer returned —
+   if another tick claimed it in the gap, abandon and restart at step 1.
+
+3. **Read the contract.** Fetch the issue and its **agent brief** comment
+   (`gh issue view <n> --comments`). The brief is authoritative; the body and
+   discussion are only context. If no agent brief comment exists, this issue was
+   mislabeled — revert the claim (`--remove-label in-progress --add-label
+needs-triage --remove-assignee @me`), comment that it reached the shelf without
+   a brief, and stop.
+
+4. **Dispatch an isolated agent.** Launch a subagent with `isolation: "worktree"`
+   so parallel dispatches never collide. Instruct it to:
+   - Create branch `issue-<n>-<short-slug>` off `main`.
+   - Implement exactly what the agent brief specifies — no scope creep.
+   - Run `/verify` and `/code-review` on the branch; fix what they surface.
+   - Push and open a PR whose body **opens with `Closes #<n>`** and summarizes the
+     change against the brief's acceptance criteria.
+   - Report back the PR number and a one-line status.
+
+5. **Reconcile on completion.**
+   - Success → comment the PR link on the issue and swap the issue label
+     `in-progress` → keep until merge (the `Closes #<n>` auto-closes on squash
+     merge). Move the **PR** to `ready-for-human`.
+   - Failure / blocked → revert the issue to `needs-triage` (or `needs-info` if the
+     blocker is a missing decision), remove `in-progress`, unassign, and comment
+     what blocked it so the next triage pass can act.
+
+## Notes
+
+- **One issue per run.** Depth over breadth — a clean single dispatch beats a
+  half-claimed batch. `/loop` provides the cadence.
+- **Never merge automatically.** This command stops at `ready-for-human`; a human
+  merges with `gh pr merge --squash --delete-branch`.
+- The queue is only as good as triage. If it's persistently empty, groom more
+  issues to `ready-for-agent` (or put `/triage` on its own loop) rather than
+  loosening the brief requirement here.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,33 @@ docs: [`worker/README.md`](worker/README.md),
 [`src/routes/dashboard/README.md`](src/routes/dashboard/README.md). Schema changes
 auto-migrate on deploy — never a manual `db:migrate` step.
 
+## Issue-driven workflow
+
+GitHub issues are the front door for all work. Ideas, bugs, and feature requests
+are written as issues, triaged into a small state machine, then picked up by
+agents. The lifecycle and the label vocabulary are owned by the `/triage` skill —
+consult it before changing an issue's state.
+
+**State labels** (exactly one per triaged issue, alongside a category label
+`bug`/`enhancement`): `needs-triage` → `needs-info` / `ready-for-agent` /
+`ready-for-human` / `wontfix`, plus `in-progress` while actively worked. An issue
+only reaches `ready-for-agent` once it carries a self-contained **agent brief**
+comment — that brief, not the original body, is the contract the agent works from.
+
+**Branch / PR / merge conventions** (every agent and human follows these):
+
+- **Worktree per task.** Run each issue in its own git worktree so parallel work
+  never collides. Never commit straight to `main`.
+- **Branch name:** `issue-<number>-<short-slug>` (e.g. `issue-17-status-card`).
+- **Claim first.** Before writing any code, flip the issue to `in-progress` and
+  self-assign — this is the single-writer guard that stops two agents grabbing the
+  same issue (same guarantee the sync worker uses for its single-writer lock).
+- **PR body opens with `Closes #<number>`** so the merge auto-closes the issue.
+- **Verify before handoff.** Run `/verify` and `/code-review` on the branch; move
+  the PR to `ready-for-human` when it's ready to merge.
+- **Squash only.** The repo enforces squash merges (merge + rebase commits are
+  disabled). Merge with `gh pr merge --squash --delete-branch`.
+
 ---
 
 You are able to use the Svelte MCP server, where you have access to comprehensive Svelte 5 and SvelteKit documentation. Here's how to use the available tools effectively:


### PR DESCRIPTION
Scaffolding for the "issues as front door" async workflow.

## What's here
- **CLAUDE.md** — new *Issue-driven workflow* section: the triage state machine, the agent-brief-as-contract rule, and branch/PR/claim/squash conventions every agent follows.
- **.claude/commands/dispatch-ready-issues.md** — claim-first, worktree-isolated dispatcher. One issue per run, drains the `ready-for-agent` shelf, stops at `ready-for-human`, never auto-merges. Drive with `/loop 10m /dispatch-ready-issues`.

## Applied directly to the repo (not in this diff)
- State labels: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `in-progress`.
- Merge settings: squash-only (merge + rebase commits disabled), auto-delete branch on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)