### PR TITLE
Replace 'Live activity' feed with a 'Currently processing' panel

### DIFF
--- a/src/lib/server/sync.ts
+++ b/src/lib/server/sync.ts
@@ -238,75 +238,89 @@ export async function listResources(opts: {
 	return { rows, total };
 }
 
-export type ActivityOutcome = 'new' | 'changed' | 'gone' | 'checked';
-
-export interface ActivityItem {
+export interface ProcessingRecord {
 	id: string;
 	url: string;
 	title: string | null;
-	kind: string;
-	sizeBytes: number | null;
-	fetchedAt: number | null;
-	outcome: ActivityOutcome;
+	// type
+	kind: string; // page | document | sitemap | other
+	contentType: string | null;
+	// current status: resource lifecycle + latest change outcome
+	state: string; // active | gone | error
+	httpStatus: number | null;
+	currentOutcome: string | null; // latest resource_version.changeKind
+	currentAt: number | null; // latest resource_version.observedAt
+	// previous status: the outcome recorded *before* the latest version
+	previousOutcome: string | null; // 2nd-newest resource_version.changeKind
+	// cache age
+	fetchedAt: number | null; // resource.lastFetchedAt
 }
 
-// Whether the newest version row was produced by *this* fetch (its observation
-// lands within a few seconds of lastFetchedAt) vs. an older change.
-const VERSION_MATCH_MS = 5000;
+export interface ProcessingPanel {
+	records: ProcessingRecord[];
+	/** True when more fetched resources exist than the panel shows (truncated). */
+	hasMore: boolean;
+}
 
-/** Live activity: the most-recently *fetched* resources, newest first. Unlike the
- *  change feed, this includes unchanged re-verifies (every fetch bumps
- *  `lastFetchedAt`), so it keeps moving even when nothing is changing — that's the
- *  point: it shows the worker is doing work. Each row's outcome comes from its
- *  latest version row (new/changed/gone) when that version was written by this same
- *  fetch; otherwise the fetch confirmed no change → 'checked'. */
-export async function getRecentActivity(limit = 12): Promise<ActivityItem[]> {
-	const lastKind = sql<string | null>`(
-		select ${resourceVersion.changeKind} from ${resourceVersion}
-		where ${resourceVersion.resourceId} = ${resource.id}
-		order by ${resourceVersion.observedAt} desc limit 1
-	)`;
-	const lastVersionAt = sql<number | null>`(
-		select ${resourceVersion.observedAt} from ${resourceVersion}
-		where ${resourceVersion.resourceId} = ${resource.id}
-		order by ${resourceVersion.observedAt} desc limit 1
-	)`;
-	const rows = await db
+/** "Currently processing": the most-recently *fetched* resources, newest first —
+ *  a compact window on what the worker just touched. Unlike the change feed it
+ *  includes unchanged re-verifies (every fetch bumps `lastFetchedAt`), so it keeps
+ *  moving even when nothing changes. Each record is enriched from its resource row
+ *  (type, current state/status) and the append-only version log: the latest
+ *  version's outcome (current) and the one before it (previous). Fetches `limit + 1`
+ *  rows so the caller can flag truncation without a second count query. */
+export async function getProcessingRecords(limit = 3): Promise<ProcessingPanel> {
+	// Fetch one extra row so the caller can flag truncation without a count query.
+	const resources = await db
 		.select({
 			id: resource.id,
 			url: resource.url,
 			title: resource.title,
 			kind: resource.kind,
+			contentType: resource.contentType,
 			state: resource.state,
-			sizeBytes: resource.sizeBytes,
-			lastFetchedAt: resource.lastFetchedAt,
-			lastKind,
-			lastVersionAt
+			httpStatus: resource.httpStatus,
+			lastFetchedAt: resource.lastFetchedAt
 		})
 		.from(resource)
 		.where(isNotNull(resource.lastFetchedAt))
 		.orderBy(desc(resource.lastFetchedAt))
-		.limit(limit);
+		.limit(limit + 1);
 
-	return rows.map((r) => {
-		const fetchedAt = r.lastFetchedAt?.getTime() ?? null;
-		const versionAt = r.lastVersionAt != null ? Number(r.lastVersionAt) : null;
-		const fromThisFetch =
-			fetchedAt != null && versionAt != null && Math.abs(fetchedAt - versionAt) < VERSION_MATCH_MS;
-		let outcome: ActivityOutcome = 'checked';
-		if (r.state === 'gone') outcome = 'gone';
-		else if (fromThisFetch && (r.lastKind === 'new' || r.lastKind === 'changed'))
-			outcome = r.lastKind;
-		return {
-			id: r.id,
-			url: r.url,
-			title: r.title,
-			kind: r.kind,
-			sizeBytes: r.sizeBytes,
-			fetchedAt,
-			outcome
-		};
-	});
+	const hasMore = resources.length > limit;
+
+	// Enrich each shown resource with its two newest version rows — [current,
+	// previous] — via a small indexed lookup (rv_resource_idx). A per-resource
+	// query keeps the correlation correct and bounded to the handful of rows the
+	// panel shows, rather than a correlated subquery in the list select.
+	const records: ProcessingRecord[] = await Promise.all(
+		resources.slice(0, limit).map(async (r) => {
+			const versions = await db
+				.select({
+					changeKind: resourceVersion.changeKind,
+					observedAt: resourceVersion.observedAt
+				})
+				.from(resourceVersion)
+				.where(eq(resourceVersion.resourceId, r.id))
+				.orderBy(desc(resourceVersion.observedAt))
+				.limit(2);
+			const [current, previous] = versions;
+			return {
+				id: r.id,
+				url: r.url,
+				title: r.title,
+				kind: r.kind,
+				contentType: r.contentType,
+				state: r.state,
+				httpStatus: r.httpStatus,
+				currentOutcome: current?.changeKind ?? null,
+				currentAt: current?.observedAt?.getTime() ?? null,
+				previousOutcome: previous?.changeKind ?? null,
+				fetchedAt: r.lastFetchedAt?.getTime() ?? null
+			};
+		})
+	);
+	return { records, hasMore };
 }
 
 /** Change feed: recent version rows joined to their resource. */

--- a/src/lib/server/sync.ts
+++ b/src/lib/server/sync.ts
@@ -238,20 +238,27 @@ export async function listResources(opts: {
 	return { rows, total };
 }
 
+// Closed value sets for the enriched fields, mirroring the schema's documented
+// column domains (see crawl.schema.ts). Kept as unions so consumers stay
+// exhaustive; the DB stores them as plain text, so reads are cast at the boundary.
+export type ResourceKind = 'page' | 'document' | 'sitemap' | 'other';
+export type ResourceState = 'active' | 'gone' | 'error';
+export type ChangeKind = 'new' | 'changed' | 'probed' | 'gone' | 'error';
+
 export interface ProcessingRecord {
 	id: string;
 	url: string;
 	title: string | null;
 	// type
-	kind: string; // page | document | sitemap | other
+	kind: ResourceKind;
 	contentType: string | null;
 	// current status: resource lifecycle + latest change outcome
-	state: string; // active | gone | error
+	state: ResourceState;
 	httpStatus: number | null;
-	currentOutcome: string | null; // latest resource_version.changeKind
+	currentOutcome: ChangeKind | null; // latest resource_version.changeKind
 	currentAt: number | null; // latest resource_version.observedAt
 	// previous status: the outcome recorded *before* the latest version
-	previousOutcome: string | null; // 2nd-newest resource_version.changeKind
+	previousOutcome: ChangeKind | null; // 2nd-newest resource_version.changeKind
 	// cache age
 	fetchedAt: number | null; // resource.lastFetchedAt
 }
@@ -270,7 +277,6 @@ export interface ProcessingPanel {
  *  version's outcome (current) and the one before it (previous). Fetches `limit + 1`
  *  rows so the caller can flag truncation without a second count query. */
 export async function getProcessingRecords(limit = 3): Promise<ProcessingPanel> {
-	// Fetch one extra row so the caller can flag truncation without a count query.
 	const resources = await db
 		.select({
 			id: resource.id,
@@ -305,17 +311,18 @@ export async function getProcessingRecords(limit = 3): Promise<ProcessingPanel> 
 				.orderBy(desc(resourceVersion.observedAt))
 				.limit(2);
 			const [current, previous] = versions;
+			// Cast the text columns to their documented unions at the read boundary.
 			return {
 				id: r.id,
 				url: r.url,
 				title: r.title,
-				kind: r.kind,
+				kind: r.kind as ResourceKind,
 				contentType: r.contentType,
-				state: r.state,
+				state: r.state as ResourceState,
 				httpStatus: r.httpStatus,
-				currentOutcome: current?.changeKind ?? null,
+				currentOutcome: (current?.changeKind ?? null) as ChangeKind | null,
 				currentAt: current?.observedAt?.getTime() ?? null,
-				previousOutcome: previous?.changeKind ?? null,
+				previousOutcome: (previous?.changeKind ?? null) as ChangeKind | null,
 				fetchedAt: r.lastFetchedAt?.getTime() ?? null
 			};
 		})

--- a/src/routes/dashboard/+page.server.ts
+++ b/src/routes/dashboard/+page.server.ts
@@ -13,7 +13,7 @@ export const load: PageServerLoad = async () => {
 		storage,
 		feed,
 		progress,
-		activity
+		processing
 	] = await Promise.all([
 		sync.getOverview(),
 		sync.getActiveRun(),
@@ -24,7 +24,7 @@ export const load: PageServerLoad = async () => {
 		sync.getStorageByType(),
 		sync.getChangeFeed(10),
 		sync.getSyncProgress(),
-		sync.getRecentActivity()
+		sync.getProcessingRecords()
 	]);
 
 	// The worker-health hint (is anything actually processing this run?) is derived
@@ -40,7 +40,7 @@ export const load: PageServerLoad = async () => {
 		storage,
 		feed,
 		progress,
-		activity
+		processing
 	};
 };
 

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -127,17 +127,14 @@
 		if (s === 'completed') return 'secondary';
 		return 'outline';
 	}
+	// Badge colour for a change/outcome/state token: new → primary, gone/error →
+	// destructive, changed → secondary, everything else (probed / active /
+	// unchanged re-verify) → outline. Shared by the change feed and the panel.
 	function changeVariant(k: string): 'default' | 'secondary' | 'destructive' | 'outline' {
 		if (k === 'new') return 'default';
 		if (k === 'gone' || k === 'error') return 'destructive';
 		if (k === 'changed') return 'secondary';
 		return 'outline';
-	}
-	function outcomeVariant(o: string): 'default' | 'secondary' | 'destructive' | 'outline' {
-		if (o === 'new') return 'default';
-		if (o === 'gone' || o === 'error') return 'destructive';
-		if (o === 'changed') return 'secondary';
-		return 'outline'; // probed / active / unchanged re-verify
 	}
 	// Resource type: page / document / other (unknown kinds collapse to "other").
 	const KNOWN_KINDS = new Set(['page', 'document', 'sitemap']);
@@ -343,7 +340,7 @@
 		<Card.Header>
 			<div class="flex items-center justify-between">
 				<Card.Title>Currently processing</Card.Title>
-				<span class="text-xs text-muted-foreground">last 3 records</span>
+				<span class="text-xs text-muted-foreground">most recently fetched</span>
 			</div>
 		</Card.Header>
 		<Card.Content>
@@ -371,7 +368,7 @@
 								{/if}
 								<span class="flex items-center gap-1">
 									current
-									<Badge variant={outcomeVariant(r.currentOutcome ?? r.state)}>
+									<Badge variant={changeVariant(r.currentOutcome ?? r.state)}>
 										{r.currentOutcome ?? r.state}
 									</Badge>
 									{#if r.httpStatus}<span class="tabular-nums">{r.httpStatus}</span>{/if}
@@ -379,7 +376,7 @@
 								<span class="flex items-center gap-1">
 									previous
 									{#if r.previousOutcome}
-										<Badge variant={outcomeVariant(r.previousOutcome)}>{r.previousOutcome}</Badge>
+										<Badge variant={changeVariant(r.previousOutcome)}>{r.previousOutcome}</Badge>
 									{:else}
 										<span>—</span>
 									{/if}
@@ -390,7 +387,7 @@
 				</ul>
 				{#if processing.hasMore}
 					<p class="mt-2 text-xs text-muted-foreground">
-						Showing the 3 most recent · older records truncated
+						Showing the {processing.records.length} most recent · older records truncated
 					</p>
 				{/if}
 			{:else}

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -18,8 +18,8 @@
 	// (and while disconnected) we fall back to the server-loaded values.
 	let streamed = $state<typeof data.active | undefined>(undefined);
 	let streamedProgress = $state<typeof data.progress | undefined>(undefined);
-	let streamedActivity = $state<typeof data.activity | undefined>(undefined);
-	const activity = $derived(streamedActivity ?? data.activity);
+	let streamedProcessing = $state<typeof data.processing | undefined>(undefined);
+	const processing = $derived(streamedProcessing ?? data.processing);
 	// New URLs discovered since the last aggregate tick — a nonzero value means the
 	// frontier (and the Overall denominator) is still growing, not converged yet.
 	let recentDelta = $state(0);
@@ -66,7 +66,7 @@
 				recentDelta = Math.max(0, p.progress.totalResources - prev);
 				streamedProgress = p.progress;
 			}
-			if (p?.activity) streamedActivity = p.activity;
+			if (p?.processing) streamedProcessing = p.processing;
 			// When the active run ends, refresh aggregates (tiles, feed, alert).
 			if (wasActive && !run) invalidateAll();
 		});
@@ -135,9 +135,14 @@
 	}
 	function outcomeVariant(o: string): 'default' | 'secondary' | 'destructive' | 'outline' {
 		if (o === 'new') return 'default';
-		if (o === 'gone') return 'destructive';
+		if (o === 'gone' || o === 'error') return 'destructive';
 		if (o === 'changed') return 'secondary';
-		return 'outline'; // checked (unchanged re-verify)
+		return 'outline'; // probed / active / unchanged re-verify
+	}
+	// Resource type: page / document / other (unknown kinds collapse to "other").
+	const KNOWN_KINDS = new Set(['page', 'document', 'sitemap']);
+	function typeLabel(kind: string): string {
+		return KNOWN_KINDS.has(kind) ? kind : 'other';
 	}
 </script>
 
@@ -333,36 +338,63 @@
 		</Card.Content>
 	</Card.Root>
 
-	<!-- Live activity: what the worker is fetching right now ---------------- -->
+	<!-- Currently processing: the worker's most-recent touches, enriched ---- -->
 	<Card.Root>
 		<Card.Header>
 			<div class="flex items-center justify-between">
-				<Card.Title>Live activity</Card.Title>
-				<span class="text-xs text-muted-foreground">most recently fetched</span>
+				<Card.Title>Currently processing</Card.Title>
+				<span class="text-xs text-muted-foreground">last 3 records</span>
 			</div>
 		</Card.Header>
 		<Card.Content>
-			{#if activity.length}
+			{#if processing.records.length}
 				<ul class="divide-y">
-					{#each activity as a (a.id)}
-						<li class="flex items-center gap-3 py-2 text-sm">
-							<Badge variant={outcomeVariant(a.outcome)} class="w-16 justify-center">
-								{a.outcome}
-							</Badge>
-							<span class="shrink-0 text-xs text-muted-foreground">
-								{a.kind === 'document' ? 'doc' : 'page'}
-							</span>
-							<span class="min-w-0 flex-1 truncate" title={a.url}>
-								{a.title || a.url}
-							</span>
-							<span class="shrink-0 text-xs tabular-nums text-muted-foreground">
-								{formatRelative(a.fetchedAt ? new Date(a.fetchedAt) : null)}
-							</span>
+					{#each processing.records as r (r.id)}
+						<li class="flex flex-col gap-1.5 py-3 text-sm">
+							<div class="flex items-center gap-2">
+								<Badge variant="outline" class="shrink-0 capitalize">{typeLabel(r.kind)}</Badge>
+								<span class="min-w-0 flex-1 truncate font-medium" title={r.url}>
+									{r.title || r.url}
+								</span>
+								<span
+									class="shrink-0 text-xs tabular-nums text-muted-foreground"
+									title="cache age — time since last fetched"
+								>
+									fetched {formatRelative(r.fetchedAt)}
+								</span>
+							</div>
+							<div
+								class="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground"
+							>
+								{#if r.contentType}
+									<span class="font-mono">{r.contentType}</span>
+								{/if}
+								<span class="flex items-center gap-1">
+									current
+									<Badge variant={outcomeVariant(r.currentOutcome ?? r.state)}>
+										{r.currentOutcome ?? r.state}
+									</Badge>
+									{#if r.httpStatus}<span class="tabular-nums">{r.httpStatus}</span>{/if}
+								</span>
+								<span class="flex items-center gap-1">
+									previous
+									{#if r.previousOutcome}
+										<Badge variant={outcomeVariant(r.previousOutcome)}>{r.previousOutcome}</Badge>
+									{:else}
+										<span>—</span>
+									{/if}
+								</span>
+							</div>
 						</li>
 					{/each}
 				</ul>
+				{#if processing.hasMore}
+					<p class="mt-2 text-xs text-muted-foreground">
+						Showing the 3 most recent · older records truncated
+					</p>
+				{/if}
 			{:else}
-				<p class="text-sm text-muted-foreground">No fetches yet.</p>
+				<p class="text-sm text-muted-foreground">Nothing processed yet.</p>
 			{/if}
 		</Card.Content>
 	</Card.Root>

--- a/src/routes/dashboard/stream/+server.ts
+++ b/src/routes/dashboard/stream/+server.ts
@@ -63,12 +63,12 @@ export const GET: RequestHandler = async ({ locals, request }) => {
 			// Reconnection delay hint for EventSource.
 			controller.enqueue(encoder.encode('retry: 3000\n\n'));
 
-			// Aggregate progress + the activity feed are heavier than the run row, so
-			// refresh them less often. `activity` is only included in the payload on
-			// the ticks it's refreshed; the client keeps its last copy otherwise.
+			// Aggregate progress + the "currently processing" panel are heavier than the
+			// run row, so refresh them less often. `processing` is only included in the
+			// payload on the ticks it's refreshed; the client keeps its last copy otherwise.
 			let lastAgg = 0;
 			let agg: sync.SyncProgress | null = null;
-			let activity: sync.ActivityItem[] = [];
+			let processing: sync.ProcessingPanel | null = null;
 			const tick = async () => {
 				try {
 					const active = await sync.getActiveRun();
@@ -76,12 +76,15 @@ export const GET: RequestHandler = async ({ locals, request }) => {
 					if (Date.now() - lastAgg >= AGG_MS) {
 						lastAgg = Date.now();
 						fresh = true;
-						[agg, activity] = await Promise.all([sync.getSyncProgress(), sync.getRecentActivity()]);
+						[agg, processing] = await Promise.all([
+							sync.getSyncProgress(),
+							sync.getProcessingRecords()
+						]);
 					}
 					send('progress', {
 						run: active ? serialize(active) : null,
 						progress: agg,
-						activity: fresh ? activity : undefined
+						processing: fresh ? processing : undefined
 					});
 				} catch {
 					// transient DB error — next tick retries


### PR DESCRIPTION
Closes #21

Removes the "Live activity" card and its recent-activity read model, replacing it with a compact **Currently processing** panel: the 3 most-recently-fetched resources, newest first, each enriched with type, current status, previous status, and cache age. The panel updates live over the existing SSE stream.

## Acceptance criteria

- [x] **The Live activity card and its dedicated feed are removed, with no orphaned server read path.** Deleted `getRecentActivity` / `ActivityItem` / `ActivityOutcome` from `src/lib/server/sync.ts`; zero references remain (grep-clean; `bun run check` passes).
- [x] **The new panel shows at most 3 records, newest first, and indicates truncation.** `getProcessingRecords()` orders by `lastFetchedAt desc`, returns `{ records, hasMore }` (fetches `limit + 1` to flag truncation without a count query); the panel renders "Showing the N most recent · older records truncated" when `hasMore`.
- [x] **Each record displays type, current status, previous status, and cache age.** Type = resource `kind` (page/document/other) + content type; current status = latest `resource_version.changeKind` (+ HTTP status), falling back to resource `state`; previous status = the 2nd-newest version's outcome; cache age = time since `lastFetchedAt`.
- [x] **The panel updates live over the existing SSE stream.** `src/routes/dashboard/stream/+server.ts` now carries the enriched `ProcessingPanel` shape on its aggregate ticks; the client assigns it to reactive `$state` driving the panel.

## Implementation note

The old approach for per-resource version enrichment (a correlated `sql\`\`` subquery) was silently broken: in drizzle-orm 0.45.2, bare columns interpolated into a `sql\`\`` subquery render **unqualified** (`where "resource_id" = "id"`), breaking correlation to the outer row — the subqueries always returned null (the old `getRecentActivity` had the same latent bug, masked by its `'checked'` fallback). Replaced with a bounded per-resource lookup of the two newest `resource_version` rows (indexed by `rv_resource_idx`, capped at the panel size).

## Verification (`/verify`)

Drove the real dashboard end-to-end against a seeded local DB (SvelteKit dev server + better-auth login):

- Seeded 6 resources across states/ages (page/document/other; active/gone/error; outcomes new/changed/gone/error/probed; single-version and multi-version).
- **SSR page:** panel renders exactly 3 newest-first (`2026-budget` → `permit-application.pdf` → `retired-page`) with type, current (`changed 200` / `new 200` / `gone 404`), previous (`new` / `—` / `changed`), and cache age; "Live activity" string absent; truncation note shown.
- **SSE stream:** `/dashboard/stream` payload carries the enriched `processing` records (verified field-by-field).
- **Live update:** inserted a newer record → it surfaced at the top of the next SSE refresh (`live-update` → `2026-budget` → `permit-application.pdf`), confirming live newest-first updates.
- `bun run check` clean (0 errors); `bun run lint` clean on all changed source files; Svelte autofixer clean on the panel.

## Out of scope (untouched)

Header/heartbeat status chip + Resume/Cancel controls (#20), progress bars (#22), any paginated history beyond the last 3.

## Reviewer must-checks

- The union casts in `getProcessingRecords` (`as ResourceKind` / `as ResourceState` / `as ChangeKind`) assume DB values stay within the schema's documented domains.
- `currentAt` (latest `observedAt`) is carried in the record per the brief's interface but not currently rendered — kept intentionally.
- UX nuance (not a defect): unchanged-304 re-verifies write no version row, so a record's shown "current" outcome can predate its cache-age timestamp — matches the brief's wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)