### PR TITLE
feat(rag): query-time retrieval — vector_top_k + grounded context (#36)

### DIFF
--- a/src/lib/server/rag/retrieve.test.ts
+++ b/src/lib/server/rag/retrieve.test.ts
@@ -1,0 +1,196 @@
+// Retrieval test (#36). Applies the REAL drizzle migrations (incl. the raw-SQL
+// ANN index) to a throwaway libSQL file DB, seeds resources + chunks embedded
+// with the deterministic fake embedder, then drives `retrieve()` with the SAME
+// fake embedder so query and chunk vectors are comparable. Proves: nearest chunks
+// come back with correct url/title/score (criteria 1–2), gone/error resources are
+// excluded (3), and the grounded-context object is assembled (4) — all offline,
+// no DATABASE_URL / network (5).
+import { afterAll, beforeAll, describe, it, expect } from 'vitest';
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createClient, type Client } from '@libsql/client';
+import { drizzle, type LibSQLDatabase } from 'drizzle-orm/libsql';
+import * as schema from '../db/schema';
+import { applyMigrations } from '../db/migrator';
+import { makeFakeEmbedder } from '../../../../worker/embeddings';
+import { retrieve } from './retrieve';
+
+const drizzleDir = fileURLToPath(new URL('../../../../drizzle/', import.meta.url));
+const embedder = makeFakeEmbedder();
+
+let tmp: string;
+let client: Client;
+let db: LibSQLDatabase<typeof schema>;
+
+// Four resources: three live (budget/harbor, wetlands, library) and one GONE
+// whose chunk text is IDENTICAL to a probe query — so if state-filtering were
+// broken it would rank first. Each resource gets one chunk for clarity.
+const DOCS = [
+	{
+		id: 'res-budget',
+		url: 'https://x/budget',
+		title: 'FY25 Town Budget',
+		state: 'active',
+		text: 'annual town budget review and harbor dredging permits for the fiscal year'
+	},
+	{
+		id: 'res-wetland',
+		url: 'https://x/wetland',
+		title: 'Conservation',
+		state: 'active',
+		text: 'wetland conservation order of conditions for a pond restoration project'
+	},
+	{
+		id: 'res-library',
+		url: 'https://x/library',
+		title: 'Library',
+		state: 'active',
+		text: 'public library summer reading program hours and childrens events'
+	},
+	{
+		id: 'res-dead',
+		url: 'https://x/dead',
+		title: 'Removed Page',
+		state: 'gone',
+		text: 'harbor dredging permits and the budget review' // == the probe query
+	}
+] as const;
+
+const QUERY = 'harbor dredging permits and the budget review';
+
+beforeAll(async () => {
+	tmp = mkdtempSync(join(tmpdir(), 'rag-retrieve-'));
+	client = createClient({ url: `file:${join(tmp, 'test.db')}` });
+	db = drizzle(client, { schema });
+	const entries = readdirSync(drizzleDir)
+		.filter((f) => f.endsWith('.sql'))
+		.map((name) => ({ name, sql: readFileSync(join(drizzleDir, name), 'utf8') }));
+	await applyMigrations(client, entries);
+
+	const vectors = await embedder.embed(DOCS.map((d) => d.text));
+	for (let i = 0; i < DOCS.length; i++) {
+		const d = DOCS[i];
+		await db.insert(schema.resource).values({
+			id: d.id,
+			url: d.url,
+			urlHash: `h-${d.id}`,
+			host: 'x',
+			path: new URL(d.url).pathname,
+			title: d.title,
+			state: d.state
+		});
+		await db.insert(schema.chunk).values({
+			resourceId: d.id,
+			sourceSha: `sha-${d.id}`,
+			chunkIndex: 0,
+			text: d.text,
+			charStart: 0,
+			charEnd: d.text.length,
+			embedding: vectors[i],
+			embedder: embedder.id,
+			url: d.url,
+			title: d.title,
+			kind: 'page'
+		});
+	}
+});
+
+afterAll(() => {
+	client?.close();
+	if (tmp) rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('retrieve', () => {
+	it('returns the nearest live chunk with correct attribution + score', async () => {
+		const { passages } = await retrieve(QUERY, { client, embedder });
+
+		expect(passages.length).toBeGreaterThan(0);
+		const top = passages[0];
+		// The budget/harbor doc is the closest LIVE match to the query.
+		expect(top.url).toBe('https://x/budget');
+		expect(top.title).toBe('FY25 Town Budget');
+		expect(top.text).toContain('harbor dredging');
+		// Similarity is a real number in [-1, 1], descending across results.
+		expect(top.score).toBeGreaterThan(0);
+		expect(top.score).toBeLessThanOrEqual(1);
+		for (let i = 1; i < passages.length; i++) {
+			expect(passages[i - 1].score).toBeGreaterThanOrEqual(passages[i].score);
+		}
+	});
+
+	it('excludes gone/error resources even when they are the nearest match', async () => {
+		// res-dead's chunk text == the query, so it would rank #1 if not filtered.
+		const { passages, sources } = await retrieve(QUERY, { client, embedder });
+		expect(passages.some((p) => p.url === 'https://x/dead')).toBe(false);
+		expect(passages.some((p) => p.resourceId === 'res-dead')).toBe(false);
+		expect(sources.some((s) => s.url === 'https://x/dead')).toBe(false);
+	});
+
+	it('assembles a grounded-context object: deduped sources + a cited block', async () => {
+		const { passages, sources, context } = await retrieve(QUERY, { client, embedder });
+
+		// Sources deduped by url, one per distinct live resource retrieved.
+		expect(sources.length).toBe(new Set(passages.map((p) => p.url)).size);
+		expect(sources[0].url).toBe('https://x/budget');
+
+		// Context is a numbered, source-cited block ready for the answerer.
+		expect(context).toContain('[1]');
+		expect(context).toContain('Sources:');
+		expect(context).toContain('https://x/budget');
+		expect(context).toContain('FY25 Town Budget');
+		expect(context).toContain('harbor dredging');
+	});
+
+	it('respects topK', async () => {
+		const { passages } = await retrieve(QUERY, { client, embedder, topK: 1 });
+		expect(passages).toHaveLength(1);
+		expect(passages[0].url).toBe('https://x/budget');
+	});
+
+	it('caps passages per resource', async () => {
+		// Add a second live resource with two near-duplicate chunks; with
+		// maxPerResource=1 only one of them should survive.
+		await db.insert(schema.resource).values({
+			id: 'res-multi',
+			url: 'https://x/multi',
+			urlHash: 'h-multi',
+			host: 'x',
+			path: '/multi',
+			title: 'Multi',
+			state: 'active'
+		});
+		const texts = ['budget review harbor permits one', 'budget review harbor permits two'];
+		const vecs = await embedder.embed(texts);
+		for (let i = 0; i < texts.length; i++) {
+			await db.insert(schema.chunk).values({
+				resourceId: 'res-multi',
+				sourceSha: 'sha-multi',
+				chunkIndex: i,
+				text: texts[i],
+				charStart: 0,
+				charEnd: texts[i].length,
+				embedding: vecs[i],
+				embedder: embedder.id,
+				url: 'https://x/multi',
+				title: 'Multi',
+				kind: 'page'
+			});
+		}
+		const { passages } = await retrieve('budget review harbor permits', {
+			client,
+			embedder,
+			maxPerResource: 1
+		});
+		const fromMulti = passages.filter((p) => p.resourceId === 'res-multi');
+		expect(fromMulti).toHaveLength(1);
+	});
+
+	it('returns empty for a blank question', async () => {
+		const result = await retrieve('   ', { client, embedder });
+		expect(result.passages).toEqual([]);
+		expect(result.sources).toEqual([]);
+		expect(result.context).toBe('');
+	});
+});

--- a/src/lib/server/rag/retrieve.ts
+++ b/src/lib/server/rag/retrieve.ts
@@ -1,0 +1,193 @@
+// Retrieval — stage 3 of the RAG pipeline (#36). The QUERY side of what stages
+// 1–2 built: given a natural-language question it embeds the question, runs an
+// approximate-nearest-neighbour search (`vector_top_k`) over the `chunk` table's
+// libSQL-native vector index (`chunk_vec_idx`, #35), and assembles the nearest
+// passages — with source attribution — into a grounded context the answer stage
+// (#37) can feed straight to an LLM.
+//
+// Two correctness invariants:
+//   • Same embedder as indexing. The question MUST be embedded with the exact
+//     model/config the chunks were embedded with (#35), or the query vector isn't
+//     comparable to the stored vectors and cosine search returns noise. We reuse
+//     the very same `Embedder` (worker/embeddings.ts → selectEmbedder), driven by
+//     the same EMBEDDING_PROVIDER + credentials — not a re-implementation — so the
+//     two sides can never silently drift apart. No query-time prefixing: chunks
+//     were embedded from raw text, so the question is too.
+//   • Only live content. `vector_top_k` searches the whole index including chunks
+//     of resources that have since gone 404/410 or errored; we join back to
+//     `resource.state` and drop anything not live, so a grounded answer never
+//     cites a dead page.
+//
+// The ANN index returns a fixed k by vector distance alone; because we filter
+// (state) and cap per-resource AFTER that, we over-fetch candidates and then trim
+// down to the requested top-k — see CANDIDATE_MULTIPLIER.
+import type { Client } from '@libsql/client';
+import { selectEmbedder, type Embedder } from '../../../../worker/embeddings';
+
+/** A retrieved chunk with its similarity score and source attribution. */
+export interface Passage {
+	text: string;
+	/** Cosine similarity in [-1, 1] (1 − cosine distance); higher = more relevant. */
+	score: number;
+	url: string;
+	title: string | null;
+	kind: string;
+	resourceId: string;
+	chunkIndex: number;
+}
+
+/** One distinct source document, deduped across passages (best score kept). */
+export interface Source {
+	url: string;
+	title: string | null;
+	kind: string;
+}
+
+/** Structured retrieval result + a prompt-ready grounded context for the answerer. */
+export interface RetrievalResult {
+	passages: Passage[];
+	/** Distinct source documents behind `passages`, ordered by best relevance. */
+	sources: Source[];
+	/** Passages assembled into a numbered, source-cited block ready to drop into
+	 *  the answer prompt. Citation `[n]` refers to `sources[n-1]`. Empty when
+	 *  nothing was retrieved. */
+	context: string;
+}
+
+export interface RetrieveOptions {
+	/** How many passages to return (after filtering + per-resource capping). Default 8. */
+	topK?: number;
+	/** Cap passages per source document so one long page can't dominate. Default 3. */
+	maxPerResource?: number;
+	/** Over-fetch factor: `vector_top_k` fetches topK × this many candidates, so
+	 *  state-filtering / per-resource capping still leaves enough. Default 5. */
+	candidateMultiplier?: number;
+	/** Inject an embedder (tests / explicit config). Defaults to `selectEmbedder()`
+	 *  — the SAME selection the indexer used, so query and chunk vectors match. */
+	embedder?: Embedder;
+	/** Inject a libSQL client (tests). Defaults to the app's DB client. */
+	client?: Client;
+}
+
+const DEFAULT_TOP_K = 8;
+const DEFAULT_MAX_PER_RESOURCE = 3;
+const CANDIDATE_MULTIPLIER = 5;
+
+interface CandidateRow {
+	text: string;
+	url: string;
+	title: string | null;
+	kind: string;
+	resource_id: string;
+	chunk_index: number;
+	distance: number;
+}
+
+/** The app's libSQL client, imported lazily so this module stays import-safe
+ *  without a configured DATABASE_URL (tests inject their own client and never
+ *  hit this path). */
+async function appClient(): Promise<Client> {
+	const { db } = await import('../db');
+	// `$client` is on drizzle()'s return intersection but not the bare
+	// LibSQLDatabase type the app exports it as — it's the underlying libSQL client.
+	return (db as unknown as { $client: Client }).$client;
+}
+
+/**
+ * Embed `question`, ANN-search the chunk index, filter to live resources, and
+ * assemble the nearest passages into a grounded context for the answer stage.
+ *
+ * Returns empty passages/sources and an empty context for a blank question or an
+ * empty corpus — callers can treat "nothing retrieved" uniformly.
+ */
+export async function retrieve(
+	question: string,
+	opts: RetrieveOptions = {}
+): Promise<RetrievalResult> {
+	const topK = Math.max(1, Math.floor(opts.topK ?? DEFAULT_TOP_K));
+	const maxPerResource = Math.max(1, Math.floor(opts.maxPerResource ?? DEFAULT_MAX_PER_RESOURCE));
+	const candidateK = Math.max(
+		topK,
+		Math.floor(topK * (opts.candidateMultiplier ?? CANDIDATE_MULTIPLIER))
+	);
+
+	if (!question.trim()) return { passages: [], sources: [], context: '' };
+
+	// Embed the query with the SAME embedder that produced the stored chunk
+	// vectors — otherwise the two aren't comparable and search is meaningless.
+	const embedder = selectEmbedder(opts.embedder);
+	const [queryVec] = await embedder.embed([question]);
+	if (!queryVec) return { passages: [], sources: [], context: '' };
+	const probe = JSON.stringify(queryVec);
+
+	// ANN search over the native vector index, joined back to `resource` so we can
+	// drop chunks whose source has gone/errored. `vector_top_k` yields chunk rowids
+	// nearest by vector distance; we re-derive the exact cosine distance for the
+	// score and ordering. The probe vector binds as a parameter; k is inlined as a
+	// validated integer (the function's arity arg isn't a bind slot).
+	const client = opts.client ?? (await appClient());
+	const result = await client.execute({
+		sql: `SELECT
+				ch.text AS text,
+				ch.url AS url,
+				ch.title AS title,
+				ch.kind AS kind,
+				ch.resource_id AS resource_id,
+				ch.chunk_index AS chunk_index,
+				vector_distance_cos(ch.embedding, vector32(?)) AS distance
+			FROM vector_top_k('chunk_vec_idx', vector32(?), ${candidateK}) AS vtk
+			JOIN chunk ch ON ch.rowid = vtk.id
+			JOIN resource r ON r.id = ch.resource_id
+			WHERE r.state NOT IN ('gone', 'error')
+			ORDER BY distance ASC`,
+		args: [probe, probe]
+	});
+	const rows = result.rows as unknown as CandidateRow[];
+
+	// Cap per resource, then take the top-k. Rows arrive best-first (distance ASC).
+	const perResource = new Map<string, number>();
+	const passages: Passage[] = [];
+	for (const row of rows) {
+		if (passages.length >= topK) break;
+		const seen = perResource.get(row.resource_id) ?? 0;
+		if (seen >= maxPerResource) continue;
+		perResource.set(row.resource_id, seen + 1);
+		passages.push({
+			text: row.text,
+			score: 1 - row.distance, // cosine distance → similarity
+			url: row.url,
+			title: row.title,
+			kind: row.kind,
+			resourceId: row.resource_id,
+			chunkIndex: row.chunk_index
+		});
+	}
+
+	const sources = dedupeSources(passages);
+	const context = assembleContext(passages, sources);
+	return { passages, sources, context };
+}
+
+/** Distinct source documents, in order of first (i.e. best-scoring) appearance. */
+function dedupeSources(passages: Passage[]): Source[] {
+	const seen = new Set<string>();
+	const sources: Source[] = [];
+	for (const p of passages) {
+		if (seen.has(p.url)) continue;
+		seen.add(p.url);
+		sources.push({ url: p.url, title: p.title, kind: p.kind });
+	}
+	return sources;
+}
+
+/** Number each passage with its source's citation `[n]`, then list the sources —
+ *  a compact, grounded block the answerer can quote and cite from. */
+function assembleContext(passages: Passage[], sources: Source[]): string {
+	if (passages.length === 0) return '';
+	const citation = new Map(sources.map((s, i) => [s.url, i + 1]));
+	const body = passages.map((p) => `[${citation.get(p.url)}] ${p.text}`).join('\n\n');
+	const cited = sources
+		.map((s, i) => `[${i + 1}] ${s.title?.trim() || s.url} — ${s.url}`)
+		.join('\n');
+	return `${body}\n\nSources:\n${cited}`;
+}


### PR DESCRIPTION
Closes #36

Stage 3 of the RAG epic (#32). Adds the query side of the pipeline: a standalone SvelteKit server module `src/lib/server/rag/retrieve.ts` that embeds a question, runs libSQL `vector_top_k` over the `chunk` table's ANN index (`chunk_vec_idx`, #35), excludes non-live resources, and assembles a grounded context for the answer stage (#37).

### Acceptance criteria
- [x] **Query embedded with the same model/config as indexing (#35).** Reuses the exact `Embedder` from `worker/embeddings.ts` via `selectEmbedder(opts.embedder)` — same `EMBEDDING_PROVIDER`/credentials, no re-implementation, no query-time prefixing — so query and chunk vectors are comparable.
- [x] **`vector_top_k` returns nearest chunks with source url/title + score.** ANN search joined back to `chunk`; each `Passage` carries `text`, `score` (cosine similarity = `1 − vector_distance_cos`), `url`, `title` (+ `kind`/`resourceId`/`chunkIndex` for the answerer's attribution).
- [x] **Non-live content excluded.** Joins to `resource` and filters `WHERE r.state NOT IN ('gone','error')`. Because filtering/capping happen after the fixed ANN fetch, candidates are over-fetched (`topK × candidateMultiplier`) then trimmed.
- [x] **Grounded-context object assembled.** Returns `{ passages, sources, context }`: `sources` deduped by url (best-score order); `context` is a numbered, source-cited block ready to drop into the answer prompt.
- [x] **Verified end-to-end.** `retrieve.test.ts` applies the real migrations to a throwaway libSQL file DB, seeds resources+chunks with the deterministic fake embedder, and drives `retrieve()` with the SAME fake embedder (so similarity is meaningful).

### Embedder-sharing approach
Imports `selectEmbedder`/`Embedder` directly from `worker/embeddings.ts` (pure `process.env`, no worker-only deps). The "app and worker never talk directly" rule governs runtime coordination (Turso rows), not code imports — worker tests already import from `src/lib/server`. The libSQL client is injectable (`opts.client`) and the app DB client is imported lazily, so the module stays import-safe without a configured `DATABASE_URL` and tests never touch app env.

### Verify coverage
6 tests, all green: nearest-live-chunk attribution + descending scores; gone/error exclusion even when a dead chunk is the nearest match; grounded-context assembly (deduped sources + cited block); `topK`; per-resource cap; blank-question → empty. `bun run check` clean; `bun run lint` clean on changed files (only pre-existing gitignored `project.inlang/*` warnings).

### Reviewer must-checks
- Constraint honored: **no** changes to `src/lib/server/sync.ts` or `src/routes/dashboard/**` (steering clear of #24). No schema change (migration: **none**).
- `topK` is best-effort (documented): a candidate window dominated by dead/one-resource chunks can return < `topK` — over-fetch mitigates.

Migration: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)