### PR TITLE
Steerable frontier-discovery toggle (pause discovery to drain backlog)

### DIFF
--- a/drizzle/0005_soft_spacker_dave.sql
+++ b/drizzle/0005_soft_spacker_dave.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `sync_run` ADD `discovery_enabled` integer DEFAULT true NOT NULL;

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,1399 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "40c7cbef-f213-4c2c-8f1d-a4468f8fb0b8",
+  "prevId": "61ee929b-63ac-4177-86b8-cbf0b171fbb6",
+  "tables": {
+    "task": {
+      "name": "task",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blob": {
+      "name": "blob",
+      "columns": {
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_count": {
+          "name": "ref_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "r2_synced_at": {
+          "name": "r2_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "blob_r2_synced_idx": {
+          "name": "blob_r2_synced_idx",
+          "columns": [
+            "r2_synced_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "crawl_event": {
+      "name": "crawl_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "at": {
+          "name": "at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "crawl_event_run_idx": {
+          "name": "crawl_event_run_idx",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": false
+        },
+        "crawl_event_kind_idx": {
+          "name": "crawl_event_kind_idx",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "link": {
+      "name": "link",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_resource_id": {
+          "name": "from_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_resource_id": {
+          "name": "to_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_url": {
+          "name": "to_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rel": {
+          "name": "rel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'href'"
+        },
+        "first_run_id": {
+          "name": "first_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "link_from_to_unique": {
+          "name": "link_from_to_unique",
+          "columns": [
+            "from_resource_id",
+            "to_url"
+          ],
+          "isUnique": true
+        },
+        "link_to_idx": {
+          "name": "link_to_idx",
+          "columns": [
+            "to_resource_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "link_from_resource_id_resource_id_fk": {
+          "name": "link_from_resource_id_resource_id_fk",
+          "tableFrom": "link",
+          "tableTo": "resource",
+          "columnsFrom": [
+            "from_resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "link_to_resource_id_resource_id_fk": {
+          "name": "link_to_resource_id_resource_id_fk",
+          "tableFrom": "link",
+          "tableTo": "resource",
+          "columnsFrom": [
+            "to_resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "resource": {
+      "name": "resource",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url_hash": {
+          "name": "url_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'page'"
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "next_fetch_at": {
+          "name": "next_fetch_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "etag": {
+          "name": "etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latest_version_id": {
+          "name": "latest_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_changed_at": {
+          "name": "last_changed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_run_id": {
+          "name": "first_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "resource_url_unique": {
+          "name": "resource_url_unique",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "resource_kind_idx": {
+          "name": "resource_kind_idx",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": false
+        },
+        "resource_state_idx": {
+          "name": "resource_state_idx",
+          "columns": [
+            "state"
+          ],
+          "isUnique": false
+        },
+        "resource_host_idx": {
+          "name": "resource_host_idx",
+          "columns": [
+            "host"
+          ],
+          "isUnique": false
+        },
+        "resource_changed_idx": {
+          "name": "resource_changed_idx",
+          "columns": [
+            "last_changed_at"
+          ],
+          "isUnique": false
+        },
+        "resource_frontier_idx": {
+          "name": "resource_frontier_idx",
+          "columns": [
+            "priority",
+            "next_fetch_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "resource_text": {
+      "name": "resource_text",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "char_count": {
+          "name": "char_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "extractor": {
+          "name": "extractor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "resource_text_resource_unique": {
+          "name": "resource_text_resource_unique",
+          "columns": [
+            "resource_id"
+          ],
+          "isUnique": true
+        },
+        "resource_text_sha_idx": {
+          "name": "resource_text_sha_idx",
+          "columns": [
+            "sha256"
+          ],
+          "isUnique": false
+        },
+        "resource_text_status_idx": {
+          "name": "resource_text_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "resource_text_resource_id_resource_id_fk": {
+          "name": "resource_text_resource_id_resource_id_fk",
+          "tableFrom": "resource_text",
+          "tableTo": "resource",
+          "columnsFrom": [
+            "resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "resource_version": {
+      "name": "resource_version",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "change_kind": {
+          "name": "change_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "etag": {
+          "name": "etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blob_sha256": {
+          "name": "blob_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rv_resource_idx": {
+          "name": "rv_resource_idx",
+          "columns": [
+            "resource_id"
+          ],
+          "isUnique": false
+        },
+        "rv_run_idx": {
+          "name": "rv_run_idx",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": false
+        },
+        "rv_observed_idx": {
+          "name": "rv_observed_idx",
+          "columns": [
+            "observed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "resource_version_resource_id_resource_id_fk": {
+          "name": "resource_version_resource_id_resource_id_fk",
+          "tableFrom": "resource_version",
+          "tableTo": "resource",
+          "columnsFrom": [
+            "resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "resource_version_blob_sha256_blob_sha256_fk": {
+          "name": "resource_version_blob_sha256_blob_sha256_fk",
+          "tableFrom": "resource_version",
+          "tableTo": "blob",
+          "columnsFrom": [
+            "blob_sha256"
+          ],
+          "columnsTo": [
+            "sha256"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_run": {
+      "name": "sync_run",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "control": {
+          "name": "control",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "discovery_enabled": {
+          "name": "discovery_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_pages": {
+          "name": "max_pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "params": {
+          "name": "params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_url": {
+          "name": "current_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_phase": {
+          "name": "current_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requests_made": {
+          "name": "requests_made",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pages": {
+          "name": "pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "documents": {
+          "name": "documents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "discovered": {
+          "name": "discovered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "fetched": {
+          "name": "fetched",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "new_count": {
+          "name": "new_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "changed_count": {
+          "name": "changed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "unchanged_count": {
+          "name": "unchanged_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "gone_count": {
+          "name": "gone_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "bytes_downloaded": {
+          "name": "bytes_downloaded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "bytes_stored": {
+          "name": "bytes_stored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "bytes_estimated": {
+          "name": "bytes_estimated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sync_run_status_idx": {
+          "name": "sync_run_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "sync_run_requested_idx": {
+          "name": "sync_run_requested_idx",
+          "columns": [
+            "requested_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1784247900750,
       "tag": "0004_normal_skreet",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1784254066273,
+      "tag": "0005_soft_spacker_dave",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/server/db/crawl.schema.ts
+++ b/src/lib/server/db/crawl.schema.ts
@@ -188,6 +188,12 @@ export const syncRun = sqliteTable(
 		mode: text('mode').notNull(), // estimate | crawl | recrawl
 		status: text('status').notNull().default('queued'), // queued|running|paused|completed|failed|canceled
 		control: text('control').notNull().default('none'), // none | pause | resume | cancel
+		// Frontier discovery switch. When true (default = today's behavior) the crawl
+		// enqueues newly-discovered in-scope URLs; when false the worker keeps
+		// fetching/refreshing already-known/queued resources but ingests no new links,
+		// so it drains the known backlog. Steerable live from the dashboard; the worker
+		// re-reads it on the heartbeat cadence (no restart needed).
+		discoveryEnabled: integer('discovery_enabled', { mode: 'boolean' }).notNull().default(true),
 		maxPages: integer('max_pages'),
 		params: text('params'), // JSON blob for future knobs
 		requestedBy: text('requested_by'), // user id

--- a/src/lib/server/sync.ts
+++ b/src/lib/server/sync.ts
@@ -40,6 +40,14 @@ export async function setControl(runId: string, action: ControlAction): Promise<
 	await db.update(syncRun).set({ control }).where(eq(syncRun.id, runId));
 }
 
+/** Toggle frontier discovery for a run. Off = the worker keeps fetching/refreshing
+ *  known/queued resources but stops enqueuing newly-discovered URLs; on = resume
+ *  discovery. Independent of pause/cancel; the worker re-reads it live on its
+ *  heartbeat cadence, so no restart is needed. */
+export async function setDiscovery(runId: string, enabled: boolean): Promise<void> {
+	await db.update(syncRun).set({ discoveryEnabled: enabled }).where(eq(syncRun.id, runId));
+}
+
 /** The run currently occupying the worker (or most-recently queued), if any. */
 export async function getActiveRun() {
 	const [row] = await db

--- a/src/routes/dashboard/+page.server.ts
+++ b/src/routes/dashboard/+page.server.ts
@@ -86,5 +86,18 @@ export const actions: Actions = {
 		}
 		await sync.setControl(runId, action as sync.ControlAction);
 		return { controlled: action };
+	},
+
+	discovery: async ({ request }) => {
+		const data = await request.formData();
+		const runId = String(data.get('runId') ?? '');
+		// Explicit target state so a rapid double-submit is idempotent (never a toggle
+		// race). 'on' | 'off'; anything else is rejected.
+		const enabled = String(data.get('enabled') ?? '');
+		if (!runId || (enabled !== 'on' && enabled !== 'off')) {
+			return fail(400, { error: 'invalid discovery toggle' });
+		}
+		await sync.setDiscovery(runId, enabled === 'on');
+		return { discovery: enabled };
 	}
 };

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -229,6 +229,33 @@
 					</Tooltip.Provider>
 
 					{#if active}
+						<!-- Frontier-discovery switch. On (default) enqueues newly-found URLs; off
+						     drains the known backlog without growing the frontier. Posts the target
+						     state (not a blind toggle) so a double-submit is idempotent. -->
+						<form method="POST" action="?/discovery" use:enhance>
+							<input type="hidden" name="runId" value={active.id} />
+							<input type="hidden" name="enabled" value={active.discoveryEnabled ? 'off' : 'on'} />
+							{#if active.discoveryEnabled}
+								<Button
+									type="submit"
+									variant="outline"
+									size="sm"
+									title="Stop enqueuing newly-discovered URLs; keep refreshing known ones"
+								>
+									Discovery: on
+								</Button>
+							{:else}
+								<Button
+									type="submit"
+									variant="outline"
+									size="sm"
+									class="border-amber-500 text-amber-600 dark:text-amber-500"
+									title="Resume enqueuing newly-discovered URLs"
+								>
+									Discovery: off
+								</Button>
+							{/if}
+						</form>
 						<form method="POST" action="?/control" use:enhance>
 							<input type="hidden" name="runId" value={active.id} />
 							{#if active.status === 'paused'}

--- a/src/routes/dashboard/stream/+server.ts
+++ b/src/routes/dashboard/stream/+server.ts
@@ -18,6 +18,7 @@ function serialize(r: SyncRun) {
 		id: r.id,
 		mode: r.mode,
 		status: r.status,
+		discoveryEnabled: r.discoveryEnabled,
 		requestsMade: r.requestsMade,
 		maxPages: r.maxPages,
 		pages: r.pages,

--- a/worker/crawl.ts
+++ b/worker/crawl.ts
@@ -260,13 +260,15 @@ export async function executeRun(run: SyncRun, opts: { publish?: boolean } = {})
 	}
 
 	let control: string = run.control;
+	// Live frontier-discovery switch, refreshed each heartbeat (see executeSync).
+	let discoveryEnabled = run.discoveryEnabled;
 	let lastBeat = 0;
 
 	async function beat(currentUrl: string | null): Promise<void> {
 		const nowMs = Date.now();
 		if (nowMs - lastBeat < HEARTBEAT_MS) return;
 		lastBeat = nowMs;
-		control = await writeHeartbeat(runId, currentUrl, stats);
+		({ control, discoveryEnabled } = await writeHeartbeat(runId, currentUrl, stats));
 	}
 
 	// Mark running.
@@ -367,10 +369,14 @@ export async function executeRun(run: SyncRun, opts: { publish?: boolean } = {})
 			stats,
 			writer
 		});
-		for (const t of targets) {
-			if (!seen.has(t)) {
-				queue.push(t);
-				stats.discovered++;
+		// Frontier discovery: only enqueue newly-discovered URLs while the switch is
+		// on. Off = keep draining what's already queued without growing the frontier.
+		if (discoveryEnabled) {
+			for (const t of targets) {
+				if (!seen.has(t)) {
+					queue.push(t);
+					stats.discovered++;
+				}
 			}
 		}
 
@@ -404,13 +410,16 @@ export async function executeSync(run: SyncRun, opts: { publish?: boolean } = {}
 	const robots = await Robots.load(BASE_URL);
 	const stats = zeroStats();
 	let control: string = run.control;
+	// Live frontier-discovery switch, refreshed each heartbeat. When false the loop
+	// still fetches/refreshes known resources but ingests no newly-discovered URLs.
+	let discoveryEnabled = run.discoveryEnabled;
 	let lastBeat = 0;
 
 	async function beat(currentUrl: string | null): Promise<void> {
 		const nowMs = Date.now();
 		if (nowMs - lastBeat < HEARTBEAT_MS) return;
 		lastBeat = nowMs;
-		control = await writeHeartbeat(runId, currentUrl, stats);
+		({ control, discoveryEnabled } = await writeHeartbeat(runId, currentUrl, stats));
 	}
 
 	/** Wait out a pause; returns false if the run was canceled. */
@@ -562,9 +571,14 @@ export async function executeSync(run: SyncRun, opts: { publish?: boolean } = {}
 				writer
 			});
 			await schedule(r.id, r.priority);
-			const fresh = discovered.filter((t) => !t.endsWith('sitemap.xml'));
-			await batchAll(fresh.map((t) => enqueueResourceStmt(t, runId)));
-			stats.discovered += fresh.length;
+			// Frontier discovery: enqueue newly-found in-scope URLs only while the
+			// switch is on. When off, the fetch/refresh above still runs (drain the
+			// known backlog) but no new URLs enter the frontier, so totals stop growing.
+			if (discoveryEnabled) {
+				const fresh = discovered.filter((t) => !t.endsWith('sitemap.xml'));
+				await batchAll(fresh.map((t) => enqueueResourceStmt(t, runId)));
+				stats.discovered += fresh.length;
+			}
 			await politeDelay();
 		}
 		if (control === 'cancel') break;
@@ -659,12 +673,14 @@ function backfillLinkTargets(): Promise<unknown> {
 	);
 }
 
-/** Write heartbeat + rollup counters; returns the current control flag. */
+/** Write heartbeat + rollup counters; returns the live steering flags (control +
+ *  whether frontier discovery is currently enabled) so the loop reacts without a
+ *  restart. */
 async function writeHeartbeat(
 	runId: string,
 	currentUrl: string | null,
 	stats: Stats
-): Promise<string> {
+): Promise<{ control: string; discoveryEnabled: boolean }> {
 	const [row] = await db
 		.update(syncRun)
 		.set({
@@ -685,8 +701,8 @@ async function writeHeartbeat(
 			bytesEstimated: stats.bytesEstimated
 		})
 		.where(eq(syncRun.id, runId))
-		.returning({ control: syncRun.control });
-	return row?.control ?? 'none';
+		.returning({ control: syncRun.control, discoveryEnabled: syncRun.discoveryEnabled });
+	return { control: row?.control ?? 'none', discoveryEnabled: row?.discoveryEnabled ?? true };
 }
 
 async function finalizeRun(runId: string, status: string, stats: Stats): Promise<void> {

--- a/worker/crawl.ts
+++ b/worker/crawl.ts
@@ -588,7 +588,13 @@ export async function executeSync(run: SyncRun, opts: { publish?: boolean } = {}
 	await finalizeRun(runId, control === 'cancel' ? 'canceled' : 'completed', stats);
 }
 
-/** Seed the frontier: module roots (tier 1) + sitemap core pages (tier 0). */
+/** Seed the frontier: module roots (tier 1) + sitemap core pages (tier 0).
+ *  NOT gated by the discovery toggle — seeds/sitemap are the *known site
+ *  structure* (the backlog to drain), a separate concern from frontier discovery,
+ *  which is specifically the ingest of newly-found links from fetched page bodies
+ *  (see the `discoveryEnabled` gate in executeSync). Seeds run once at run start
+ *  and are bounded, so they don't cause the runaway frontier growth the toggle
+ *  exists to pause. */
 async function refreshSeeds(runId: string, stats: Stats): Promise<void> {
 	const roots = SEED_PATHS.map((p) => normalize(p, BASE_URL)).filter(
 		(u) => !u.endsWith('sitemap.xml') && inScope(u)


### PR DESCRIPTION
Closes #23

Adds a persisted, dashboard-steerable flag that pauses frontier discovery so the worker drains the known backlog. While off, the worker keeps fetching/refreshing already-known/queued resources but enqueues no newly-discovered URLs; turning it back on resumes discovery without a worker restart. Default is on (unchanged behavior).

## Acceptance criteria
- [x] A persisted discovery-enabled flag exists and defaults to on (unchanged current behavior) — new `sync_run.discovery_enabled` boolean, `DEFAULT true` (migration `0005`).
- [x] With discovery off, the worker fetches known/queued resources but enqueues no newly discovered URLs — gated at the frontier-ingest step in `executeSync`/`executeRun`.
- [x] The toggle is operable from the dashboard and reflects the live state — `Discovery: on/off` control alongside Resume/Cancel, fed by `getActiveRun` + the SSE stream.
- [x] Re-enabling resumes discovery without restarting the worker — the loop re-reads the flag on the existing heartbeat cadence (`writeHeartbeat` now returns `{ control, discoveryEnabled }`).

## Implementation
- **Schema (minimal):** one boolean column `discovery_enabled` on `sync_run` (mirrors how `control`/pause is per-run), rather than a new table.
- **Control plane:** `sync.setDiscovery(runId, enabled)`; state exposed via the existing `getActiveRun` (full row) and added to the SSE `serialize`.
- **Worker:** `worker/crawl.ts` honors the flag only at the discovered-links ingest step; `refreshSeeds` (sitemap/module-root seeding = the known backlog) is intentionally not gated, documented inline.
- **Dashboard:** `+page.svelte` toggle posts an explicit target state (`on`/`off`) so a double-submit is idempotent; `+page.server.ts` `discovery` action.

## Verify coverage
Drove the real `executeSync` against a real local SQLite with the network boundary mocked (canned orleans-host pages), asserting behavior end-to-end:
1. Default-on: a run inserted without the flag reads `discovery_enabled = true`.
2. Discovery ON: page links `discovered-1/2` get enqueued; run rollup `discovered > 0`.
3. Discovery OFF: known/seed page still fetched (`lastFetchedAt` set) but `discovered-1/2` are NOT enqueued and rollup `discovered = 0`.
4. Live re-read (no restart): a run that starts with an OFF snapshot but has the persisted flag flipped ON before processing resumes discovery via the heartbeat; the inverse (start ON, live OFF) stops it.

`bun run check` and `eslint` are clean (the only prettier/check noise is gitignored `project.inlang/*` generated i18n code).

## Migration
Added: `drizzle/0005_soft_spacker_dave.sql` — `ALTER TABLE sync_run ADD discovery_enabled integer DEFAULT true NOT NULL`. Per the coordination note, generated normally; any `_journal.json` ordering conflict with #35's parallel migration is for the coordinator to resolve at merge.

## Reviewer must-check
- The deliberate boundary: `refreshSeeds` (sitemap + module-root seeds) is intentionally NOT gated by the flag — seeds are the known site structure / backlog, distinct from link discovery. If you want new sitemap `<loc>`s suppressed too when a run *starts* with discovery off, that's a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)