### PR TITLE
feat(worker): R2 canonical archive + opt-in --publish with r2_synced_at marker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,10 +18,10 @@ DATABASE_AUTH_TOKEN=""
 # Sync worker (worker/) — a standalone `bun run worker` process. It reads the
 # same DATABASE_URL / DATABASE_AUTH_TOKEN above, plus:
 # ---------------------------------------------------------------------------
-# Content-addressed blob storage. Two backends; only crawl/recrawl store bodies.
-#   BLOB_STORE=auto (default) uses R2 when the R2_* vars below are set, else the
-#   local cache dir. Force one with BLOB_STORE=r2 or BLOB_STORE=local.
-# BLOB_STORE=auto
+# Content-addressed blob storage. Crawls always write new bodies to the local
+# cache dir; R2 (the canonical archive) is written through only when the worker
+# runs with --publish (a CLI flag, not an env var — prod passes it). `blob.
+# r2_synced_at` marks objects confirmed in R2. `blobs:push` promotes held blobs.
 # BLOB_DIR=.cache/blobs        # local cache location (dev/testing, no egress cost)
 
 # Cloudflare R2 (S3-compatible) — remote persistence. Also used by the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ bun run auth:schema      # regenerate auth tables after editing src/lib/server/a
 ```sh
 bun run worker           # run the sync worker   ·   worker:estimate for a dry count
 # local crawl, no R2 needed:
-DATABASE_URL="file:local.db" BLOB_STORE=local bun run worker/index.ts --mode estimate --max 100 --once
+DATABASE_URL="file:local.db" bun run worker/index.ts --mode estimate --max 100 --once
 bun run blobs:sync       # reconcile local cache ↔ R2 (blobs:push / blobs:pull for one direction)
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ control the sync.
 bun install
 bun run dev            # app + dashboard at http://localhost:5173/dashboard
 
-# crawl into the local cache (no R2 needed), in another shell:
-DATABASE_URL="file:local.db" BLOB_STORE=local \
+# crawl into the local cache (default: no --publish, no R2 needed), in another shell:
+DATABASE_URL="file:local.db" \
   bun run worker/index.ts --mode estimate --max 100 --once
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -62,14 +62,14 @@ Key decisions (and why):
 Six tables (defined in [`src/lib/server/db/crawl.schema.ts`](../src/lib/server/db/crawl.schema.ts)),
 alongside the existing `user`/`session`/`account`/`verification`/`task` tables.
 
-| Table              | One row per                  | Purpose                                                                                                                                                                     |
-| ------------------ | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `resource`         | unique normalized URL        | The manifest. Latest fingerprint (sha256/etag/size/status), `kind` (page/document/sitemap), `state` (active/gone/error), lifecycle timestamps. Stable identity across runs. |
-| `resource_version` | observed change              | Append-only history. A row is written only on a real change: `new`, `changed`, `probed` (estimate), `gone`, `error`. This is the "what changed, when" log.                  |
-| `blob`             | unique file content (sha256) | Content-addressed store record: size, content-type, `storage_key`, ref-count. Many versions can point to one blob (dedup).                                                  |
-| `link`             | discovered edge              | The link graph: `from_resource` → `to_url`/`to_resource`, so you can find orphan documents, hub pages, etc.                                                                 |
-| `sync_run`         | a run                        | Mode, status, `control` flag, heartbeat, `current_url`, and rollup counters (pages/docs/new/changed/errors/bytes). Also the control plane.                                  |
-| `crawl_event`      | a per-URL event              | Errors and notable events (`http_error`, `fetch_error`, `throttled`, `robots_blocked`, …) for the dashboard's errors panel.                                                 |
+| Table              | One row per                  | Purpose                                                                                                                                                                                              |
+| ------------------ | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `resource`         | unique normalized URL        | The manifest. Latest fingerprint (sha256/etag/size/status), `kind` (page/document/sitemap), `state` (active/gone/error), lifecycle timestamps. Stable identity across runs.                          |
+| `resource_version` | observed change              | Append-only history. A row is written only on a real change: `new`, `changed`, `probed` (estimate), `gone`, `error`. This is the "what changed, when" log.                                           |
+| `blob`             | unique file content (sha256) | Content-addressed store record: size, content-type, `storage_key`, ref-count, and `r2_synced_at` (null until confirmed in R2 — the publish marker, §5). Many versions can point to one blob (dedup). |
+| `link`             | discovered edge              | The link graph: `from_resource` → `to_url`/`to_resource`, so you can find orphan documents, hub pages, etc.                                                                                          |
+| `sync_run`         | a run                        | Mode, status, `control` flag, heartbeat, `current_url`, and rollup counters (pages/docs/new/changed/errors/bytes). Also the control plane.                                                           |
+| `crawl_event`      | a per-URL event              | Errors and notable events (`http_error`, `fetch_error`, `throttled`, `robots_blocked`, …) for the dashboard's errors panel.                                                                          |
 
 Change detection: on fetch, the worker compares the new sha256 (crawl) or
 size/etag (estimate) to the resource's stored fingerprint → decides
@@ -106,28 +106,47 @@ This is the cheapest way to archive the text/HTML while deferring multi-MB PDFs.
 
 ---
 
-## 5. Blob storage & sync
+## 5. Blob storage: R2 canonical + opt-in publishing
 
-Bodies are content-addressed: `blobs/<ab>/<cd>/<sha256><ext>`. Two interchangeable
-backends selected by `BLOB_STORE` (`auto` | `local` | `r2`; default `auto` = R2 if
-its env is set, else the local cache):
+Bodies are content-addressed: `blobs/<ab>/<cd>/<sha256><ext>`. There are two
+backends, but they are **not** interchangeable targets picked by a switch —
+they're layered:
 
-- **local** — a filesystem dir (`.cache/blobs`, or `BLOB_DIR`). Free; ideal for
-  dev/testing. Stores real bytes.
-- **r2** — Cloudflare R2 (S3-compatible), for durable remote storage.
+- **local** — a filesystem dir (`.cache/blobs`, or `BLOB_DIR`). The dev/staging
+  store. Every crawl writes new bytes here first.
+- **r2** — Cloudflare R2 (S3-compatible), the **canonical durable archive**.
 
-Because keys are immutable, moving objects between backends is a plain
-copy-what's-missing (no conflicts). The `blob` table is the manifest:
+**Publishing to R2 is opt-in.** The crawler always writes new blobs to the local
+backend; it only writes **through** to R2 when the worker runs with `--publish`
+(prod runs pass it). A default (unpublished) run therefore never touches R2, so a
+dev/experimental crawl can't pollute the canonical archive. This is a write-path
+policy, not a read cache — nothing in the app reads blob bytes on the hot path, so
+there is no prod read-through cache.
+
+`blob.r2_synced_at` (nullable timestamp) is the publish marker: **null until the
+object is confirmed present in R2**, then stamped. It's set on a successful
+`--publish` write-through and on a `blobs:push` promotion. Because it doubles as
+the "held / pending publish" queue, `r2_synced_at IS NULL` is exactly the set of
+blobs that exist only locally. The read model `getUnpublishedBlobCount()`
+(`src/lib/server/sync.ts`) exposes that backlog.
+
+Because keys are immutable, promoting/reconciling is a plain copy-what's-missing
+(no conflicts, ever). The `blob` table is the manifest:
 
 ```bash
-bun run blobs:push    # local  → R2
-bun run blobs:pull    # R2     → local
+bun run blobs:push    # promote held (r2_synced_at IS NULL) blobs → R2, then stamp them
+bun run blobs:pull    # R2 → local (download objects the cache lacks)
 bun run blobs:sync    # both directions
 bun run worker/sync-blobs.ts --both --dry-run
 ```
 
-Cost-saving workflow: crawl locally (`BLOB_STORE=local`, no R2 usage), then
-`bun run blobs:push` when you want it durable.
+`blobs:push` is marker-aware: it only considers held blobs, uploads what R2 lacks,
+and stamps `r2_synced_at` — so a second push right after copies nothing. There is
+no automatic/scheduled sync (that's a separate concern).
+
+Cost-saving workflow: crawl locally (default, no `--publish` → no R2 usage), then
+`bun run blobs:push` when you want it durable — or run the prod worker with
+`--publish` to write through as it goes.
 
 **Viewing an archived copy.** The dashboard's content explorer links each stored
 resource to `/dashboard/blob/[id]` (auth-gated). In prod it presigns a short-lived
@@ -178,8 +197,8 @@ Control is just DB writes: enqueue = insert `sync_run(status=queued)`; pause/can
 bun install
 bun run dev                      # web app + dashboard (http://localhost:5173/dashboard)
 
-# in another shell — crawl into the local cache, no R2 needed:
-DATABASE_URL="file:local.db" BLOB_STORE=local \
+# in another shell — crawl into the local cache (default: no --publish, no R2 needed):
+DATABASE_URL="file:local.db" \
   bun run worker/index.ts --mode estimate --max 100 --once
 ```
 
@@ -191,8 +210,10 @@ Default seeded login (local/mock DB): `admin@example.com` / `password`.
    `DATABASE_AUTH_TOKEN` + `ORIGIN` + `BETTER_AUTH_SECRET`, and the `R2_*` vars so
    the dashboard can presign archived copies (§5). Tables auto-create on first request.
 2. Blob store → create an R2 bucket + token, set `R2_*` (see below).
-3. Worker → run `bun run worker` on an always-on host with the same
-   `DATABASE_URL`/`DATABASE_AUTH_TOKEN` + `R2_*`. Drive it from `/dashboard`.
+3. Worker → run `bun run worker --publish` on an always-on host with the same
+   `DATABASE_URL`/`DATABASE_AUTH_TOKEN` + `R2_*`. `--publish` writes blobs through
+   to R2 (the canonical archive); without it the worker holds blobs local-only.
+   Drive it from `/dashboard`.
 
 ---
 
@@ -200,22 +221,22 @@ Default seeded login (local/mock DB): `admin@example.com` / `password`.
 
 Full list in [`.env.example`](../.env.example).
 
-| Var                                                                       | Used by      | Notes                                                                                                             |
-| ------------------------------------------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------- |
-| `DATABASE_URL`                                                            | app + worker | Turso `libsql://…` (or `file:` locally)                                                                           |
-| `DATABASE_AUTH_TOKEN`                                                     | app + worker | Required for remote Turso                                                                                         |
-| `ORIGIN`, `BETTER_AUTH_SECRET`                                            | app          | Auth                                                                                                              |
-| `BLOB_STORE`                                                              | worker       | `auto` \| `local` \| `r2` (default `auto`)                                                                        |
-| `BLOB_DIR`                                                                | worker       | Local cache dir (default `.cache/blobs`)                                                                          |
-| `R2_ENDPOINT` / `R2_BUCKET` / `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` | worker + app | Cloudflare R2 (S3 API). Worker for crawl/recrawl + `blobs:*`; the app presigns them to view archived copies (§5). |
-| `CRAWLER_USER_AGENT`                                                      | worker       | How the crawler identifies itself (see §13).                                                                      |
-| `CRAWLER_RATE_LIMIT` / `CRAWLER_RATE_LIMIT_JITTER`                        | worker       | Base seconds between requests + random extra 0..N (non-periodic).                                                 |
-| `CRAWLER_MAX_PAGES`                                                       | worker       | Hard safety cap per run.                                                                                          |
-| `CRAWLER_MAX_DOC_BYTES`                                                   | worker       | Skip downloading docs over N bytes (0 = pages-only). See §4.                                                      |
-| `CRAWLER_SEEDS`                                                           | worker       | Comma-separated paths/URLs to override the default seeds.                                                         |
-| `CRAWLER_TTL_{CORE,PAGE,AGENDA,DOC}_DAYS`                                 | worker       | `sync` per-tier freshness TTLs (default 7/7/30/180). See §11.                                                     |
-| `CRAWLER_SYNC_BATCH` / `CRAWLER_ERROR_BACKOFF_HOURS`                      | worker       | `sync` claim batch size / failed-URL re-schedule delay.                                                           |
-| `SYNC_SCHEDULE_MINUTES` / `WORKER_STALE_MINUTES`                          | worker       | Auto-enqueue `sync` this often (0=off); reap crashed runs. §11.                                                   |
+| Var                                                                       | Used by      | Notes                                                                                                                |
+| ------------------------------------------------------------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `DATABASE_URL`                                                            | app + worker | Turso `libsql://…` (or `file:` locally)                                                                              |
+| `DATABASE_AUTH_TOKEN`                                                     | app + worker | Required for remote Turso                                                                                            |
+| `ORIGIN`, `BETTER_AUTH_SECRET`                                            | app          | Auth                                                                                                                 |
+| `--publish` (CLI flag, not env)                                           | worker       | Write blobs through to R2 (canonical archive) + stamp `r2_synced_at`. Default off = local-only (§5). Prod passes it. |
+| `BLOB_DIR`                                                                | worker       | Local cache dir (default `.cache/blobs`)                                                                             |
+| `R2_ENDPOINT` / `R2_BUCKET` / `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` | worker + app | Cloudflare R2 (S3 API). Worker for crawl/recrawl + `blobs:*`; the app presigns them to view archived copies (§5).    |
+| `CRAWLER_USER_AGENT`                                                      | worker       | How the crawler identifies itself (see §13).                                                                         |
+| `CRAWLER_RATE_LIMIT` / `CRAWLER_RATE_LIMIT_JITTER`                        | worker       | Base seconds between requests + random extra 0..N (non-periodic).                                                    |
+| `CRAWLER_MAX_PAGES`                                                       | worker       | Hard safety cap per run.                                                                                             |
+| `CRAWLER_MAX_DOC_BYTES`                                                   | worker       | Skip downloading docs over N bytes (0 = pages-only). See §4.                                                         |
+| `CRAWLER_SEEDS`                                                           | worker       | Comma-separated paths/URLs to override the default seeds.                                                            |
+| `CRAWLER_TTL_{CORE,PAGE,AGENDA,DOC}_DAYS`                                 | worker       | `sync` per-tier freshness TTLs (default 7/7/30/180). See §11.                                                        |
+| `CRAWLER_SYNC_BATCH` / `CRAWLER_ERROR_BACKOFF_HOURS`                      | worker       | `sync` claim batch size / failed-URL re-schedule delay.                                                              |
+| `SYNC_SCHEDULE_MINUTES` / `WORKER_STALE_MINUTES`                          | worker       | Auto-enqueue `sync` this often (0=off); reap crashed runs. §11.                                                      |
 
 ---
 

--- a/drizzle/0003_yellow_leech.sql
+++ b/drizzle/0003_yellow_leech.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `blob` ADD `r2_synced_at` integer;--> statement-breakpoint
+CREATE INDEX `blob_r2_synced_idx` ON `blob` (`r2_synced_at`);

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,1272 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "fc1cffed-490a-453c-bf6a-fa6272cb7134",
+  "prevId": "e0b1d395-2308-4764-bd39-63c08a07a977",
+  "tables": {
+    "task": {
+      "name": "task",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blob": {
+      "name": "blob",
+      "columns": {
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_count": {
+          "name": "ref_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "r2_synced_at": {
+          "name": "r2_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "blob_r2_synced_idx": {
+          "name": "blob_r2_synced_idx",
+          "columns": [
+            "r2_synced_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "crawl_event": {
+      "name": "crawl_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "at": {
+          "name": "at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "crawl_event_run_idx": {
+          "name": "crawl_event_run_idx",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": false
+        },
+        "crawl_event_kind_idx": {
+          "name": "crawl_event_kind_idx",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "link": {
+      "name": "link",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_resource_id": {
+          "name": "from_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_resource_id": {
+          "name": "to_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_url": {
+          "name": "to_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rel": {
+          "name": "rel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'href'"
+        },
+        "first_run_id": {
+          "name": "first_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "link_from_to_unique": {
+          "name": "link_from_to_unique",
+          "columns": [
+            "from_resource_id",
+            "to_url"
+          ],
+          "isUnique": true
+        },
+        "link_to_idx": {
+          "name": "link_to_idx",
+          "columns": [
+            "to_resource_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "link_from_resource_id_resource_id_fk": {
+          "name": "link_from_resource_id_resource_id_fk",
+          "tableFrom": "link",
+          "tableTo": "resource",
+          "columnsFrom": [
+            "from_resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "link_to_resource_id_resource_id_fk": {
+          "name": "link_to_resource_id_resource_id_fk",
+          "tableFrom": "link",
+          "tableTo": "resource",
+          "columnsFrom": [
+            "to_resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "resource": {
+      "name": "resource",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url_hash": {
+          "name": "url_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'page'"
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "next_fetch_at": {
+          "name": "next_fetch_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "etag": {
+          "name": "etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latest_version_id": {
+          "name": "latest_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_changed_at": {
+          "name": "last_changed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_run_id": {
+          "name": "first_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "resource_url_unique": {
+          "name": "resource_url_unique",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "resource_kind_idx": {
+          "name": "resource_kind_idx",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": false
+        },
+        "resource_state_idx": {
+          "name": "resource_state_idx",
+          "columns": [
+            "state"
+          ],
+          "isUnique": false
+        },
+        "resource_host_idx": {
+          "name": "resource_host_idx",
+          "columns": [
+            "host"
+          ],
+          "isUnique": false
+        },
+        "resource_changed_idx": {
+          "name": "resource_changed_idx",
+          "columns": [
+            "last_changed_at"
+          ],
+          "isUnique": false
+        },
+        "resource_frontier_idx": {
+          "name": "resource_frontier_idx",
+          "columns": [
+            "priority",
+            "next_fetch_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "resource_version": {
+      "name": "resource_version",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "change_kind": {
+          "name": "change_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "etag": {
+          "name": "etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blob_sha256": {
+          "name": "blob_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rv_resource_idx": {
+          "name": "rv_resource_idx",
+          "columns": [
+            "resource_id"
+          ],
+          "isUnique": false
+        },
+        "rv_run_idx": {
+          "name": "rv_run_idx",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": false
+        },
+        "rv_observed_idx": {
+          "name": "rv_observed_idx",
+          "columns": [
+            "observed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "resource_version_resource_id_resource_id_fk": {
+          "name": "resource_version_resource_id_resource_id_fk",
+          "tableFrom": "resource_version",
+          "tableTo": "resource",
+          "columnsFrom": [
+            "resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "resource_version_blob_sha256_blob_sha256_fk": {
+          "name": "resource_version_blob_sha256_blob_sha256_fk",
+          "tableFrom": "resource_version",
+          "tableTo": "blob",
+          "columnsFrom": [
+            "blob_sha256"
+          ],
+          "columnsTo": [
+            "sha256"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_run": {
+      "name": "sync_run",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "control": {
+          "name": "control",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "max_pages": {
+          "name": "max_pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "params": {
+          "name": "params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_url": {
+          "name": "current_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_phase": {
+          "name": "current_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requests_made": {
+          "name": "requests_made",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pages": {
+          "name": "pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "documents": {
+          "name": "documents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "discovered": {
+          "name": "discovered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "fetched": {
+          "name": "fetched",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "new_count": {
+          "name": "new_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "changed_count": {
+          "name": "changed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "unchanged_count": {
+          "name": "unchanged_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "gone_count": {
+          "name": "gone_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "bytes_downloaded": {
+          "name": "bytes_downloaded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "bytes_stored": {
+          "name": "bytes_stored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "bytes_estimated": {
+          "name": "bytes_estimated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sync_run_status_idx": {
+          "name": "sync_run_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "sync_run_requested_idx": {
+          "name": "sync_run_requested_idx",
+          "columns": [
+            "requested_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1784170458192,
       "tag": "0002_fancy_betty_brant",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1784233252002,
+      "tag": "0003_yellow_leech",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/server/db/crawl.schema.ts
+++ b/src/lib/server/db/crawl.schema.ts
@@ -9,15 +9,28 @@ const uuid = () => crypto.randomUUID();
 // blob — content-addressed store. One row per unique file *content* (sha256).
 // Identical bytes seen across many URLs/runs dedupe to a single object in R2,
 // so `ref_count` drives storage-savings analytics and eventual GC.
+//
+// R2 is the canonical durable archive, but publishing to it is opt-in. Every
+// blob is first written to the local backend; `r2_synced_at` stays null until
+// the object is *confirmed* present in R2 (a `--publish` write-through or a
+// `blobs:push` promotion stamps it). So `r2_synced_at IS NULL` doubles as the
+// "held / pending publish" queue.
 // ---------------------------------------------------------------------------
-export const blob = sqliteTable('blob', {
-	sha256: text('sha256').primaryKey(),
-	sizeBytes: integer('size_bytes').notNull(),
-	contentType: text('content_type'),
-	storageKey: text('storage_key').notNull(), // object key in R2
-	refCount: integer('ref_count').notNull().default(0),
-	createdAt: integer('created_at', { mode: 'timestamp_ms' }).default(nowMs).notNull()
-});
+export const blob = sqliteTable(
+	'blob',
+	{
+		sha256: text('sha256').primaryKey(),
+		sizeBytes: integer('size_bytes').notNull(),
+		contentType: text('content_type'),
+		storageKey: text('storage_key').notNull(), // content-addressed object key
+		refCount: integer('ref_count').notNull().default(0),
+		// null until the object is confirmed in R2 (the canonical archive); set on a
+		// successful `--publish` write-through or a `blobs:push` promotion.
+		r2SyncedAt: integer('r2_synced_at', { mode: 'timestamp_ms' }),
+		createdAt: integer('created_at', { mode: 'timestamp_ms' }).default(nowMs).notNull()
+	},
+	(t) => [index('blob_r2_synced_idx').on(t.r2SyncedAt)]
+);
 
 // ---------------------------------------------------------------------------
 // resource — one row per unique normalized URL. Stable identity across runs;

--- a/src/lib/server/sync.ts
+++ b/src/lib/server/sync.ts
@@ -1,7 +1,7 @@
 // Server-side control plane + read models for the sync dashboard. The web app
 // never talks to the worker directly: it enqueues sync_run rows and writes the
 // `control` column; the worker polls, executes, and writes back progress here.
-import { and, count, desc, eq, inArray, isNotNull, like, or, sql } from 'drizzle-orm';
+import { and, count, desc, eq, inArray, isNotNull, isNull, like, or, sql } from 'drizzle-orm';
 import { db } from '$lib/server/db';
 import { blob, crawlEvent, link, resource, resourceVersion, syncRun } from '$lib/server/db/schema';
 
@@ -88,6 +88,15 @@ export async function getOverview() {
 		links: links?.total ?? 0,
 		versions: versions?.total ?? 0
 	};
+}
+
+/** How many blobs are held locally but not yet confirmed in R2 (the canonical
+ *  archive) — i.e. `r2_synced_at IS NULL`. This is the "pending publish" backlog
+ *  that a `--publish` run or `blobs:push` drains. Exposed for the dashboard /
+ *  publish tooling to surface; not rendered here. */
+export async function getUnpublishedBlobCount(): Promise<number> {
+	const [row] = await db.select({ n: count() }).from(blob).where(isNull(blob.r2SyncedAt));
+	return row?.n ?? 0;
 }
 
 export async function getRecentRuns(limit = 10) {

--- a/worker/README.md
+++ b/worker/README.md
@@ -66,8 +66,12 @@ SYNC_SCHEDULE_MINUTES=60 bun run worker
 bun run worker/index.ts --mode estimate --max 80 --once
 bun run worker/index.ts --mode crawl --once
 
-# Local dev: crawl into the local blob cache (.cache/blobs), no R2 needed
-BLOB_STORE=local bun run worker/index.ts --mode crawl --max 30 --once
+# Local dev: crawl into the local blob cache (.cache/blobs) — default holds blobs
+# local-only, no R2 needed:
+bun run worker/index.ts --mode crawl --max 30 --once
+
+# Publish through to R2 (the canonical archive) as it crawls — prod shape (needs R2_*):
+bun run worker --publish
 ```
 
 > **Restart after pulling code.** Bun does not hot-reload a running `bun run`
@@ -77,26 +81,36 @@ BLOB_STORE=local bun run worker/index.ts --mode crawl --max 30 --once
 > Tell-tale: a `sync` run stuck in `current_phase='crawling'` with no tier-0
 > resources or unfetched frontier rows — that's an old worker.
 
-## Blob storage & local ↔ R2 sync
+## Blob storage: R2 canonical + opt-in publishing
 
-Bodies are stored content-addressed (by sha256). Two backends, chosen by
-`BLOB_STORE` (`auto` = R2 if configured, else the local cache):
+Bodies are stored content-addressed (by sha256). R2 is the **canonical durable
+archive**, but publishing to it is **opt-in**:
 
-- **local** — `.cache/blobs` (or `BLOB_DIR`). Free, great for dev/testing.
-- **r2** — Cloudflare R2, for remote persistence.
+- **local** — `.cache/blobs` (or `BLOB_DIR`). The dev/staging store. Every crawl
+  writes new bytes here first.
+- **r2** — Cloudflare R2. Written **through** only when the worker runs with
+  `--publish` (prod passes it). A default run holds blobs local-only, so a
+  dev/experimental crawl can't pollute the archive.
 
-Because keys are immutable, moving objects between them is a plain
-copy-what's-missing — no conflicts:
+`blob.r2_synced_at` is the publish marker — null until an object is confirmed in
+R2, then stamped (on a `--publish` write-through or a `blobs:push` promotion). It
+doubles as the held/pending-publish queue (`r2_synced_at IS NULL`).
+
+Because keys are immutable, promoting/reconciling is a plain copy-what's-missing —
+no conflicts:
 
 ```bash
-bun run blobs:push    # local  -> R2   (upload objects R2 doesn't have)
-bun run blobs:pull    # R2     -> local (download objects the cache lacks)
+bun run blobs:push    # promote held (r2_synced_at IS NULL) blobs -> R2, then stamp them
+bun run blobs:pull    # R2 -> local (download objects the cache lacks)
 bun run blobs:sync    # reconcile both directions
 bun run worker/sync-blobs.ts --both --dry-run   # preview
 ```
 
-Typical workflow: crawl locally (cheap, `BLOB_STORE=local`), then
-`bun run blobs:push` to persist to R2.
+`blobs:push` is marker-aware: only held blobs are considered, so a second push
+right after copies nothing. There is no automatic/scheduled sync.
+
+Typical workflow: crawl locally (default, no `--publish`), then
+`bun run blobs:push` to persist to R2 — or run the worker with `--publish`.
 
 ## Environment
 

--- a/worker/crawl.ts
+++ b/worker/crawl.ts
@@ -13,7 +13,7 @@ import {
 	syncRun
 } from '../src/lib/server/db/schema';
 import type { SyncRun } from '../src/lib/server/db/crawl.schema';
-import { getStorage } from './storage';
+import { makeBlobWriter, type BlobWriter } from './storage';
 import {
 	BASE_URL,
 	docExtFor,
@@ -95,6 +95,7 @@ interface IngestCtx {
 	maxDocBytes: number | undefined;
 	runId: string;
 	stats: Stats;
+	writer: BlobWriter;
 }
 
 /**
@@ -104,7 +105,7 @@ interface IngestCtx {
  * the frontier `sync` loop so their fetch handling can't drift apart.
  */
 async function ingestResponse(resp: Response, ctx: IngestCtx): Promise<string[]> {
-	const { url, prevId, prevSha, prevSize, mode, maxDocBytes, runId, stats } = ctx;
+	const { url, prevId, prevSha, prevSize, mode, maxDocBytes, runId, stats, writer } = ctx;
 	const ctype = (resp.headers.get('Content-Type') ?? '').split(';')[0].trim().toLowerCase();
 	const etag = resp.headers.get('ETag') ?? undefined;
 	const lastModified = resp.headers.get('Last-Modified') ?? undefined;
@@ -148,7 +149,7 @@ async function ingestResponse(resp: Response, ctx: IngestCtx): Promise<string[]>
 			const sha = sha256Hex(bytes);
 			stats.bytesDownloaded += size;
 			const blobSha =
-				sha !== prevSha ? await ensureBlob(sha, ext, bytes, ctype, size, stats) : null;
+				sha !== prevSha ? await ensureBlob(sha, ext, bytes, ctype, size, stats, writer) : null;
 			await recordObservation({
 				runId,
 				url,
@@ -199,7 +200,7 @@ async function ingestResponse(resp: Response, ctx: IngestCtx): Promise<string[]>
 			stats.bytesDownloaded += size; // bytes actually fetched (original)
 			if (sha !== prevSha) {
 				const bytes = new TextEncoder().encode(normalized);
-				blobSha = await ensureBlob(sha, '.html', bytes, ctype, bytes.byteLength, stats);
+				blobSha = await ensureBlob(sha, '.html', bytes, ctype, bytes.byteLength, stats, writer);
 			}
 		}
 		const resourceId = await recordObservation({
@@ -231,7 +232,7 @@ async function ingestResponse(resp: Response, ctx: IngestCtx): Promise<string[]>
 	return [];
 }
 
-export async function executeRun(run: SyncRun): Promise<void> {
+export async function executeRun(run: SyncRun, opts: { publish?: boolean } = {}): Promise<void> {
 	const mode = run.mode as Mode;
 	const runId = run.id;
 	const maxPages = run.maxPages ?? MAX_PAGES;
@@ -241,9 +242,10 @@ export async function executeRun(run: SyncRun): Promise<void> {
 	// undefined = download all documents; 0 = skip all (pages-only).
 	const params = run.params ? (JSON.parse(run.params) as { maxDocBytes?: number }) : {};
 	const maxDocBytes = typeof params.maxDocBytes === 'number' ? params.maxDocBytes : MAX_DOC_BYTES;
-	// Blob store is chosen by env (R2 in prod, local cache in dev — see storage.ts).
-	// Only crawl/recrawl write bodies; estimate never touches it.
-	if (mode !== 'estimate') console.log(`blob store: ${getStorage().label}`);
+	// Blobs always land in the local backend; R2 write-through is opt-in (--publish).
+	// Only crawl/recrawl write bodies; estimate never touches storage.
+	const writer = makeBlobWriter({ publish: opts.publish ?? false });
+	if (mode !== 'estimate') console.log(`blob store: ${writer.label}`);
 
 	const robots = await Robots.load(BASE_URL);
 	const stats = zeroStats();
@@ -362,7 +364,8 @@ export async function executeRun(run: SyncRun): Promise<void> {
 			mode,
 			maxDocBytes,
 			runId,
-			stats
+			stats,
+			writer
 		});
 		for (const t of targets) {
 			if (!seen.has(t)) {
@@ -389,12 +392,14 @@ export async function executeRun(run: SyncRun): Promise<void> {
 // discovered URLs as due-now — so core pages finish before the long tail, and
 // the run picks up exactly where it left off, only fetching what's stale.
 // ---------------------------------------------------------------------------
-export async function executeSync(run: SyncRun): Promise<void> {
+export async function executeSync(run: SyncRun, opts: { publish?: boolean } = {}): Promise<void> {
 	const runId = run.id;
 	const maxPages = run.maxPages ?? MAX_PAGES;
 	const params = run.params ? (JSON.parse(run.params) as { maxDocBytes?: number }) : {};
 	const maxDocBytes = typeof params.maxDocBytes === 'number' ? params.maxDocBytes : MAX_DOC_BYTES;
-	console.log(`blob store: ${getStorage().label}`);
+	// Blobs always land in the local backend; R2 write-through is opt-in (--publish).
+	const writer = makeBlobWriter({ publish: opts.publish ?? false });
+	console.log(`blob store: ${writer.label}`);
 
 	const robots = await Robots.load(BASE_URL);
 	const stats = zeroStats();
@@ -553,7 +558,8 @@ export async function executeSync(run: SyncRun): Promise<void> {
 				mode: 'sync',
 				maxDocBytes,
 				runId,
-				stats
+				stats,
+				writer
 			});
 			await schedule(r.id, r.priority);
 			const fresh = discovered.filter((t) => !t.endsWith('sitemap.xml'));
@@ -851,31 +857,47 @@ async function upsertResource(r: ResourceUpsert): Promise<string> {
 	return row.id;
 }
 
-/** Content-addressed store: upload if new, dedupe otherwise; track refcount. */
+/** Content-addressed store: write if new, dedupe otherwise; track refcount.
+ *  Bytes always land locally; on a publishing run they also write through to R2
+ *  and `r2_synced_at` is stamped. A blob already held (r2_synced_at IS NULL) that
+ *  a publishing run sees again is promoted to R2 and stamped rather than left. */
 async function ensureBlob(
 	sha: string,
 	ext: string,
 	bytes: Uint8Array,
 	contentType: string,
 	size: number,
-	stats: Stats
+	stats: Stats,
+	writer: BlobWriter
 ): Promise<string> {
+	const now = new Date();
 	const existing = await db
-		.select({ sha256: blob.sha256 })
+		.select({ storageKey: blob.storageKey, r2SyncedAt: blob.r2SyncedAt })
 		.from(blob)
 		.where(eq(blob.sha256, sha))
 		.limit(1);
 	if (existing.length === 0) {
-		const key = await getStorage().putIfAbsent(sha, ext, bytes, contentType);
+		const { key, r2Synced } = await writer.putIfAbsent(sha, ext, bytes, contentType);
 		await db
 			.insert(blob)
-			.values({ sha256: sha, sizeBytes: size, contentType, storageKey: key, refCount: 1 })
+			.values({
+				sha256: sha,
+				sizeBytes: size,
+				contentType,
+				storageKey: key,
+				refCount: 1,
+				r2SyncedAt: r2Synced ? now : null
+			})
 			.onConflictDoUpdate({ target: blob.sha256, set: { refCount: sql`${blob.refCount} + 1` } });
 		stats.bytesStored += size; // newly stored bytes (dedup savings = downloaded - stored)
 	} else {
+		const stampR2 = writer.publish && existing[0].r2SyncedAt === null;
+		const syncedNow = stampR2
+			? await writer.ensurePublished(existing[0].storageKey, bytes, contentType)
+			: false;
 		await db
 			.update(blob)
-			.set({ refCount: sql`${blob.refCount} + 1` })
+			.set({ refCount: sql`${blob.refCount} + 1`, ...(syncedNow ? { r2SyncedAt: now } : {}) })
 			.where(eq(blob.sha256, sha));
 	}
 	return sha;

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -3,8 +3,13 @@
 // a one-shot CLI mode for ops/testing:
 //
 //   bun run worker/index.ts                       # long-running poll loop
+//   bun run worker/index.ts --publish             # ...writing blobs through to R2
 //   bun run worker/index.ts --mode estimate --max 80 --once
 //   bun run worker/index.ts --mode crawl          # enqueue + run once, then exit
+//
+// Publishing is opt-in: without --publish the worker holds blobs in the LOCAL
+// backend only (r2_synced_at null); with --publish it writes through to R2 (the
+// canonical archive) and stamps r2_synced_at. Prod runs pass --publish.
 import { readdirSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { and, asc, desc, eq, gt, inArray, lt } from 'drizzle-orm';
@@ -81,11 +86,11 @@ async function claimNext(): Promise<SyncRun | null> {
 	return claimed[0] ?? null; // null => another worker grabbed it first
 }
 
-async function runOne(run: SyncRun): Promise<void> {
+async function runOne(run: SyncRun, publish: boolean): Promise<void> {
 	console.log(`▶ run ${run.id} mode=${run.mode} max=${run.maxPages ?? 'default'}`);
 	try {
-		if (run.mode === 'sync') await executeSync(run);
-		else await executeRun(run);
+		if (run.mode === 'sync') await executeSync(run, { publish });
+		else await executeRun(run, { publish });
 		const [done] = await db.select().from(syncRun).where(eq(syncRun.id, run.id));
 		console.log(
 			`✓ run ${run.id} ${done?.status}: ${done?.pages} pages, ${done?.documents} docs, ` +
@@ -138,9 +143,10 @@ async function maybeScheduleSync(): Promise<void> {
 	console.log('scheduled sync enqueued');
 }
 
-async function pollLoop(): Promise<void> {
+async function pollLoop(publish: boolean): Promise<void> {
 	const sched = SYNC_SCHEDULE_MS > 0 ? `; auto-sync every ${SYNC_SCHEDULE_MS / 60_000}m` : '';
-	console.log(`sync worker ${WORKER_ID} polling (every ${POLL_INTERVAL_MS}ms${sched})`);
+	const pub = publish ? '; publishing to R2' : '; local-only (unpublished)';
+	console.log(`sync worker ${WORKER_ID} polling (every ${POLL_INTERVAL_MS}ms${sched}${pub})`);
 	let lastMaintenance = 0;
 	while (!stopping) {
 		if (Date.now() - lastMaintenance > MAINTENANCE_INTERVAL_MS) {
@@ -149,27 +155,36 @@ async function pollLoop(): Promise<void> {
 			await maybeScheduleSync();
 		}
 		const run = await claimNext();
-		if (run) await runOne(run);
+		if (run) await runOne(run, publish);
 		else await Bun.sleep(POLL_INTERVAL_MS);
 	}
 	console.log('stopped.');
 }
 
-async function enqueueAndRunOnce(mode: string, maxPages?: number): Promise<void> {
+async function enqueueAndRunOnce(mode: string, publish: boolean, maxPages?: number): Promise<void> {
 	const [run] = await db
 		.insert(syncRun)
 		.values({ mode, maxPages: maxPages ?? null, status: 'queued', requestedBy: 'cli' })
 		.returning();
 	const claimed = await claimNext(); // claims the row we just made
-	await runOne(claimed ?? run);
+	await runOne(claimed ?? run, publish);
 }
 
-function parseArgs(argv: string[]): { mode?: string; max?: number; once: boolean } {
-	const out: { mode?: string; max?: number; once: boolean } = { once: false };
+function parseArgs(argv: string[]): {
+	mode?: string;
+	max?: number;
+	once: boolean;
+	publish: boolean;
+} {
+	const out: { mode?: string; max?: number; once: boolean; publish: boolean } = {
+		once: false,
+		publish: false
+	};
 	for (let i = 0; i < argv.length; i++) {
 		if (argv[i] === '--mode') out.mode = argv[++i];
 		else if (argv[i] === '--max') out.max = Number(argv[++i]);
 		else if (argv[i] === '--once') out.once = true;
+		else if (argv[i] === '--publish') out.publish = true;
 	}
 	return out;
 }
@@ -177,9 +192,9 @@ function parseArgs(argv: string[]): { mode?: string; max?: number; once: boolean
 const args = parseArgs(process.argv.slice(2));
 await ensureSchema();
 if (args.mode || args.once) {
-	await enqueueAndRunOnce(args.mode ?? 'estimate', args.max);
+	await enqueueAndRunOnce(args.mode ?? 'estimate', args.publish, args.max);
 	process.exit(0);
 } else {
-	await pollLoop();
+	await pollLoop(args.publish);
 	process.exit(0);
 }

--- a/worker/storage.ts
+++ b/worker/storage.ts
@@ -108,7 +108,7 @@ export function makeR2Storage(): Storage | null {
 }
 
 // ---------------------------------------------------------------------------
-// Backend selection
+// Local backend location
 // ---------------------------------------------------------------------------
 const DEFAULT_LOCAL_DIR = '.cache/blobs';
 
@@ -116,20 +116,58 @@ export function localDir(): string {
 	return process.env.BLOB_DIR ?? DEFAULT_LOCAL_DIR;
 }
 
-/** Which backend the crawler writes to. `BLOB_STORE=r2|local|auto` (default auto:
- *  R2 when its env is set, else the local cache dir `BLOB_DIR` / .cache/blobs). */
-let active: Storage | undefined;
-export function getStorage(): Storage {
-	if (active) return active;
-	const mode = (process.env.BLOB_STORE ?? 'auto').toLowerCase();
-	const r2 = makeR2Storage();
-	if (mode === 'r2') {
-		if (!r2) throw new Error('BLOB_STORE=r2 but R2_* env vars are not set.');
-		active = r2;
-	} else if (mode === 'local') {
-		active = makeLocalStorage(localDir());
-	} else {
-		active = r2 ?? makeLocalStorage(localDir());
+// ---------------------------------------------------------------------------
+// Blob write path (the crawler's view of storage)
+// ---------------------------------------------------------------------------
+// R2 is the canonical durable archive, but publishing to it is *opt-in*. The
+// crawler ALWAYS writes new bytes to the local backend (the dev/staging cache);
+// only when publishing is enabled does it ALSO write-through to R2 and report
+// the object as synced (which stamps `blob.r2_synced_at`). A default run never
+// touches R2, so a dev/experimental crawl can't pollute the canonical archive.
+export interface BlobWriter {
+	/** True when this run writes through to R2 (prod / `--publish`). */
+	readonly publish: boolean;
+	readonly label: string;
+	/** Store bytes under the content-addressed key. Always writes to the local
+	 *  backend; when publishing, also writes-through to R2. Returns the key and
+	 *  whether the object is confirmed present in R2 (drives `blob.r2_synced_at`). */
+	putIfAbsent(
+		sha256: string,
+		ext: string,
+		bytes: Uint8Array,
+		contentType?: string
+	): Promise<{ key: string; r2Synced: boolean }>;
+	/** Promote an already-stored object to R2 (only when publishing). Returns true
+	 *  once the object is confirmed in R2 — so an unpublished blob seen again by a
+	 *  publishing run gets stamped rather than left held. */
+	ensurePublished(key: string, bytes: Uint8Array, contentType?: string): Promise<boolean>;
+}
+
+/** Build the crawler's blob write path. `publish` gates the R2 write-through
+ *  ONLY — the local backend is always written. Publishing requires R2 env. */
+export function makeBlobWriter(opts: { publish: boolean }): BlobWriter {
+	const local = makeLocalStorage(localDir());
+	const r2 = opts.publish ? makeR2Storage() : null;
+	if (opts.publish && !r2) {
+		throw new Error(
+			'--publish requires R2_* env vars (R2_ENDPOINT / R2_BUCKET / R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY).'
+		);
 	}
-	return active;
+	return {
+		publish: opts.publish,
+		label: r2
+			? `${local.label} + write-through to ${r2.label}`
+			: `${local.label} — local-only (unpublished; pass --publish to write through to R2)`,
+		async putIfAbsent(sha256, ext, bytes, contentType) {
+			const key = await local.putIfAbsent(sha256, ext, bytes, contentType);
+			if (!r2) return { key, r2Synced: false };
+			await r2.putIfAbsent(sha256, ext, bytes, contentType);
+			return { key, r2Synced: true };
+		},
+		async ensurePublished(key, bytes, contentType) {
+			if (!r2) return false;
+			if (!(await r2.has(key))) await r2.put(key, bytes, contentType);
+			return true;
+		}
+	};
 }

--- a/worker/storage.ts
+++ b/worker/storage.ts
@@ -1,11 +1,14 @@
-// Content-addressed blob storage with two interchangeable backends:
+// Content-addressed blob storage over two *layered* backends:
 //
-//   • local  — a filesystem directory (dev/testing; no egress cost)
-//   • r2     — Cloudflare R2 (S3-compatible; remote persistence)
+//   • local  — a filesystem directory (the dev/staging store; no egress cost)
+//   • r2     — Cloudflare R2 (S3-compatible; the canonical durable archive)
 //
-// Objects are keyed by sha256, so content is immutable and identical bytes
-// dedupe to one object. Because keys never change meaning, moving objects
-// between backends is a plain copy-what's-missing — see sync-blobs.ts.
+// They are not interchangeable targets picked by a switch. New bytes always land
+// in local; R2 is written *through* only when publishing is enabled (see
+// makeBlobWriter + the --publish flag). Objects are keyed by sha256, so content
+// is immutable and identical bytes dedupe to one object — and because keys never
+// change meaning, promoting/reconciling is a plain copy-what's-missing (see
+// sync-blobs.ts).
 import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import { S3Client } from 'bun';

--- a/worker/sync-blobs.ts
+++ b/worker/sync-blobs.ts
@@ -1,6 +1,6 @@
 // Sync content-addressed blobs between the local cache and R2.
 //
-//   bun run worker/sync-blobs.ts --push    # local  -> R2  (upload what R2 lacks)
+//   bun run worker/sync-blobs.ts --push    # local  -> R2  (promote held blobs)
 //   bun run worker/sync-blobs.ts --pull    # R2     -> local (download what's missing)
 //   bun run worker/sync-blobs.ts --both    # reconcile in both directions (default)
 //   bun run worker/sync-blobs.ts --both --dry-run
@@ -8,6 +8,12 @@
 // The `blob` table is the manifest of every object that should exist (sha256 ->
 // storage_key). Keys are immutable, so syncing is just: for each blob, if the
 // destination lacks the key, copy it from the source. No conflicts, ever.
+//
+// R2 is the canonical archive; `blob.r2_synced_at` marks objects confirmed there.
+// PUSH is the promotion path: it considers only *held* blobs (r2_synced_at IS
+// NULL), uploads what R2 lacks, and stamps r2_synced_at — so a second push right
+// after copies nothing. PULL reconciles the local cache from R2.
+import { eq, isNull } from 'drizzle-orm';
 import { db } from './db';
 import { blob } from '../src/lib/server/db/schema';
 import { makeLocalStorage, makeR2Storage, localDir, type Storage } from './storage';
@@ -55,6 +61,50 @@ async function copyMissing(
 	return { copied, bytes, missingSrc };
 }
 
+/** Promote held blobs (r2_synced_at IS NULL) from local → R2, stamping each once
+ *  it is confirmed in R2. Already-confirmed blobs are skipped via the marker, so
+ *  a second push right after copies nothing. */
+async function pushHeld(local: Storage, r2: Storage, dryRun: boolean) {
+	const held = (
+		await db
+			.select({ sha256: blob.sha256, key: blob.storageKey, contentType: blob.contentType })
+			.from(blob)
+			.where(isNull(blob.r2SyncedAt))
+	).filter((r) => r.key && !r.key.startsWith('local/'));
+
+	let copied = 0;
+	let bytes = 0;
+	let stamped = 0;
+	let missingSrc = 0;
+	const now = new Date();
+	for (const { sha256, key, contentType } of held) {
+		if (await r2.has(key)) {
+			// Already in R2 (e.g. pushed before the marker existed) — just confirm it.
+			if (!dryRun) await db.update(blob).set({ r2SyncedAt: now }).where(eq(blob.sha256, sha256));
+			stamped++;
+			continue;
+		}
+		const data = await local.getBytes(key);
+		if (!data) {
+			missingSrc++; // held per the manifest but the local bytes are gone
+			continue;
+		}
+		if (!dryRun) {
+			await r2.put(key, data, contentType ?? undefined);
+			await db.update(blob).set({ r2SyncedAt: now }).where(eq(blob.sha256, sha256));
+		}
+		copied++;
+		stamped++;
+		bytes += data.byteLength;
+	}
+	console.log(
+		`push (local→R2): ${held.length} held · ${dryRun ? 'would promote' : 'promoted'} ${copied} ` +
+			`object(s), ${human(bytes)}${dryRun ? '' : ` · stamped ${stamped}`}` +
+			(missingSrc ? ` — ${missingSrc} missing at source (local)` : '')
+	);
+	return { copied, bytes, stamped, missingSrc };
+}
+
 const args = new Set(process.argv.slice(2));
 const dryRun = args.has('--dry-run');
 const doPush =
@@ -81,7 +131,8 @@ console.log(
 	`manifest: ${rows.length} blob(s) · local=${local.label} · remote=${r2.label}${dryRun ? ' · DRY RUN' : ''}`
 );
 
-if (doPush) await copyMissing({ name: 'push (local→R2)', src: local, dst: r2 }, rows, dryRun);
+// Push is the promotion path (marker-aware); pull reconciles the local cache.
+if (doPush) await pushHeld(local, r2, dryRun);
 if (doPull) await copyMissing({ name: 'pull (R2→local)', src: r2, dst: local }, rows, dryRun);
 
 process.exit(0);

--- a/worker/sync-blobs.ts
+++ b/worker/sync-blobs.ts
@@ -70,7 +70,7 @@ async function pushHeld(local: Storage, r2: Storage, dryRun: boolean) {
 			.select({ sha256: blob.sha256, key: blob.storageKey, contentType: blob.contentType })
 			.from(blob)
 			.where(isNull(blob.r2SyncedAt))
-	).filter((r) => r.key && !r.key.startsWith('local/'));
+	).filter((r) => r.key && !r.key.startsWith('local/')); // skip legacy placeholder keys
 
 	let copied = 0;
 	let bytes = 0;


### PR DESCRIPTION
Closes #26

Makes R2 the canonical durable archive with **opt-in** publishing. The crawler always writes new blobs to the local backend; it writes **through** to R2 only when the worker runs with `--publish`, stamping a new nullable `blob.r2_synced_at` marker. A default (unpublished) run never touches R2, so a dev/experimental crawl can't pollute the canonical archive.

### Design
- `worker/storage.ts` — new `makeBlobWriter({ publish })`: local always, plus write-through to R2 when publishing (replaces the single-backend `getStorage()` selector). `--publish` requires `R2_*` env or it throws.
- `worker/index.ts` — `--publish` flag (default false) threaded through to `executeRun`/`executeSync`.
- `worker/crawl.ts` — `ensureBlob` stamps `r2_synced_at` on a successful write-through; a held blob (marker null) seen again by a publishing run is promoted + stamped.
- `worker/sync-blobs.ts` — `blobs:push` is now marker-aware: promotes only held (`r2_synced_at IS NULL`) blobs and stamps them.
- `src/lib/server/db/crawl.schema.ts` — nullable `r2_synced_at` timestamp (+ index). Migration `drizzle/0003_yellow_leech.sql`.
- `src/lib/server/sync.ts` — `getUnpublishedBlobCount()` read model (for #24/#25; not rendered).
- Docs: ARCHITECTURE §5 + `worker/README.md` + `.env.example` + READMEs updated for the new model.

### Acceptance criteria
- [x] 1. `bun run worker` (no `--publish`) writes blobs to local only, nothing to R2, new blobs have `r2_synced_at` null.
- [x] 2. `bun run worker --publish` writes blobs through to R2 and sets `r2_synced_at` on success.
- [x] 3. Blob record has a nullable `r2_synced_at` that stays null until confirmed in R2.
- [x] 4. `blobs:push` promotes `r2_synced_at`-null blobs and stamps them; a second push copies nothing.
- [x] 5. A read model returns the count of unpublished (`r2_synced_at IS NULL`) blobs.
- [x] 6. After an unpublished run, deleting the local blob dir leaves R2 unchanged (no canonical pollution).
- [x] 7. `docs/ARCHITECTURE.md` §5 documents the write-through + `--publish` + `r2_synced_at` model.

### Verified locally
Driven with `DATABASE_URL="file:…"` against the live site (small `--mode crawl --max 6`, no `--publish`):
- **#1, #3** — 5 blobs stored, all `r2_synced_at` null, all present as local files; label logged "local-only (unpublished)".
- **#5** — the exact drizzle `count() where isNull(r2_synced_at)` query returns 5.
- **#6** — direct test of `makeBlobWriter({ publish:false })` **with `R2_*` env set**: `putIfAbsent` returns `r2Synced:false`, writes local only, constructs no R2 client → R2 untouched even when configured.
- **#4 (marker half)** — stamping one held row drops the `r2_synced_at IS NULL` count 5→4, proving a re-push skips confirmed objects.
- **Gate** — `makeBlobWriter({ publish:true })` throws without `R2_*`; with fake `R2_*` it builds the write-through path (label confirms).
- `bun run check` clean; `bun run lint` clean on all changed files (only pre-existing gitignored `project.inlang/*` generated files warn); server unit tests pass.

### Needs a real-R2 check by the reviewer
I could not reach real R2 from the sandbox, so these were verified by code path + the publish-gate test but **not** against a live bucket:
- **#2** — the actual S3 `PUT` on a `--publish` write-through (byte upload succeeds) and the resulting stamp.
- **#4 (upload half)** — `blobs:push` actually uploading held bytes to R2 before stamping.

### Notes / intentional consequences (reviewer FYI)
- The `BLOB_STORE=auto|local|r2` selector env var is **removed** — the layered "local always + R2 on publish" model supersedes it (the brief explicitly said not to "just flip the selector"). `BLOB_STORE=r2` write-only-to-R2 is no longer a mode; that's by design (opt-in publishing is what prevents accidental R2 writes).
- With `--publish`, the prod host now **also** writes each blob to local disk (true write-through). R2 stays canonical; the local copy is incidental. Ensure the prod worker has disk headroom (or an ephemeral `BLOB_DIR`).
- `blobs:sync` pull half is intentionally left probe-based (not marker-filtered); the brief says push "may" use the marker and push is the promotion path. No automatic/scheduled sync added (out of scope, #27).
