### PR TITLE
feat(worker): text extraction — HTML main-content + text-layer PDF (#34)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,10 @@
     "": {
       "name": "orleans",
       "dependencies": {
+        "@mozilla/readability": "^0.6.0",
         "aws4fetch": "^1.0.20",
+        "linkedom": "^0.18.13",
+        "unpdf": "^1.6.2",
       },
       "devDependencies": {
         "@better-auth/cli": "~1.4.21",
@@ -403,6 +406,8 @@
 
     "@mdx-js/react": ["@mdx-js/react@3.1.1", "", { "dependencies": { "@types/mdx": "^2.0.0" }, "peerDependencies": { "@types/react": ">=16", "react": ">=16" } }, "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw=="],
 
+    "@mozilla/readability": ["@mozilla/readability@0.6.0", "", {}, "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ=="],
+
     "@mrleebo/prisma-ast": ["@mrleebo/prisma-ast@0.13.1", "", { "dependencies": { "chevrotain": "^10.5.0", "lilconfig": "^2.1.0" } }, "sha512-XyroGQXcHrZdvmrGJvsA9KNeOOgGMg1Vg9OlheUsBOSKznLMDl+YChxbkboRHvtFYJEMRYmlV3uoo/njCw05iw=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
@@ -763,6 +768,8 @@
 
     "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
 
+    "boolbase": ["boolbase@2.0.0", "", {}, "sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA=="],
+
     "brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
 
     "browserslist": ["browserslist@4.28.6", "", { "dependencies": { "baseline-browser-mapping": "^2.10.42", "caniuse-lite": "^1.0.30001803", "electron-to-chromium": "^1.5.389", "node-releases": "^2.0.51", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw=="],
@@ -811,9 +818,15 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
+    "css-select": ["css-select@7.0.0", "", { "dependencies": { "boolbase": "^2.0.0", "css-what": "^8.0.0", "domhandler": "^6.0.1", "domutils": "^4.0.2", "nth-check": "^3.0.1" } }, "sha512-snmjEVXy+1LnwXdxhYvTMj1d9tOh4HxkA1YmoayVBeeyR2C14Pum7fcxJIm4SswYspVy866eYNwlH6xC3/VH5g=="],
+
+    "css-what": ["css-what@8.0.0", "", {}, "sha512-DH0Bqq3DNp5tdOReuNyAA+Ev4Y2GS5FMbZpeTLP6C4CDi0h5nL0BmUPChXw3o/qbHLDWHl49sbNqQVY7bMSDdw=="],
+
     "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
 
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
+
+    "cssom": ["cssom@0.5.0", "", {}, "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
@@ -905,6 +918,14 @@
 
     "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
+    "dom-serializer": ["dom-serializer@3.1.1", "", { "dependencies": { "domelementtype": "^3.0.0", "domhandler": "^6.0.0", "entities": "^8.0.0" } }, "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@6.0.1", "", { "dependencies": { "domelementtype": "^3.0.0" } }, "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg=="],
+
+    "domutils": ["domutils@4.0.2", "", { "dependencies": { "dom-serializer": "^3.0.0", "domelementtype": "^3.0.0", "domhandler": "^6.0.0" } }, "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA=="],
+
     "dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
 
     "drizzle-kit": ["drizzle-kit@0.31.10", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.25.4", "tsx": "^4.21.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw=="],
@@ -924,6 +945,8 @@
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.21.6", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ=="],
+
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
 
@@ -1019,7 +1042,9 @@
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
-    "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
+    "html-escaper": ["html-escaper@3.0.3", "", {}, "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="],
+
+    "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
@@ -1131,6 +1156,8 @@
 
     "lilconfig": ["lilconfig@2.1.0", "", {}, "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ=="],
 
+    "linkedom": ["linkedom@0.18.13", "", { "dependencies": { "css-select": "^7.0.0", "cssom": "^0.5.0", "html-escaper": "^3.0.3", "htmlparser2": "^10.1.0", "uhyphen": "^0.2.0" }, "peerDependencies": { "canvas": ">= 2" }, "optionalPeers": ["canvas"] }, "sha512-ES/o9qotMpzpN2MHs+Iq/JcVoOj8Fa5wiQYrTdFpvAnwXL0g66XHHUc9WUMk6nAlBtGsFQ24ne+SYnvnaQ2FSw=="],
+
     "lint-staged": ["lint-staged@17.0.8", "", { "dependencies": { "listr2": "^10.2.1", "picomatch": "^4.0.4", "string-argv": "^0.3.2", "tinyexec": "^1.2.4" }, "optionalDependencies": { "yaml": "^2.9.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-B2P/d+jVW0UXOQ0MVMLrB/9ydA1P+zz6jYfdrbbEd9ur3S2rcbduFWKiUCC02Sm5hbC8nrm7y24WuYMG54HfxA=="],
 
     "listr2": ["listr2@10.2.2", "", { "dependencies": { "cli-truncate": "^5.2.0", "eventemitter3": "^5.0.4", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^10.0.0" } }, "sha512-JtNtbZj8q5BnDMR7trpwvwk3RIrANtIVzEUm8w7amp6xelLgyuq+4WZoTH913XaQAoH/cNdYhaNzBPA2U3xbDw=="],
@@ -1202,6 +1229,8 @@
     "node-releases": ["node-releases@2.0.51", "", {}, "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ=="],
 
     "nopt": ["nopt@8.1.0", "", { "dependencies": { "abbrev": "^3.0.0" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A=="],
+
+    "nth-check": ["nth-check@3.0.1", "", { "dependencies": { "boolbase": "^2.0.0" } }, "sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ=="],
 
     "obug": ["obug@2.1.3", "", {}, "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg=="],
 
@@ -1483,6 +1512,8 @@
 
     "typescript-eslint": ["typescript-eslint@8.63.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.63.0", "@typescript-eslint/parser": "8.63.0", "@typescript-eslint/typescript-estree": "8.63.0", "@typescript-eslint/utils": "8.63.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-xgwXyzG4sK9ALkBxbyGkTMMOS+imnW65iPhxCQMK83KhxyoDNW7l+IDqEf9vMdoUidHpOoS967RCq4eMiTexwQ=="],
 
+    "uhyphen": ["uhyphen@0.2.0", "", {}, "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA=="],
+
     "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
@@ -1490,6 +1521,8 @@
     "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 
     "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
+
+    "unpdf": ["unpdf@1.6.2", "", { "peerDependencies": { "@napi-rs/canvas": "^0.1.69" }, "optionalPeers": ["@napi-rs/canvas"] }, "sha512-zQ80ySoPuPHOsvIoRp/nJyQt8TOUoTh1+WBCGcBvlddQNgKDLRwm0AY3x8Q35I7+kIiRSgqMx+Ma2pl9McIp7A=="],
 
     "unplugin": ["unplugin@2.3.11", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "acorn": "^8.15.0", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww=="],
 
@@ -1639,7 +1672,21 @@
 
     "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
 
+    "dom-serializer/domelementtype": ["domelementtype@3.0.0", "", {}, "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg=="],
+
+    "dom-serializer/entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
+
+    "domhandler/domelementtype": ["domelementtype@3.0.0", "", {}, "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg=="],
+
+    "domutils/domelementtype": ["domelementtype@3.0.0", "", {}, "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg=="],
+
     "eslint-plugin-svelte/globals": ["globals@16.5.0", "", {}, "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ=="],
+
+    "htmlparser2/domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "htmlparser2/domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
+    "istanbul-reports/html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
     "layerchart/runed": ["runed@0.37.1", "", { "dependencies": { "dequal": "^2.0.3", "esm-env": "^1.0.0", "lz-string": "^1.5.0" }, "peerDependencies": { "@sveltejs/kit": "^2.21.0", "svelte": "^5.7.0", "zod": "^4.1.0" }, "optionalPeers": ["@sveltejs/kit", "zod"] }, "sha512-MeFY73xBW8IueWBm012nNFIGy19WUGPLtknavyUPMpnyt350M47PhGSGrGoSLbidwn+Zlt/O0cp8/OZE3LASWA=="],
 
@@ -1766,6 +1813,8 @@
     "d3-sankey/d3-array/internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
 
     "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
+
+    "htmlparser2/domutils/dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
     "log-update/wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
@@ -1930,5 +1979,7 @@
     "wrangler/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
 
     "wrangler/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
+
+    "htmlparser2/domutils/dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
   }
 }

--- a/drizzle/0004_normal_skreet.sql
+++ b/drizzle/0004_normal_skreet.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `resource_text` (
+	`id` text PRIMARY KEY NOT NULL,
+	`resource_id` text NOT NULL,
+	`sha256` text NOT NULL,
+	`content_type` text,
+	`status` text NOT NULL,
+	`text` text,
+	`char_count` integer DEFAULT 0 NOT NULL,
+	`extractor` text,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`resource_id`) REFERENCES `resource`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `resource_text_resource_unique` ON `resource_text` (`resource_id`);--> statement-breakpoint
+CREATE INDEX `resource_text_sha_idx` ON `resource_text` (`sha256`);--> statement-breakpoint
+CREATE INDEX `resource_text_status_idx` ON `resource_text` (`status`);

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,1391 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "61ee929b-63ac-4177-86b8-cbf0b171fbb6",
+  "prevId": "fc1cffed-490a-453c-bf6a-fa6272cb7134",
+  "tables": {
+    "task": {
+      "name": "task",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blob": {
+      "name": "blob",
+      "columns": {
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_count": {
+          "name": "ref_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "r2_synced_at": {
+          "name": "r2_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "blob_r2_synced_idx": {
+          "name": "blob_r2_synced_idx",
+          "columns": [
+            "r2_synced_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "crawl_event": {
+      "name": "crawl_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "at": {
+          "name": "at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "crawl_event_run_idx": {
+          "name": "crawl_event_run_idx",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": false
+        },
+        "crawl_event_kind_idx": {
+          "name": "crawl_event_kind_idx",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "link": {
+      "name": "link",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_resource_id": {
+          "name": "from_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_resource_id": {
+          "name": "to_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_url": {
+          "name": "to_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rel": {
+          "name": "rel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'href'"
+        },
+        "first_run_id": {
+          "name": "first_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "link_from_to_unique": {
+          "name": "link_from_to_unique",
+          "columns": [
+            "from_resource_id",
+            "to_url"
+          ],
+          "isUnique": true
+        },
+        "link_to_idx": {
+          "name": "link_to_idx",
+          "columns": [
+            "to_resource_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "link_from_resource_id_resource_id_fk": {
+          "name": "link_from_resource_id_resource_id_fk",
+          "tableFrom": "link",
+          "tableTo": "resource",
+          "columnsFrom": [
+            "from_resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "link_to_resource_id_resource_id_fk": {
+          "name": "link_to_resource_id_resource_id_fk",
+          "tableFrom": "link",
+          "tableTo": "resource",
+          "columnsFrom": [
+            "to_resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "resource": {
+      "name": "resource",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url_hash": {
+          "name": "url_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'page'"
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "next_fetch_at": {
+          "name": "next_fetch_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "etag": {
+          "name": "etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latest_version_id": {
+          "name": "latest_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_changed_at": {
+          "name": "last_changed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_run_id": {
+          "name": "first_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "resource_url_unique": {
+          "name": "resource_url_unique",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "resource_kind_idx": {
+          "name": "resource_kind_idx",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": false
+        },
+        "resource_state_idx": {
+          "name": "resource_state_idx",
+          "columns": [
+            "state"
+          ],
+          "isUnique": false
+        },
+        "resource_host_idx": {
+          "name": "resource_host_idx",
+          "columns": [
+            "host"
+          ],
+          "isUnique": false
+        },
+        "resource_changed_idx": {
+          "name": "resource_changed_idx",
+          "columns": [
+            "last_changed_at"
+          ],
+          "isUnique": false
+        },
+        "resource_frontier_idx": {
+          "name": "resource_frontier_idx",
+          "columns": [
+            "priority",
+            "next_fetch_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "resource_text": {
+      "name": "resource_text",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "char_count": {
+          "name": "char_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "extractor": {
+          "name": "extractor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "resource_text_resource_unique": {
+          "name": "resource_text_resource_unique",
+          "columns": [
+            "resource_id"
+          ],
+          "isUnique": true
+        },
+        "resource_text_sha_idx": {
+          "name": "resource_text_sha_idx",
+          "columns": [
+            "sha256"
+          ],
+          "isUnique": false
+        },
+        "resource_text_status_idx": {
+          "name": "resource_text_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "resource_text_resource_id_resource_id_fk": {
+          "name": "resource_text_resource_id_resource_id_fk",
+          "tableFrom": "resource_text",
+          "tableTo": "resource",
+          "columnsFrom": [
+            "resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "resource_version": {
+      "name": "resource_version",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "change_kind": {
+          "name": "change_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "etag": {
+          "name": "etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blob_sha256": {
+          "name": "blob_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rv_resource_idx": {
+          "name": "rv_resource_idx",
+          "columns": [
+            "resource_id"
+          ],
+          "isUnique": false
+        },
+        "rv_run_idx": {
+          "name": "rv_run_idx",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": false
+        },
+        "rv_observed_idx": {
+          "name": "rv_observed_idx",
+          "columns": [
+            "observed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "resource_version_resource_id_resource_id_fk": {
+          "name": "resource_version_resource_id_resource_id_fk",
+          "tableFrom": "resource_version",
+          "tableTo": "resource",
+          "columnsFrom": [
+            "resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "resource_version_blob_sha256_blob_sha256_fk": {
+          "name": "resource_version_blob_sha256_blob_sha256_fk",
+          "tableFrom": "resource_version",
+          "tableTo": "blob",
+          "columnsFrom": [
+            "blob_sha256"
+          ],
+          "columnsTo": [
+            "sha256"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_run": {
+      "name": "sync_run",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "control": {
+          "name": "control",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "max_pages": {
+          "name": "max_pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "params": {
+          "name": "params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_url": {
+          "name": "current_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_phase": {
+          "name": "current_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requests_made": {
+          "name": "requests_made",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pages": {
+          "name": "pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "documents": {
+          "name": "documents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "discovered": {
+          "name": "discovered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "fetched": {
+          "name": "fetched",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "new_count": {
+          "name": "new_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "changed_count": {
+          "name": "changed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "unchanged_count": {
+          "name": "unchanged_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "gone_count": {
+          "name": "gone_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "bytes_downloaded": {
+          "name": "bytes_downloaded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "bytes_stored": {
+          "name": "bytes_stored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "bytes_estimated": {
+          "name": "bytes_estimated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sync_run_status_idx": {
+          "name": "sync_run_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "sync_run_requested_idx": {
+          "name": "sync_run_requested_idx",
+          "columns": [
+            "requested_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1784233252002,
       "tag": "0003_yellow_leech",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1784247900750,
+      "tag": "0004_normal_skreet",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"db:studio": "drizzle-kit studio",
 		"worker": "bun run worker/index.ts",
 		"worker:estimate": "bun run worker/index.ts --mode estimate --once",
+		"worker:extract": "bun run worker/index.ts --mode extract --once",
 		"blobs:sync": "bun run worker/sync-blobs.ts --both",
 		"blobs:push": "bun run worker/sync-blobs.ts --push",
 		"blobs:pull": "bun run worker/sync-blobs.ts --pull",
@@ -97,6 +98,9 @@
 		"*.{js,ts,svelte}": "eslint --fix"
 	},
 	"dependencies": {
-		"aws4fetch": "^1.0.20"
+		"@mozilla/readability": "^0.6.0",
+		"aws4fetch": "^1.0.20",
+		"linkedom": "^0.18.13",
+		"unpdf": "^1.6.2"
 	}
 }

--- a/src/lib/server/db/crawl.schema.ts
+++ b/src/lib/server/db/crawl.schema.ts
@@ -110,6 +110,47 @@ export const resourceVersion = sqliteTable(
 );
 
 // ---------------------------------------------------------------------------
+// resource_text — cleaned, retrievable main-content plain text per resource, the
+// input to the RAG pipeline (chunking/embedding, retrieval). Kept OUT of the blob
+// store on purpose: it's derived, cheap to recompute, and queried relationally.
+//
+// Cached by *content* hash: `sha256` is the resource's content fingerprint the
+// text was extracted from. A resource has at most one row (unique on
+// resource_id); on a content change the row is overwritten with the new sha +
+// text. So extraction skips a resource whose stored `sha256` already matches its
+// row, and re-extracts when the content (hence the sha) changes.
+//
+// `status` is a closed set: `ok` (text extracted) | `empty` (parsed, no usable
+// text) | `scanned` (image-only PDF, no text layer — NOT an error) | `unsupported`
+// (a content type we don't extract, e.g. Office docs). `text` is populated only
+// for `ok`. The `scanned` status is the queryable image-only-PDF census.
+// ---------------------------------------------------------------------------
+export const resourceText = sqliteTable(
+	'resource_text',
+	{
+		id: text('id').primaryKey().$defaultFn(uuid),
+		resourceId: text('resource_id')
+			.notNull()
+			.references(() => resource.id, { onDelete: 'cascade' }),
+		// content fingerprint this text was extracted from (matches resource.sha256 /
+		// blob.sha256). Drives the content-addressed cache — see the table comment.
+		sha256: text('sha256').notNull(),
+		contentType: text('content_type'), // the stored blob's content type (html / pdf / …)
+		status: text('status').notNull(), // ok | empty | scanned | unsupported
+		text: text('text'), // extracted plain text; null unless status = 'ok'
+		charCount: integer('char_count').notNull().default(0),
+		extractor: text('extractor'), // which seam produced it (e.g. html:readability, pdf:unpdf)
+		createdAt: integer('created_at', { mode: 'timestamp_ms' }).default(nowMs).notNull(),
+		updatedAt: integer('updated_at', { mode: 'timestamp_ms' }).default(nowMs).notNull()
+	},
+	(t) => [
+		uniqueIndex('resource_text_resource_unique').on(t.resourceId),
+		index('resource_text_sha_idx').on(t.sha256),
+		index('resource_text_status_idx').on(t.status)
+	]
+);
+
+// ---------------------------------------------------------------------------
 // link — the discovered relation graph (who links to what). `to_resource_id`
 // is backfilled when the target URL becomes a known resource; `to_url` always
 // holds the raw normalized target so nothing is lost before that.
@@ -198,8 +239,12 @@ export const crawlEvent = sqliteTable(
 	(t) => [index('crawl_event_run_idx').on(t.runId), index('crawl_event_kind_idx').on(t.kind)]
 );
 
+/** Closed set of extraction outcomes stored on `resource_text.status`. */
+export type ExtractionStatus = 'ok' | 'empty' | 'scanned' | 'unsupported';
+
 export type Resource = typeof resource.$inferSelect;
 export type ResourceVersion = typeof resourceVersion.$inferSelect;
+export type ResourceText = typeof resourceText.$inferSelect;
 export type Blob = typeof blob.$inferSelect;
 export type Link = typeof link.$inferSelect;
 export type SyncRun = typeof syncRun.$inferSelect;

--- a/worker/extract.ts
+++ b/worker/extract.ts
@@ -1,0 +1,299 @@
+// Text extraction — stage 1 of the RAG-chatbot pipeline (#32). Turns the stored
+// blobs (normalized HTML pages, raw PDF bytes) into clean, retrievable
+// main-content plain text and persists it per resource in `resource_text`, so
+// downstream chunking/embedding (#35) and retrieval (#36) consume clean text
+// instead of chrome-laden HTML or opaque PDF bytes.
+//
+// Two swappable seams do the actual work (each independently testable):
+//   • HTML → readability-style main content, so repeated site chrome
+//     (nav/header/footer/sidebar) is dropped — every page no longer looks alike.
+//   • PDF  → the text layer, cleaned of layout noise. Image-only / scanned PDFs
+//     (no text layer) are recorded `scanned` and counted — never errored.
+//
+// Caching is by CONTENT hash: a resource is (re)extracted only when its stored
+// `sha256` differs from the sha its `resource_text` row was built from. So a
+// re-run over unchanged content does no work; changed content re-extracts.
+import { and, asc, eq, gt, isNotNull, sql } from 'drizzle-orm';
+import { Readability } from '@mozilla/readability';
+import { parseHTML } from 'linkedom';
+import { extractText as pdfExtractText, getDocumentProxy } from 'unpdf';
+import { db } from './db';
+import { blob, crawlEvent, resource, resourceText, syncRun } from '../src/lib/server/db/schema';
+import type { ExtractionStatus, SyncRun } from '../src/lib/server/db/crawl.schema';
+import { localDir, makeLocalStorage, makeR2Storage } from './storage';
+
+const HEARTBEAT_MS = 2000;
+const BATCH = 200; // resources per DB round-trip
+
+export interface Extraction {
+	status: ExtractionStatus;
+	text: string; // '' unless status = 'ok'
+	extractor: string; // seam id, for provenance/debugging
+}
+
+// ---------------------------------------------------------------------------
+// Text cleanup — normalize whitespace while preserving block/paragraph breaks
+// (they help the downstream chunker split on natural boundaries).
+// ---------------------------------------------------------------------------
+function cleanText(s: string): string {
+	return s
+		.replace(/\r\n?/g, '\n')
+		.replace(/[^\S\n]+/g, ' ') // collapse runs of horizontal whitespace, keep newlines
+		.replace(/ *\n */g, '\n')
+		.replace(/\n{3,}/g, '\n\n')
+		.trim();
+}
+
+/** Does the text carry any actual words? Used to tell "real text" from the empty
+ *  / punctuation-only output an image-only (scanned) PDF produces. */
+function hasWords(s: string): boolean {
+	return /[\p{L}\p{N}]/u.test(s);
+}
+
+// ---------------------------------------------------------------------------
+// HTML seam — readability-style main-content extraction.
+// ---------------------------------------------------------------------------
+const CHROME_SELECTORS =
+	'script,style,noscript,template,svg,nav,header,footer,aside,form,' +
+	'[role=navigation],[role=banner],[role=contentinfo],[role=search]';
+
+export function extractHtmlText(html: string): Extraction {
+	const { document } = parseHTML(html);
+
+	// Readability mutates the document, so clone for the fallback first.
+	const parsed = new Readability(document.cloneNode(true) as typeof document).parse();
+	const main = cleanText(parsed?.textContent ?? '');
+	if (hasWords(main)) return { status: 'ok', text: main, extractor: 'html:readability' };
+
+	// Readability found no article (short/atypical pages). Fall back to body text
+	// with the big shared chrome elements removed — so two pages still don't share
+	// large identical nav/footer blocks, which is the whole point of extraction.
+	for (const el of document.querySelectorAll(CHROME_SELECTORS)) el.remove();
+	const body = cleanText(document.body?.textContent ?? '');
+	if (hasWords(body)) return { status: 'ok', text: body, extractor: 'html:body-fallback' };
+
+	return { status: 'empty', text: '', extractor: 'html:readability' };
+}
+
+// ---------------------------------------------------------------------------
+// PDF seam — extract the text layer via unpdf (a Bun/serverless-friendly pdf.js
+// bundle). A parseable PDF with no words in its text layer is image-only
+// (scanned): recorded `scanned`, not errored. A genuinely corrupt/undecodable
+// PDF throws and is handled as a per-resource error by the caller.
+// ---------------------------------------------------------------------------
+export async function extractPdfText(bytes: Uint8Array): Promise<Extraction> {
+	// verbosity 0 silences pdf.js info/warn chatter (e.g. "Indexing all PDF objects").
+	const proxy = await getDocumentProxy(bytes, { verbosity: 0 });
+	const { text } = await pdfExtractText(proxy, { mergePages: true });
+	const cleaned = cleanText(text);
+	if (!hasWords(cleaned)) return { status: 'scanned', text: '', extractor: 'pdf:unpdf' };
+	return { status: 'ok', text: cleaned, extractor: 'pdf:unpdf' };
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch on the stored blob's content type.
+// ---------------------------------------------------------------------------
+export async function extractFromBlob(
+	contentType: string | null,
+	bytes: Uint8Array
+): Promise<Extraction> {
+	const ct = (contentType ?? '').toLowerCase();
+	// PDF first: Office Open XML doc types (…openxmlformats…) contain the substring
+	// "xml", so an HTML/xml check must not run ahead of the precise type checks.
+	if (ct === 'application/pdf' || ct.endsWith('/pdf')) {
+		return extractPdfText(bytes);
+	}
+	if (ct.includes('html') || ct === 'text/xml' || ct === 'application/xml' || ct.endsWith('+xml')) {
+		return extractHtmlText(new TextDecoder().decode(bytes));
+	}
+	// Office docs (.doc/.docx/.xls/.xlsx), images, etc. — out of scope for now
+	// (#40 covers OCR / richer document parsing).
+	return { status: 'unsupported', text: '', extractor: `none:${ct || 'unknown'}` };
+}
+
+// ---------------------------------------------------------------------------
+// Blob read path — reuse the Storage backends. Bytes always live locally; on a
+// publishing deployment they may only be in R2, so fall back to it.
+// ---------------------------------------------------------------------------
+function makeBlobReader(): (storageKey: string) => Promise<Uint8Array | null> {
+	const local = makeLocalStorage(localDir());
+	const r2 = makeR2Storage(); // null when R2 env is absent
+	return async (storageKey) =>
+		(await local.getBytes(storageKey)) ?? (r2 ? await r2.getBytes(storageKey) : null);
+}
+
+// ---------------------------------------------------------------------------
+// The extraction run.
+// ---------------------------------------------------------------------------
+interface ExtractStats {
+	processed: number; // resources whose content we extracted this run
+	ok: number;
+	empty: number;
+	scanned: number;
+	unsupported: number;
+	missingBlob: number; // stored sha but bytes not found in any backend
+	errors: number;
+}
+
+function zero(): ExtractStats {
+	return { processed: 0, ok: 0, empty: 0, scanned: 0, unsupported: 0, missingBlob: 0, errors: 0 };
+}
+
+/** Persist (upsert) the extraction result for a resource, keyed by content sha. */
+async function writeResult(
+	resourceId: string,
+	sha256: string,
+	contentType: string | null,
+	result: Extraction
+): Promise<void> {
+	const now = new Date();
+	const text = result.status === 'ok' ? result.text : null;
+	await db
+		.insert(resourceText)
+		.values({
+			resourceId,
+			sha256,
+			contentType,
+			status: result.status,
+			text,
+			charCount: text?.length ?? 0,
+			extractor: result.extractor,
+			createdAt: now,
+			updatedAt: now
+		})
+		.onConflictDoUpdate({
+			target: resourceText.resourceId,
+			set: {
+				sha256,
+				contentType,
+				status: result.status,
+				text,
+				charCount: text?.length ?? 0,
+				extractor: result.extractor,
+				updatedAt: now
+			}
+		});
+}
+
+export async function executeExtract(run: SyncRun): Promise<void> {
+	const runId = run.id;
+	const maxPages = run.maxPages ?? Infinity; // --max caps processed count (testing)
+	const readBlob = makeBlobReader();
+	const stats = zero();
+	let control: string = run.control;
+	let lastBeat = 0;
+
+	// Heartbeat keeps the run alive (so reapStaleRuns doesn't kill it) and reads
+	// back the control word. Deliberately does NOT write the syncRun rollup
+	// counters — those columns are crawl-specific (pages/new/changed/…); the
+	// authoritative extraction census lives in `resource_text.status` (queryable)
+	// and per-resource errors in `crawl_event`, so we don't overload them here.
+	async function beat(currentUrl: string | null): Promise<void> {
+		const nowMs = Date.now();
+		if (nowMs - lastBeat < HEARTBEAT_MS) return;
+		lastBeat = nowMs;
+		const [row] = await db
+			.update(syncRun)
+			.set({ heartbeatAt: new Date(), currentUrl })
+			.where(eq(syncRun.id, runId))
+			.returning({ control: syncRun.control });
+		control = row?.control ?? 'none';
+	}
+
+	await db
+		.update(syncRun)
+		.set({ status: 'running', startedAt: new Date(), currentPhase: 'extracting' })
+		.where(eq(syncRun.id, runId));
+
+	// Cursor walk over resources that still need extraction: a stored body whose
+	// current sha has no matching resource_text row (never extracted, or content
+	// changed since). Cache hits are excluded by the NOT-EXISTS, so a re-run over
+	// unchanged content selects nothing. The id cursor advances monotonically, so
+	// a resource that errors (no row written) is simply skipped, never re-looped.
+	let cursor = '';
+	while (stats.processed < maxPages) {
+		await beat(null);
+		if (control === 'cancel') break;
+		while (control === 'pause') {
+			await db.update(syncRun).set({ status: 'paused' }).where(eq(syncRun.id, runId));
+			await Bun.sleep(1500);
+			lastBeat = 0;
+			await beat(null);
+			if (control === 'cancel') break;
+			if (control !== 'pause') {
+				await db.update(syncRun).set({ status: 'running' }).where(eq(syncRun.id, runId));
+			}
+		}
+		if (control === 'cancel') break;
+
+		const needsExtract = sql`not exists (
+			select 1 from ${resourceText} rt
+			where rt.resource_id = ${resource.id} and rt.sha256 = ${resource.sha256}
+		)`;
+		const batch = await db
+			.select({
+				id: resource.id,
+				url: resource.url,
+				sha256: resource.sha256,
+				contentType: blob.contentType,
+				storageKey: blob.storageKey
+			})
+			.from(resource)
+			.innerJoin(blob, eq(blob.sha256, resource.sha256))
+			.where(and(isNotNull(resource.sha256), gt(resource.id, cursor), needsExtract))
+			.orderBy(asc(resource.id))
+			.limit(BATCH);
+		if (batch.length === 0) break; // caught up
+
+		for (const r of batch) {
+			if (stats.processed >= maxPages) break;
+			cursor = r.id;
+			await beat(r.url);
+			if (control === 'cancel') break;
+
+			try {
+				const bytes = await readBlob(r.storageKey);
+				if (!bytes) {
+					stats.missingBlob++;
+					await logEvent(runId, r.url, r.id, 'blob bytes not found in any backend');
+					continue;
+				}
+				const result = await extractFromBlob(r.contentType, bytes);
+				await writeResult(r.id, r.sha256!, r.contentType, result);
+				stats.processed++;
+				stats[result.status]++;
+			} catch (e) {
+				stats.errors++;
+				const msg = e instanceof Error ? e.message : String(e);
+				await logEvent(runId, r.url, r.id, `extract failed: ${msg}`.slice(0, 500));
+			}
+		}
+	}
+
+	const status = control === 'cancel' ? 'canceled' : 'completed';
+	await db
+		.update(syncRun)
+		.set({
+			status,
+			finishedAt: new Date(),
+			currentUrl: null,
+			currentPhase: null,
+			heartbeatAt: new Date()
+		})
+		.where(eq(syncRun.id, runId));
+
+	console.log(
+		`✓ extract ${runId} ${status}: ${stats.processed} processed ` +
+			`(${stats.ok} ok, ${stats.empty} empty, ${stats.scanned} scanned, ` +
+			`${stats.unsupported} unsupported), ${stats.missingBlob} missing-blob, ${stats.errors} errors`
+	);
+}
+
+async function logEvent(
+	runId: string,
+	url: string,
+	resourceId: string,
+	message: string
+): Promise<void> {
+	await db.insert(crawlEvent).values({ runId, resourceId, url, kind: 'extract_error', message });
+}

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -19,6 +19,7 @@ import type { SyncRun } from '../src/lib/server/db/crawl.schema';
 import { applyMigrations } from '../src/lib/server/db/migrator';
 import { SYNC_SCHEDULE_MS, STALE_RUN_MS } from './config';
 import { executeRun, executeSync } from './crawl';
+import { executeExtract } from './extract';
 
 const WORKER_ID = `${process.env.HOSTNAME ?? 'worker'}-${process.pid}-${crypto.randomUUID().slice(0, 8)}`;
 const POLL_INTERVAL_MS = 3000;
@@ -90,12 +91,16 @@ async function runOne(run: SyncRun, publish: boolean): Promise<void> {
 	console.log(`▶ run ${run.id} mode=${run.mode} max=${run.maxPages ?? 'default'}`);
 	try {
 		if (run.mode === 'sync') await executeSync(run, { publish });
+		else if (run.mode === 'extract') await executeExtract(run);
 		else await executeRun(run, { publish });
 		const [done] = await db.select().from(syncRun).where(eq(syncRun.id, run.id));
-		console.log(
-			`✓ run ${run.id} ${done?.status}: ${done?.pages} pages, ${done?.documents} docs, ` +
-				`${done?.newCount} new / ${done?.changedCount} changed, ${done?.errorCount} errors`
-		);
+		// extract logs its own summary (counts are extraction-specific, not crawl rollups).
+		if (run.mode !== 'extract') {
+			console.log(
+				`✓ run ${run.id} ${done?.status}: ${done?.pages} pages, ${done?.documents} docs, ` +
+					`${done?.newCount} new / ${done?.changedCount} changed, ${done?.errorCount} errors`
+			);
+		}
 	} catch (e) {
 		const msg = e instanceof Error ? (e.stack ?? e.message) : String(e);
 		console.error(`✗ run ${run.id} failed:`, msg);


### PR DESCRIPTION
Closes #34

Stage 1 of the RAG-chatbot epic (#32): extract clean, retrievable main-content plain text from the crawled corpus so downstream chunking/embedding (#35) and retrieval (#36) consume clean text instead of chrome-laden HTML or opaque PDF bytes.

## What this adds

- **`resource_text` table** (migration `0004_normal_skreet.sql`): per-resource extracted text keyed by content `sha256`, so extraction caches by content hash. Closed `status` set: `ok | empty | scanned | unsupported`. Carries a few provenance fields for the #35 consumer (`content_type`, `char_count`, `extractor`).
- **`worker/extract.ts`** — a new `extract` worker mode (`bun run worker/index.ts --mode extract --once`, or `bun run worker:extract`). It cursor-walks resources whose stored `sha256` has no matching `resource_text` row, reads each blob via the existing `Storage` read path (local, falling back to R2), dispatches on content type behind two swappable/testable seams, and upserts the result. Heartbeat/pause/cancel are honored like the crawl loop; per-resource extraction failures are logged to `crawl_event` (`kind='extract_error'`) and never abort the run.
- Extraction counts are **not** written into the crawl-semantic `sync_run` rollup columns — the authoritative census lives in `resource_text.status` (queryable) and errors in `crawl_event`.

## Libraries (all verified running under Bun 1.3)

- HTML main content: **`@mozilla/readability`** + **`linkedom`** (lightweight, Bun-friendly DOM; jsdom not needed).
- Text-layer PDF: **`unpdf`** (unjs; bundles pdf.js for any JS runtime). No Bun-compat caveats — `unpdf/pdfjs` resolves fine from the project's `node_modules`.

## Acceptance criteria

- [x] **1. HTML main content, boilerplate removed.** Verified: two real crawled pages (`/FAQ.aspx`, `/CivicAlerts.aspx`) share **zero** long lines; site chrome (`Skip to Main Content`, `<nav>`, `<footer>`, CivicPlus) present in the 363k-char raw HTML blob is absent from the 51k-char extracted text.
- [x] **2. Text-layer PDFs yield text.** Verified: a text-layer PDF → `status=ok` with extracted text.
- [x] **3. Scanned/image-only PDFs → `scanned`, counted, no error.** Verified: an image-only (no text layer) PDF → `status=scanned`, 0 chars, no throw; `select count(*) from resource_text where status='scanned'` is the queryable census.
- [x] **4. Keyed by content hash.** Verified: a re-run over unchanged content processes 0; repointing a resource to new content re-extracts exactly that one.
- [x] **5. Generated drizzle migration.** `drizzle/0004_normal_skreet.sql` (via `bun run db:generate`; auto-migrates on deploy).

## What `/verify` exercised

Isolated DB + blob dir. Ran a real crawl (`--mode crawl --max 10`) → 9 HTML pages, then `--mode extract`: 9 pages → `ok`. Injected deterministic PDF blobs through the real blob store: text-layer → `ok`, image-only → `scanned`. Probed the error paths: a corrupt PDF is a counted `extract_error` (run still completes), an Office `.docx` (whose content type contains "xml") correctly falls through to `unsupported` rather than being mis-routed to the HTML seam. Re-ran to confirm the content-hash cache (0 processed) and content-change re-extraction (1 processed). `bun run lint` clean.

## Reviewer must-checks

- **Per-resource cache, not cross-resource dedup:** the unique index is on `resource_id` (one row per resource). Two resources with byte-identical content each extract independently — deliberate, matching the "per resource" brief; the text is stored per resource anyway for the retrieval consumer. Cross-resource content dedup was not an acceptance criterion.
- **Corrupt blobs retry each run:** an errored resource writes no `resource_text` row, so it's re-attempted on the next run (bounded, logged). Scanned/empty/unsupported all write a row and are not retried.
- **Out of scope confirmed:** no chunking/embeddings, no OCR, no retrieval/UI, no `src/routes/dashboard/**` edits.
