### PR TITLE
Break sync progress bars down by content type (HTML vs PDF vs other)

### DIFF
--- a/src/lib/server/sync.ts
+++ b/src/lib/server/sync.ts
@@ -103,10 +103,42 @@ export async function getRecentRuns(limit = 10) {
 	return db.select().from(syncRun).orderBy(desc(syncRun.requestedAt)).limit(limit);
 }
 
+/** One coverage bucket for a resource `kind` (page / document / sitemap / other):
+ *  how many of that kind have been fetched vs discovered. `kind` is assigned at
+ *  discovery time (independent of fetch), so `total` is a stable denominator — unlike
+ *  `contentType`, which is null until a body is fetched and would make totals drift. */
+export interface SyncProgressBucket {
+	kind: string;
+	label: string;
+	total: number;
+	fetched: number;
+}
+
+// Preferred display order + human labels for the known kinds; unknown kinds sort
+// last and fall back to their raw value as the label. Keeps rendering data-driven
+// (only kinds that exist get a bar) while giving a stable, legible ordering.
+const KIND_LABELS: Record<string, string> = {
+	page: 'Pages',
+	document: 'Documents',
+	sitemap: 'Sitemaps',
+	other: 'Other'
+};
+const KIND_ORDER = ['page', 'document', 'sitemap', 'other'];
+const kindRank = (kind: string) => {
+	const i = KIND_ORDER.indexOf(kind);
+	return i === -1 ? KIND_ORDER.length : i;
+};
+
 export interface SyncProgress {
 	totalResources: number;
 	fetched: number;
 	dueRemaining: number;
+	/** Per-content-type coverage, one entry per resource `kind` present. Empty when
+	 *  nothing has been discovered yet. Zero-total kinds never appear (grouped query). */
+	byType: SyncProgressBucket[];
+	// Core-vs-Documents roll-up, kept for backward derivability. These are crawl
+	// *priority tier* based (core = priority 0, docs = priority >= 2), a different cut
+	// than `byType`'s kind buckets, so the original headline stays reconstructable.
 	coreTotal: number;
 	coreFetched: number;
 	docTotal: number;
@@ -116,8 +148,9 @@ export interface SyncProgress {
 	storedBytes: number;
 }
 
-/** Live archive progress, for the sync status card. Core coverage is the headline
- *  (fetched sitemap pages / total core); `dueRemaining` is the frontier work left. */
+/** Live archive progress, for the sync status card. `fetched / totalResources` is
+ *  the overall roll-up; `byType` breaks coverage down per content type; `dueRemaining`
+ *  is the frontier work left. */
 export async function getSyncProgress(): Promise<SyncProgress> {
 	const now = Date.now();
 	const [r] = await db
@@ -132,6 +165,24 @@ export async function getSyncProgress(): Promise<SyncProgress> {
 			documents: sql<number>`sum(case when ${resource.kind} = 'document' and ${resource.lastFetchedAt} is not null then 1 else 0 end)`
 		})
 		.from(resource);
+	// Per-kind coverage — grouped so only kinds that actually exist produce a bucket
+	// (no divide-by-zero downstream, since total >= 1 for every returned row).
+	const typeRows = await db
+		.select({
+			kind: resource.kind,
+			total: count(),
+			fetched: sql<number>`sum(case when ${resource.lastFetchedAt} is not null then 1 else 0 end)`
+		})
+		.from(resource)
+		.groupBy(resource.kind);
+	const byType: SyncProgressBucket[] = typeRows
+		.map((t) => ({
+			kind: t.kind,
+			label: KIND_LABELS[t.kind] ?? t.kind,
+			total: Number(t.total),
+			fetched: Number(t.fetched)
+		}))
+		.sort((a, b) => kindRank(a.kind) - kindRank(b.kind) || a.kind.localeCompare(b.kind));
 	const [b] = await db
 		.select({ objects: count(), bytes: sql<number>`coalesce(sum(${blob.sizeBytes}), 0)` })
 		.from(blob);
@@ -139,6 +190,7 @@ export async function getSyncProgress(): Promise<SyncProgress> {
 		totalResources: r?.total ?? 0,
 		fetched: Number(r?.fetched ?? 0),
 		dueRemaining: Number(r?.dueRemaining ?? 0),
+		byType,
 		coreTotal: Number(r?.coreTotal ?? 0),
 		coreFetched: Number(r?.coreFetched ?? 0),
 		docTotal: Number(r?.docTotal ?? 0),

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -27,15 +27,10 @@
 	const progress = $derived(streamedProgress ?? data.progress);
 	let connected = $state(false);
 
-	// Core coverage % (headline), request rate, and ETA for the remaining frontier.
-	const corePct = $derived(
-		progress.coreTotal > 0 ? Math.round((progress.coreFetched / progress.coreTotal) * 100) : 0
-	);
-	// Documents = the long tail. Shown as its own bar (not blended with the ~complete
-	// page count) so it climbs within its own range instead of dragging the % down.
-	const docPct = $derived(
-		progress.docTotal > 0 ? Math.round((progress.docFetched / progress.docTotal) * 100) : 0
-	);
+	// Coverage %, guarded against divide-by-zero (a zero-total bucket reads as 0%).
+	const pctOf = (done: number, total: number) => (total > 0 ? Math.round((done / total) * 100) : 0);
+	// Overall roll-up: everything fetched vs everything discovered (the headline).
+	const overallPct = $derived(pctOf(progress.fetched, progress.totalResources));
 	const ratePerMin = $derived.by(() => {
 		if (!active?.startedAt) return 0;
 		const min = (Date.now() - active.startedAt.getTime()) / 60000;
@@ -251,27 +246,29 @@
 						</span>
 					</div>
 
-					<!-- Coverage: core (the site's pages) + overall (long tail incl. documents) -->
+					<!-- Coverage: overall roll-up + one bar per content type (data-driven) -->
 					<div class="space-y-2">
 						{@render coverageBar(
-							'Core site coverage',
-							progress.coreFetched,
-							progress.coreTotal,
-							corePct,
-							'pages'
+							'Overall',
+							progress.fetched,
+							progress.totalResources,
+							overallPct,
+							'resources'
 						)}
-						{@render coverageBar(
-							'Documents (PDFs)',
-							progress.docFetched,
-							progress.docTotal,
-							docPct,
-							'docs'
-						)}
+						{#each progress.byType as t (t.kind)}
+							{@render coverageBar(
+								t.label,
+								t.fetched,
+								t.total,
+								pctOf(t.fetched, t.total),
+								t.label.toLowerCase()
+							)}
+						{/each}
 						<p class="text-xs text-muted-foreground">
 							{formatNumber(progress.totalResources)} discovered
 							{#if recentDelta > 0}
 								<span class="text-amber-600 dark:text-amber-500">
-									↑ +{formatNumber(recentDelta)} — still finding new URLs (the Documents total keeps growing
+									↑ +{formatNumber(recentDelta)} — still finding new URLs (per-type totals keep growing
 									until page crawling finishes)
 								</span>
 							{:else}
@@ -309,19 +306,21 @@
 					</p>
 					<div class="space-y-2">
 						{@render coverageBar(
-							'Core site coverage',
-							progress.coreFetched,
-							progress.coreTotal,
-							corePct,
-							'pages'
+							'Overall',
+							progress.fetched,
+							progress.totalResources,
+							overallPct,
+							'resources'
 						)}
-						{@render coverageBar(
-							'Documents (PDFs)',
-							progress.docFetched,
-							progress.docTotal,
-							docPct,
-							'docs'
-						)}
+						{#each progress.byType as t (t.kind)}
+							{@render coverageBar(
+								t.label,
+								t.fetched,
+								t.total,
+								pctOf(t.fetched, t.total),
+								t.label.toLowerCase()
+							)}
+						{/each}
 					</div>
 					<p class="text-xs text-muted-foreground">
 						{formatNumber(progress.fetched)} archived · {formatNumber(progress.documents)} documents ·

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -138,7 +138,7 @@
 	}
 </script>
 
-{#snippet coverageBar(label: string, done: number, total: number, pct: number, unit: string)}
+{#snippet coverageBar(label: string, done: number, total: number, pct: number, unit = '')}
 	<div class="space-y-1">
 		<div class="flex justify-between text-xs">
 			<span class="font-medium">{label}</span>
@@ -151,6 +151,22 @@
 			<div class="h-full rounded-full bg-primary transition-all" style="width:{pct}%"></div>
 		</div>
 	</div>
+{/snippet}
+
+<!-- Overall roll-up + one bar per content type (data-driven from progress.byType).
+     Shared by the active-run and idle branches so both stay in lockstep. Per-type
+     bars omit a unit — the label already names the type; only Overall needs one. -->
+{#snippet coverageBars()}
+	{@render coverageBar(
+		'Overall',
+		progress.fetched,
+		progress.totalResources,
+		overallPct,
+		'resources'
+	)}
+	{#each progress.byType as t (t.kind)}
+		{@render coverageBar(t.label, t.fetched, t.total, pctOf(t.fetched, t.total))}
+	{/each}
 {/snippet}
 
 {#snippet statusDetail(label: string, value: string)}
@@ -248,22 +264,7 @@
 
 					<!-- Coverage: overall roll-up + one bar per content type (data-driven) -->
 					<div class="space-y-2">
-						{@render coverageBar(
-							'Overall',
-							progress.fetched,
-							progress.totalResources,
-							overallPct,
-							'resources'
-						)}
-						{#each progress.byType as t (t.kind)}
-							{@render coverageBar(
-								t.label,
-								t.fetched,
-								t.total,
-								pctOf(t.fetched, t.total),
-								t.label.toLowerCase()
-							)}
-						{/each}
+						{@render coverageBars()}
 						<p class="text-xs text-muted-foreground">
 							{formatNumber(progress.totalResources)} discovered
 							{#if recentDelta > 0}
@@ -305,22 +306,7 @@
 						· {formatRelative(data.lastRun.finishedAt)}
 					</p>
 					<div class="space-y-2">
-						{@render coverageBar(
-							'Overall',
-							progress.fetched,
-							progress.totalResources,
-							overallPct,
-							'resources'
-						)}
-						{#each progress.byType as t (t.kind)}
-							{@render coverageBar(
-								t.label,
-								t.fetched,
-								t.total,
-								pctOf(t.fetched, t.total),
-								t.label.toLowerCase()
-							)}
-						{/each}
+						{@render coverageBars()}
 					</div>
 					<p class="text-xs text-muted-foreground">
 						{formatNumber(progress.fetched)} archived · {formatNumber(progress.documents)} documents ·


### PR DESCRIPTION
Closes #22

Replaces the fixed **Core vs Documents** progress pair with a data-driven set: an **Overall** roll-up plus one bar per resource content type. Which types appear is driven by the data, not hardcoded.

## What changed
- **`src/lib/server/sync.ts`** — `getSyncProgress()` now returns `byType: SyncProgressBucket[]`, a grouped per-`kind` cut (`{ kind, label, total, fetched }`). Bucketing is by resource **`kind`** (page/document/sitemap/other), not `contentType`: `kind` is assigned at discovery time so `total` is a stable denominator, whereas `contentType` is null until a body is fetched and would make totals drift. Only kinds that exist produce a bucket (`GROUP BY kind` ⇒ `total >= 1`), so there is no divide-by-zero downstream. Unknown kinds fall back to their raw value as the label.
- **`src/routes/dashboard/+page.svelte`** — a shared `coverageBars` snippet renders Overall + the `byType` loop through the existing `coverageBar` snippet, used by **both** the active-run and idle (last-run) branches. A `pctOf()` helper guards against divide-by-zero (a zero-total bucket reads `0%`).
- The priority-tier **Core-vs-Documents** counts (`coreTotal/coreFetched/docTotal/docFetched`) are **kept** in the read model so the original headline stays derivable (criterion 4). They are a different cut (crawl priority tier) than the kind buckets; retained deliberately even though the UI no longer renders those two specific bars.

## Acceptance criteria
- [x] 1. The progress read model returns per-content-type fetched/total counts plus an overall (`byType[]` + `fetched`/`totalResources`).
- [x] 2. The dashboard renders one bar per content type and an overall bar (both active and idle states).
- [x] 3. Types with zero total are hidden (grouped query omits them) and present-but-unfetched kinds show an unambiguous `0%` — no divide-by-zero.
- [x] 4. The existing Core-vs-Documents information is still derivable (kept in the read model).

## Verification (`/verify`, drove the real dashboard)
Seeded 13 resources across kinds — page 4/5, document 1/4, sitemap 1/1, other 0/2, plus an unknown kind `widget` 1/1 — and drove the dashboard with Playwright after logging in:
- **Active state**: 6 bars in correct order with correct math + fill width — Overall `54% · 7/13`, Pages `80% · 4/5`, Documents `25% · 1/4`, Sitemaps `100% · 1/1`, Other `0% · 0/2`, widget `100% · 1/1`.
- **Idle state** (completed lastRun, no active run): identical 6 bars via the shared snippet.
- **Empty-DB probe** (0 resources, active run): only `Overall 0% · 0/0 resources`, **no NaN**, no phantom per-type bars — divide-by-zero guard holds.
- Header chip (#20) and Currently-processing panel (#21) untouched.
- `bun run check` (0 errors), `bun run lint` clean, `svelte-autofixer` clean.

## Out of scope (untouched)
Discovery toggle (#23), storage aggregates (#24), header chip/controls (#20), processing panel (#21), crawl priority tiers / fetch scheduling.

## Reviewer must-checks
- The `kind`-vs-`contentType` bucketing decision (rationale above): `document` lumps PDF/Word/etc. together rather than splitting by MIME — the spec framed "HTML pages, PDF documents" as examples, not a required split.
- The retained `coreTotal/coreFetched/docTotal/docFetched` fields have no current UI consumer; kept intentionally to satisfy criterion 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)