### PR TITLE
feat: surface storage & cache-health aggregates on the dashboard (#24)

### DIFF
--- a/src/lib/server/sync.ts
+++ b/src/lib/server/sync.ts
@@ -111,6 +111,91 @@ export async function getRecentRuns(limit = 10) {
 	return db.select().from(syncRun).orderBy(desc(syncRun.requestedAt)).limit(limit);
 }
 
+/** One cache-age bucket: how many stored blobs fall into an age window (by
+ *  `blob.createdAt`, relative to now). Empty buckets are still returned so the
+ *  distribution renders a stable set of columns. */
+export interface CacheAgeBucket {
+	label: string;
+	count: number;
+}
+
+/** Storage + cache-health aggregates for the dashboard's storage panel. All
+ *  derived from today's schema — no per-blob backend/location column:
+ *  - stored size & object count come from the content-addressed `blob` table;
+ *  - cache age (oldest / newest / distribution) from `blob.createdAt`;
+ *  - `unpublishedBlobs` (r2_synced_at IS NULL) is the pending-publish backlog;
+ *  - health signals count resources stale past their refresh-due time plus the
+ *    error / gone lifecycle states.
+ *  Every field is coalesced/guarded so an empty DB reads as zeroes, never a
+ *  divide-by-zero or a null. */
+export interface StorageHealth {
+	storedBytes: number;
+	blobObjects: number;
+	unpublishedBlobs: number;
+	/** Epoch ms of the oldest / newest stored blob, or null when the store is empty. */
+	oldestBlobAt: number | null;
+	newestBlobAt: number | null;
+	/** Cache-age distribution over stored blobs (<1d / 1–7d / 7–30d / >30d). */
+	ageBuckets: CacheAgeBucket[];
+	/** Health signals. `stalePastDue`: active resources whose refresh is due
+	 *  (`nextFetchAt` <= now); `errorResources` / `goneResources`: lifecycle states. */
+	stalePastDue: number;
+	errorResources: number;
+	goneResources: number;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export async function getStorageHealth(): Promise<StorageHealth> {
+	const now = Date.now();
+	const d1 = now - DAY_MS;
+	const d7 = now - 7 * DAY_MS;
+	const d30 = now - 30 * DAY_MS;
+
+	// Blob store: totals, cache-age extremes, and the age distribution in one pass.
+	// createdAt is a timestamp_ms column, so it compares directly against epoch ms.
+	const [b] = await db
+		.select({
+			objects: count(),
+			storedBytes: sql<number>`coalesce(sum(${blob.sizeBytes}), 0)`,
+			oldest: sql<number | null>`min(${blob.createdAt})`,
+			newest: sql<number | null>`max(${blob.createdAt})`,
+			under1d: sql<number>`sum(case when ${blob.createdAt} >= ${d1} then 1 else 0 end)`,
+			d1to7: sql<number>`sum(case when ${blob.createdAt} < ${d1} and ${blob.createdAt} >= ${d7} then 1 else 0 end)`,
+			d7to30: sql<number>`sum(case when ${blob.createdAt} < ${d7} and ${blob.createdAt} >= ${d30} then 1 else 0 end)`,
+			over30d: sql<number>`sum(case when ${blob.createdAt} < ${d30} then 1 else 0 end)`
+		})
+		.from(blob);
+
+	const [unpublished] = await db.select({ n: count() }).from(blob).where(isNull(blob.r2SyncedAt));
+
+	// Health signals over resources: refresh-due backlog + error/gone lifecycle.
+	const [h] = await db
+		.select({
+			stalePastDue: sql<number>`sum(case when ${resource.state} = 'active' and ${resource.nextFetchAt} is not null and ${resource.nextFetchAt} <= ${now} then 1 else 0 end)`,
+			errorResources: sql<number>`sum(case when ${resource.state} = 'error' then 1 else 0 end)`,
+			goneResources: sql<number>`sum(case when ${resource.state} = 'gone' then 1 else 0 end)`
+		})
+		.from(resource);
+
+	return {
+		storedBytes: Number(b?.storedBytes ?? 0),
+		blobObjects: b?.objects ?? 0,
+		unpublishedBlobs: unpublished?.n ?? 0,
+		oldestBlobAt: b?.oldest != null ? Number(b.oldest) : null,
+		newestBlobAt: b?.newest != null ? Number(b.newest) : null,
+		ageBuckets: [
+			{ label: '< 1d', count: Number(b?.under1d ?? 0) },
+			{ label: '1–7d', count: Number(b?.d1to7 ?? 0) },
+			{ label: '7–30d', count: Number(b?.d7to30 ?? 0) },
+			{ label: '> 30d', count: Number(b?.over30d ?? 0) }
+		],
+		stalePastDue: Number(h?.stalePastDue ?? 0),
+		errorResources: Number(h?.errorResources ?? 0),
+		goneResources: Number(h?.goneResources ?? 0)
+	};
+}
+
 /** One coverage bucket for a resource `kind` (page / document / sitemap / other):
  *  how many of that kind have been fetched vs discovered. `kind` is assigned at
  *  discovery time (independent of fetch), so `total` is a stable denominator — unlike

--- a/src/lib/server/sync.ts
+++ b/src/lib/server/sync.ts
@@ -167,7 +167,9 @@ export async function getStorageHealth(): Promise<StorageHealth> {
 		})
 		.from(blob);
 
-	const [unpublished] = await db.select({ n: count() }).from(blob).where(isNull(blob.r2SyncedAt));
+	// Pending-publish backlog — reuse the dedicated read model added by #26 rather
+	// than re-inlining the `r2_synced_at IS NULL` count.
+	const unpublishedBlobs = await getUnpublishedBlobCount();
 
 	// Health signals over resources: refresh-due backlog + error/gone lifecycle.
 	const [h] = await db
@@ -181,7 +183,7 @@ export async function getStorageHealth(): Promise<StorageHealth> {
 	return {
 		storedBytes: Number(b?.storedBytes ?? 0),
 		blobObjects: b?.objects ?? 0,
-		unpublishedBlobs: unpublished?.n ?? 0,
+		unpublishedBlobs,
 		oldestBlobAt: b?.oldest != null ? Number(b.oldest) : null,
 		newestBlobAt: b?.newest != null ? Number(b.newest) : null,
 		ageBuckets: [

--- a/src/routes/dashboard/+page.server.ts
+++ b/src/routes/dashboard/+page.server.ts
@@ -11,6 +11,7 @@ export const load: PageServerLoad = async () => {
 		events,
 		eventCounts,
 		storage,
+		storageHealth,
 		feed,
 		progress,
 		processing
@@ -22,6 +23,7 @@ export const load: PageServerLoad = async () => {
 		sync.getEvents({ limit: 10 }),
 		sync.getEventCounts(),
 		sync.getStorageByType(),
+		sync.getStorageHealth(),
 		sync.getChangeFeed(10),
 		sync.getSyncProgress(),
 		sync.getProcessingRecords()
@@ -38,6 +40,7 @@ export const load: PageServerLoad = async () => {
 		events,
 		eventCounts,
 		storage,
+		storageHealth,
 		feed,
 		progress,
 		processing

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -192,6 +192,14 @@
 	</div>
 {/snippet}
 
+<!-- Thin proportional bar (storage & cache-health panel). `pct` is pre-clamped by
+     the caller against a floored max, so it's always 0–100. -->
+{#snippet miniBar(pct: number)}
+	<div class="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+		<div class="h-full rounded-full bg-primary/70" style="width:{pct}%"></div>
+	</div>
+{/snippet}
+
 {#snippet statusDetail(label: string, value: string)}
 	<span class="flex justify-between gap-4">
 		<span class="text-background/60">{label}</span>
@@ -533,7 +541,7 @@
 					)}
 					{@render fig(
 						'Cache span',
-						sh.newestBlobAt != null ? formatRelative(sh.oldestBlobAt) : '—',
+						sh.oldestBlobAt != null ? formatRelative(sh.oldestBlobAt) : '—',
 						sh.newestBlobAt != null ? `newest ${formatRelative(sh.newestBlobAt)}` : 'no blobs yet'
 					)}
 				</div>
@@ -550,12 +558,7 @@
 										>{formatNumber(bucket.count)}</span
 									>
 								</div>
-								<div class="h-1.5 w-full overflow-hidden rounded-full bg-muted">
-									<div
-										class="h-full rounded-full bg-primary/70"
-										style="width:{Math.round((bucket.count / maxAgeBucket) * 100)}%"
-									></div>
-								</div>
+								{@render miniBar(Math.round((bucket.count / maxAgeBucket) * 100))}
 							</div>
 						{/each}
 					{:else}
@@ -599,12 +602,7 @@
 									{formatBytes(Number(row.bytes))} · {formatNumber(row.n)}
 								</span>
 							</div>
-							<div class="h-1.5 w-full overflow-hidden rounded-full bg-muted">
-								<div
-									class="h-full rounded-full bg-primary/70"
-									style="width:{Math.round((Number(row.bytes) / maxStorage) * 100)}%"
-								></div>
-							</div>
+							{@render miniBar(Math.round((Number(row.bytes) / maxStorage) * 100))}
 						</div>
 					{:else}
 						<p class="text-sm text-muted-foreground">No data yet.</p>

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -116,6 +116,21 @@
 
 	const maxStorage = $derived(Math.max(1, ...data.storage.map((s) => Number(s.bytes))));
 
+	// Storage & cache health (all derived from today's schema — no per-blob location).
+	const sh = $derived(data.storageHealth);
+	// Tallest age bucket, floored at 1 so an empty store scales to 0%-width bars
+	// (never a divide-by-zero).
+	const maxAgeBucket = $derived(Math.max(1, ...sh.ageBuckets.map((b) => b.count)));
+	// A health signal reads "bad" (destructive/amber) only when its count is nonzero;
+	// a clean store shows muted zeroes.
+	function healthVariant(
+		n: number,
+		tone: 'warn' | 'bad'
+	): 'default' | 'secondary' | 'destructive' | 'outline' {
+		if (n <= 0) return 'outline';
+		return tone === 'bad' ? 'destructive' : 'secondary';
+	}
+
 	function statusVariant(s: string): 'default' | 'secondary' | 'destructive' | 'outline' {
 		if (s === 'running') return 'default';
 		if (s === 'failed') return 'destructive';
@@ -167,6 +182,14 @@
 	{#each progress.byType as t (t.kind)}
 		{@render coverageBar(t.label, t.fetched, t.total, pctOf(t.fetched, t.total))}
 	{/each}
+{/snippet}
+
+{#snippet fig(label: string, value: string, sub?: string, tone?: string)}
+	<div>
+		<p class="text-muted-foreground">{label}</p>
+		<p class={`mt-0.5 text-lg font-semibold tabular-nums ${tone ?? ''}`}>{value}</p>
+		{#if sub}<p class="text-muted-foreground">{sub}</p>{/if}
+	</div>
 {/snippet}
 
 {#snippet statusDetail(label: string, value: string)}
@@ -483,28 +506,110 @@
 	</div>
 
 	<div class="grid gap-6 lg:grid-cols-2">
-		<!-- Storage by type ---------------------------------------------- -->
+		<!-- Storage & cache health --------------------------------------- -->
+		<!-- Total size, by-content-type breakdown, cache age (from blob.createdAt),
+		     health signals, and the pending-publish backlog — all derived from
+		     today's schema (no per-blob backend/location column). -->
 		<Card.Root>
-			<Card.Header><Card.Title>Storage by content type</Card.Title></Card.Header>
-			<Card.Content class="space-y-2">
-				{#each data.storage as row (row.contentType)}
-					<div class="space-y-1">
-						<div class="flex justify-between text-xs">
-							<span class="truncate font-mono" title={row.contentType}>{row.contentType}</span>
-							<span class="text-muted-foreground">
-								{formatBytes(Number(row.bytes))} · {formatNumber(row.n)}
-							</span>
-						</div>
-						<div class="h-1.5 w-full overflow-hidden rounded-full bg-muted">
-							<div
-								class="h-full rounded-full bg-primary/70"
-								style="width:{Math.round((Number(row.bytes) / maxStorage) * 100)}%"
-							></div>
-						</div>
+			<Card.Header>
+				<div class="flex items-center justify-between">
+					<Card.Title>Storage &amp; cache health</Card.Title>
+					<span class="text-xs text-muted-foreground">derived from stored blobs</span>
+				</div>
+			</Card.Header>
+			<Card.Content class="space-y-4">
+				<!-- Headline figures -->
+				<div class="grid grid-cols-3 gap-2 text-xs">
+					{@render fig(
+						'Stored',
+						formatBytes(sh.storedBytes),
+						`${formatNumber(sh.blobObjects)} objects`
+					)}
+					{@render fig(
+						'Unpublished',
+						formatNumber(sh.unpublishedBlobs),
+						'awaiting R2',
+						sh.unpublishedBlobs > 0 ? 'text-amber-600 dark:text-amber-500' : undefined
+					)}
+					{@render fig(
+						'Cache span',
+						sh.newestBlobAt != null ? formatRelative(sh.oldestBlobAt) : '—',
+						sh.newestBlobAt != null ? `newest ${formatRelative(sh.newestBlobAt)}` : 'no blobs yet'
+					)}
+				</div>
+
+				<!-- Cache-age distribution (blob.createdAt) -->
+				<div class="space-y-2">
+					<p class="text-xs font-medium">Cache age</p>
+					{#if sh.blobObjects > 0}
+						{#each sh.ageBuckets as bucket (bucket.label)}
+							<div class="space-y-1">
+								<div class="flex justify-between text-xs">
+									<span class="text-muted-foreground">{bucket.label}</span>
+									<span class="tabular-nums text-muted-foreground"
+										>{formatNumber(bucket.count)}</span
+									>
+								</div>
+								<div class="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+									<div
+										class="h-full rounded-full bg-primary/70"
+										style="width:{Math.round((bucket.count / maxAgeBucket) * 100)}%"
+									></div>
+								</div>
+							</div>
+						{/each}
+					{:else}
+						<p class="text-sm text-muted-foreground">No blobs stored yet.</p>
+					{/if}
+				</div>
+
+				<!-- Health signals -->
+				<div class="space-y-1.5">
+					<p class="text-xs font-medium">Health signals</p>
+					<div class="flex flex-wrap gap-2">
+						<Badge
+							variant={healthVariant(sh.stalePastDue, 'warn')}
+							title="Active resources whose refresh is due (past next_fetch_at)"
+						>
+							Stale past due: {formatNumber(sh.stalePastDue)}
+						</Badge>
+						<Badge
+							variant={healthVariant(sh.errorResources, 'bad')}
+							title="Resources in the error state"
+						>
+							Errors: {formatNumber(sh.errorResources)}
+						</Badge>
+						<Badge
+							variant={healthVariant(sh.goneResources, 'bad')}
+							title="Resources gone (404/410)"
+						>
+							Gone: {formatNumber(sh.goneResources)}
+						</Badge>
 					</div>
-				{:else}
-					<p class="text-sm text-muted-foreground">No data yet.</p>
-				{/each}
+				</div>
+
+				<!-- By content type (reuses getStorageByType) -->
+				<div class="space-y-2">
+					<p class="text-xs font-medium">By content type</p>
+					{#each data.storage as row (row.contentType)}
+						<div class="space-y-1">
+							<div class="flex justify-between text-xs">
+								<span class="truncate font-mono" title={row.contentType}>{row.contentType}</span>
+								<span class="text-muted-foreground">
+									{formatBytes(Number(row.bytes))} · {formatNumber(row.n)}
+								</span>
+							</div>
+							<div class="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+								<div
+									class="h-full rounded-full bg-primary/70"
+									style="width:{Math.round((Number(row.bytes) / maxStorage) * 100)}%"
+								></div>
+							</div>
+						</div>
+					{:else}
+						<p class="text-sm text-muted-foreground">No data yet.</p>
+					{/each}
+				</div>
 			</Card.Content>
 		</Card.Root>
 

--- a/src/routes/dashboard/README.md
+++ b/src/routes/dashboard/README.md
@@ -7,14 +7,14 @@ page when there's no session). See the
 
 ## Routes
 
-| Route                  | File(s)                            | Shows                                                                                                            |
-| ---------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `/dashboard`           | `+page.svelte` / `+page.server.ts` | Overview: **live** run status + progress, run controls, stat tiles, storage-by-type, errors, recent-changes feed |
-| `/dashboard/stream`    | `stream/+server.ts`                | SSE endpoint — streams the active run's progress (auth-gated)                                                    |
-| `/dashboard/runs`      | `runs/+page.*`                     | Run history table (click a row → detail)                                                                         |
-| `/dashboard/runs/[id]` | `runs/[id]/+page.*`                | Per-run stats, timing, worker id, and full event log                                                             |
-| `/dashboard/content`   | `content/+page.*`                  | Searchable/filterable resource explorer (by URL/title, kind, state) with pagination                              |
-| `/dashboard/blob/[id]` | `blob/[id]/+server.ts`             | View a resource's archived copy — presigned R2 redirect (prod) or local file (dev)                               |
+| Route                  | File(s)                            | Shows                                                                                                                   |
+| ---------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `/dashboard`           | `+page.svelte` / `+page.server.ts` | Overview: **live** run status + progress, run controls, stat tiles, storage & cache health, errors, recent-changes feed |
+| `/dashboard/stream`    | `stream/+server.ts`                | SSE endpoint — streams the active run's progress (auth-gated)                                                           |
+| `/dashboard/runs`      | `runs/+page.*`                     | Run history table (click a row → detail)                                                                                |
+| `/dashboard/runs/[id]` | `runs/[id]/+page.*`                | Per-run stats, timing, worker id, and full event log                                                                    |
+| `/dashboard/content`   | `content/+page.*`                  | Searchable/filterable resource explorer (by URL/title, kind, state) with pagination                                     |
+| `/dashboard/blob/[id]` | `blob/[id]/+server.ts`             | View a resource's archived copy — presigned R2 redirect (prod) or local file (dev)                                      |
 
 ## Control plane
 


### PR DESCRIPTION
Closes #24

## What

Adds a **Storage & cache health** panel to the dashboard, built entirely from read models over today's schema (no migration, no per-blob backend/location column).

New read model `getStorageHealth()` in `src/lib/server/sync.ts` aggregates:
- total stored size + object count (`blob`),
- cache age from `blob.createdAt`: oldest/newest + a `<1d / 1–7d / 7–30d / >30d` distribution (single pass),
- health signals over `resource`: stale-past-due (`state='active' AND next_fetch_at <= now`), error, and gone counts,
- unpublished backlog via the existing `getUnpublishedBlobCount()` (#26 marker, `r2_synced_at IS NULL`).

The panel (in `+page.svelte`) reuses the existing `getStorageByType()` for the by-content-type breakdown, and matches the existing Card/stat-tile/progress-bar idiom. All aggregates are coalesced and bar widths guarded, so an empty DB reads as zeroes (no divide-by-zero).

## Acceptance criteria

- [x] 1. Panel shows total stored size and the by-content-type breakdown.
- [x] 2. Panel shows cache-age information derived from blob timestamps (oldest/newest + distribution).
- [x] 3. Panel shows at least one health signal (stale-past-due, error, and gone counts).
- [x] 4. Panel shows the unpublished-blobs count via `getUnpublishedBlobCount()` (#26).
- [x] 5. No dependency on a per-blob backend/location column.

## Verify coverage

Drove the real SSR dashboard (Playwright login + cookie fetch) against a seeded local libSQL DB:
- **Empty DB:** dashboard returns 200, panel renders with the "No blobs stored yet" empty state — no divide-by-zero.
- **Seeded DB:** panel renders `Stored 832 KB / 10 objects`, `Unpublished 4 awaiting R2`, cache span (oldest/newest), age distribution buckets (`<1d`, `1–7d`, `7–30d`, `>30d`), health signals (`Stale past due`, `Errors`, `Gone`), and the by-content-type breakdown (`text/html`, `application/pdf`).

`bun run check` (0 errors) and `bun run lint` pass (only gitignored `project.inlang/*` flagged). Svelte MCP autofixer: no issues.

## Scope

Read-model + dashboard only. No schema change. Did not touch the status chip (#20), processing panel (#21), progress bars (#22), or discovery toggle (#23). Local-vs-R2 backend location and worker health (#25) remain out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
