### PR TITLE
[chat] Grounded answer generation + citation/abstention policy (#37)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "orleans",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.112.1",
         "@mozilla/readability": "^0.6.0",
         "aws4fetch": "^1.0.20",
         "linkedom": "^0.18.13",
@@ -75,6 +76,8 @@
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],
+
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.112.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-vPRhHWxG9gIDyI9anVET2tBkmMBOXyTpIFvQgUVveiAV0ihmQgBYzQHb/s9+pZ/FxprSWcQnj15YnRfPxOIEmg=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
@@ -554,6 +557,8 @@
 
     "@sqlite.org/sqlite-wasm": ["@sqlite.org/sqlite-wasm@3.48.0-build4", "", { "bin": { "sqlite-wasm": "bin/index.js" } }, "sha512-hI6twvUkzOmyGZhQMza1gpfqErZxXRw6JEsiVjUbo7tFanVD+8Oil0Ih3l2nGzHdxPI41zFmfUQG7GHqhciKZQ=="],
 
+    "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
+
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@storybook/addon-a11y": ["@storybook/addon-a11y@10.5.0", "", { "dependencies": { "@storybook/global": "^5.0.0", "axe-core": "^4.2.0" }, "peerDependencies": { "storybook": "^10.5.0" } }, "sha512-AguqTsYS2NX20AF1vWt6IonbkpMXur30/dAOOYltbEW7uKmPxBNtjuiBmYB2WI4aFN4r8jje4bbDGk/Yfq58hQ=="],
@@ -1006,6 +1011,8 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
+    "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
@@ -1105,6 +1112,8 @@
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
@@ -1424,6 +1433,8 @@
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
+    "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
+
     "std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
 
     "storybook": ["storybook@10.5.0", "", { "dependencies": { "@storybook/global": "^5.0.0", "@storybook/icons": "^2.0.2", "@testing-library/dom": "^10.4.1", "@testing-library/jest-dom": "^6.9.1", "@testing-library/user-event": "^14.6.1", "@vitest/expect": "3.2.4", "@vitest/spy": "3.2.4", "@webcontainer/env": "^1.1.1", "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0 || ^0.28.0", "jsonc-parser": "^3.3.1", "open": "^10.2.0", "oxc-parser": "^0.127.0", "oxc-resolver": "^11.19.1", "recast": "^0.23.5", "semver": "^7.7.3", "use-sync-external-store": "^1.5.0", "ws": "^8.18.0" }, "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "prettier": "^2 || ^3", "vite-plus": "^0.1.15 || ^0.2.0" }, "optionalPeers": ["@types/react", "prettier", "vite-plus"], "bin": "./dist/bin/dispatcher.js" }, "sha512-dRhM/kSSvHQR8DmZO41v5sJuz9U6zDjjR2gRBTgZN2RBSXbmF0Brvgszrvvxyx2VfxuYKzhB+xumKwWkwlBtig=="],
@@ -1491,6 +1502,8 @@
     "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
 
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
     "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
 		"*.{js,ts,svelte}": "eslint --fix"
 	},
 	"dependencies": {
+		"@anthropic-ai/sdk": "^0.112.1",
 		"@mozilla/readability": "^0.6.0",
 		"aws4fetch": "^1.0.20",
 		"linkedom": "^0.18.13",

--- a/src/lib/server/rag/answer.test.ts
+++ b/src/lib/server/rag/answer.test.ts
@@ -1,0 +1,192 @@
+// Answer-generation test (#37). Drives answer() with a DETERMINISTIC fake LLM and
+// a fake retrieval fn — no network, no API key, no DB — so all three policy modes
+// and the citation invariants are exercised offline (criterion 5). A live smoke
+// test against the real Anthropic client runs only when ANTHROPIC_API_KEY is set.
+import { describe, it, expect, vi } from 'vitest';
+import { answer } from './answer';
+import { makeFakeLlm, type LlmClient, type LlmCompletionRequest } from './llm';
+import type { RetrievalResult, Source } from './retrieve';
+
+/** A retrieval fn that returns a fixed result and records the question it saw. */
+function fakeRetrieval(result: Partial<RetrievalResult>) {
+	const sources = (result.sources ?? []) as Source[];
+	const full: RetrievalResult = {
+		passages: result.passages ?? [],
+		sources,
+		context:
+			result.context ??
+			(sources.length
+				? `${sources.map((s, i) => `[${i + 1}] passage`).join('\n\n')}\n\nSources:\n${sources
+						.map((s, i) => `[${i + 1}] ${s.title ?? s.url} — ${s.url}`)
+						.join('\n')}`
+				: '')
+	};
+	return async () => full;
+}
+
+const BUDGET: Source = { url: 'https://x/budget', title: 'FY25 Town Budget', kind: 'page' };
+const HARBOR: Source = { url: 'https://x/harbor', title: 'Harbor', kind: 'page' };
+
+/** An LLM whose raw output is fixed, but that captures the request for assertions. */
+function scriptedLlm(raw: string): {
+	llm: LlmClient;
+	last: () => LlmCompletionRequest | undefined;
+} {
+	let seen: LlmCompletionRequest | undefined;
+	const llm = makeFakeLlm((req) => {
+		seen = req;
+		return raw;
+	});
+	return { llm, last: () => seen };
+}
+
+describe('answer', () => {
+	it('criterion 1: grounded question cites the correct retrieved source URL', async () => {
+		const { llm, last } = scriptedLlm(
+			JSON.stringify({
+				mode: 'grounded',
+				answer: 'The FY25 budget covers harbor dredging permits.',
+				citations: ['https://x/budget']
+			})
+		);
+		const result = await answer('What does the budget say about the harbor?', {
+			llm,
+			retrieve: fakeRetrieval({ sources: [BUDGET] })
+		});
+
+		expect(result.mode).toBe('grounded');
+		expect(result.citations).toEqual(['https://x/budget']);
+		expect(result.answer).toContain('harbor');
+
+		// Grounding wiring: the model got the policy in `system` and the grounded
+		// context + URL allow-list in the user message.
+		const req = last();
+		expect(req?.system).toMatch(/grounded/);
+		expect(req?.messages[0].content).toContain('https://x/budget');
+		expect(req?.messages[0].content).toContain('What does the budget say');
+	});
+
+	it('criterion 4: fabricated citations are dropped; only retrieved URLs survive', async () => {
+		const { llm } = scriptedLlm(
+			JSON.stringify({
+				mode: 'grounded',
+				answer: 'Grounded answer.',
+				// One real (retrieved) URL, one invented one, plus a duplicate.
+				citations: ['https://x/budget', 'https://evil/made-up', 'https://x/budget']
+			})
+		);
+		const result = await answer('q', {
+			llm,
+			retrieve: fakeRetrieval({ sources: [BUDGET, HARBOR] })
+		});
+
+		expect(result.mode).toBe('grounded');
+		expect(result.citations).toEqual(['https://x/budget']); // deduped, fabricated removed
+		// Whatever comes back is always a subset of what was retrieved.
+		const retrieved = new Set(['https://x/budget', 'https://x/harbor']);
+		expect(result.citations.every((u) => retrieved.has(u))).toBe(true);
+	});
+
+	it('criterion 2: an uncovered context question yields a labeled fallback, no citations', async () => {
+		const { llm } = scriptedLlm(
+			JSON.stringify({
+				mode: 'fallback',
+				answer:
+					"This is not from the town's records: a select board is the executive body of a New England town.",
+				citations: []
+			})
+		);
+		const result = await answer('What is a select board in general?', {
+			llm,
+			retrieve: fakeRetrieval({ sources: [] })
+		});
+
+		expect(result.mode).toBe('fallback');
+		expect(result.answer).toMatch(/not from the town's records/i);
+		expect(result.citations).toEqual([]);
+	});
+
+	it('fallback never carries citations even if the model returns some', async () => {
+		const { llm } = scriptedLlm(
+			JSON.stringify({
+				mode: 'fallback',
+				answer: "This is not from the town's records: general background.",
+				citations: ['https://x/budget'] // model slipped a citation in
+			})
+		);
+		const result = await answer('q', { llm, retrieve: fakeRetrieval({ sources: [BUDGET] }) });
+		expect(result.mode).toBe('fallback');
+		expect(result.citations).toEqual([]);
+	});
+
+	it('criterion 3: a hard specific not in the corpus abstains and points to where to look', async () => {
+		const { llm } = scriptedLlm(
+			JSON.stringify({
+				mode: 'abstained',
+				answer:
+					"That deadline isn't in the town's records. Check with the Town Clerk or the town website.",
+				citations: []
+			})
+		);
+		const result = await answer('What is the deadline to file for a shellfish permit?', {
+			llm,
+			retrieve: fakeRetrieval({ sources: [] })
+		});
+
+		expect(result.mode).toBe('abstained');
+		expect(result.citations).toEqual([]);
+		// Abstention must not fabricate a specific and should route the asker onward.
+		expect(result.answer).toMatch(/isn't in the town's records/i);
+		expect(result.answer).toMatch(/clerk|website|department|board/i);
+	});
+
+	it('degrades a malformed model response to a safe abstention', async () => {
+		const { llm } = scriptedLlm('the model rambled without any JSON at all');
+		const result = await answer('q', { llm, retrieve: fakeRetrieval({ sources: [BUDGET] }) });
+		expect(result.mode).toBe('abstained');
+		expect(result.citations).toEqual([]);
+	});
+
+	it('recovers JSON wrapped in prose / code fences', async () => {
+		const { llm } = scriptedLlm(
+			'Sure!\n```json\n{"mode":"grounded","answer":"ok","citations":["https://x/budget"]}\n```\n'
+		);
+		const result = await answer('q', { llm, retrieve: fakeRetrieval({ sources: [BUDGET] }) });
+		expect(result.mode).toBe('grounded');
+		expect(result.citations).toEqual(['https://x/budget']);
+	});
+
+	it('an unknown mode degrades to abstained', async () => {
+		const { llm } = scriptedLlm(
+			JSON.stringify({ mode: 'confident-guess', answer: 'The fee is $50.', citations: [] })
+		);
+		const result = await answer('q', { llm, retrieve: fakeRetrieval({ sources: [] }) });
+		expect(result.mode).toBe('abstained');
+	});
+
+	it('short-circuits a blank question to abstained without calling the LLM', async () => {
+		const complete = vi.fn(async () => '{}');
+		const llm: LlmClient = { id: 'spy', complete };
+		const result = await answer('   ', { llm, retrieve: fakeRetrieval({ sources: [BUDGET] }) });
+		expect(result.mode).toBe('abstained');
+		expect(complete).not.toHaveBeenCalled();
+	});
+});
+
+// Live smoke test — only runs with a real key. Injects a fake retrieval with a
+// known source so it exercises the real Anthropic call + our parsing/enforcement
+// without needing a seeded DB. Asserts the contract holds, not exact wording.
+describe.runIf(!!process.env.ANTHROPIC_API_KEY)('answer (live smoke)', () => {
+	it('produces a valid mode and citations that are a subset of retrieved', async () => {
+		const result = await answer('What does the FY25 budget cover about the harbor?', {
+			retrieve: fakeRetrieval({
+				sources: [BUDGET],
+				context:
+					'[1] The FY25 town budget funds harbor dredging permits for the fiscal year.\n\nSources:\n[1] FY25 Town Budget — https://x/budget'
+			})
+		});
+		expect(['grounded', 'fallback', 'abstained']).toContain(result.mode);
+		const retrieved = new Set(['https://x/budget']);
+		expect(result.citations.every((u) => retrieved.has(u))).toBe(true);
+	}, 30_000);
+});

--- a/src/lib/server/rag/answer.test.ts
+++ b/src/lib/server/rag/answer.test.ts
@@ -119,6 +119,41 @@ describe('answer', () => {
 		expect(result.citations).toEqual([]);
 	});
 
+	it("forces the 'not from the town's records' label onto an unlabeled fallback", async () => {
+		const { llm } = scriptedLlm(
+			JSON.stringify({
+				mode: 'fallback',
+				answer: 'A select board is the executive body of a New England town.', // no label
+				citations: []
+			})
+		);
+		const result = await answer('what is a select board?', {
+			llm,
+			retrieve: fakeRetrieval({ sources: [] })
+		});
+		expect(result.mode).toBe('fallback');
+		expect(result.answer).toMatch(/^This is not from the town's records:/);
+		expect(result.answer).toContain('executive body');
+	});
+
+	it('downgrades a grounded answer whose citations were all fabricated to abstained', async () => {
+		const { llm } = scriptedLlm(
+			JSON.stringify({
+				mode: 'grounded',
+				answer: 'The fee is $50.', // asserts a specific, but every citation is fake
+				citations: ['https://evil/made-up', 'https://also/fake']
+			})
+		);
+		const result = await answer('what is the fee?', {
+			llm,
+			retrieve: fakeRetrieval({ sources: [BUDGET] })
+		});
+		// No real source survived → cannot stand behind "grounded"; abstain instead.
+		expect(result.mode).toBe('abstained');
+		expect(result.citations).toEqual([]);
+		expect(result.answer).not.toContain('$50');
+	});
+
 	it('criterion 3: a hard specific not in the corpus abstains and points to where to look', async () => {
 		const { llm } = scriptedLlm(
 			JSON.stringify({

--- a/src/lib/server/rag/answer.ts
+++ b/src/lib/server/rag/answer.ts
@@ -12,11 +12,17 @@
 //                 fee, legal rule, or who holds an office): do NOT guess — say it
 //                 isn't in the town's records and point to where to look.
 //
-// Two invariants the code enforces regardless of what the model returns, so a
-// hallucinating model can't break the contract:
+// Four invariants the code enforces regardless of what the model returns, so a
+// hallucinating model can't break the contract (the prompt asks for these; the
+// code guarantees them):
 //   • Citations are ALWAYS a subset of what was retrieved — we intersect the
 //     model's cited URLs with `sources`, dropping anything fabricated (criterion
 //     4). Only `grounded` answers carry citations; fallback/abstained carry none.
+//   • A `grounded` answer must keep at least one real (retrieved) citation — if
+//     every cited URL was fabricated and gets dropped, we can't stand behind the
+//     "grounded" claim, so it degrades to `abstained`.
+//   • A `fallback` answer is ALWAYS prefixed with the "not from the town's
+//     records" label, whether or not the model remembered to add it.
 //   • Mode is validated to the three-value enum; anything else degrades to
 //     `abstained` (the safe default — never assert an unsupported specific).
 import {
@@ -63,19 +69,16 @@ export interface AnswerOptions {
  * A blank question short-circuits to an abstention (nothing to ground on).
  */
 export async function answer(question: string, opts: AnswerOptions = {}): Promise<Answer> {
-	if (!question.trim()) {
-		return {
-			answer: "That question isn't answerable from the town's records.",
-			citations: [],
-			mode: 'abstained'
-		};
-	}
+	if (!question.trim()) return abstention();
+
+	// Select the LLM up front so a missing ANTHROPIC_API_KEY fails fast, before we
+	// spend an embed + vector query on retrieval we'd then throw away.
+	const llm = selectLlm(opts.llm);
 
 	const retrieveFn = opts.retrieve ?? defaultRetrieve;
 	const retrieval = await retrieveFn(question, opts.retrieveOptions);
 	const retrievedUrls = retrieval.sources.map((s) => s.url);
 
-	const llm = selectLlm(opts.llm);
 	const req: LlmCompletionRequest = {
 		system: SYSTEM_PROMPT,
 		messages: [{ role: 'user', content: buildUserMessage(question, retrieval) }],
@@ -121,39 +124,65 @@ Available source URLs (cite only these, verbatim):
 ${urls}`;
 }
 
+/** The label a fallback answer must carry — general knowledge, not town records. */
+const FALLBACK_LABEL = "This is not from the town's records:";
+
+/** The canned abstention: says it isn't in the records AND points onward — used
+ *  for blank/malformed/ungroundable cases so the "where to look" pointer (the
+ *  policy's requirement) holds even when we don't have the model's own wording. */
+function abstention(): Answer {
+	return {
+		answer:
+			"That isn't in the town's records. Try the relevant town department or board, or the town website / clerk.",
+		citations: [],
+		mode: 'abstained'
+	};
+}
+
 /**
  * Enforce the contract on the model's raw output: parse the JSON, validate the
- * mode, and intersect citations with what was actually retrieved. A malformed or
- * empty response degrades to a safe abstention rather than surfacing garbage.
+ * mode, intersect citations with what was actually retrieved, require a real
+ * citation to stay `grounded`, and force the fallback label. A malformed or empty
+ * response degrades to a safe abstention rather than surfacing garbage.
  */
 function normalize(raw: string, retrievedUrls: string[]): Answer {
 	const parsed = parseJsonObject(raw);
-	if (!parsed) {
-		return {
-			answer: "That question isn't answerable from the town's records.",
-			citations: [],
-			mode: 'abstained'
-		};
-	}
+	if (!parsed) return abstention();
 
 	const mode: AnswerMode =
 		parsed.mode === 'grounded' || parsed.mode === 'fallback' ? parsed.mode : 'abstained';
 
-	const answerText =
-		typeof parsed.answer === 'string' && parsed.answer.trim()
-			? parsed.answer.trim()
-			: "That question isn't answerable from the town's records.";
+	// Empty/malformed answer text → canned abstention (which points onward).
+	const answerText = typeof parsed.answer === 'string' ? parsed.answer.trim() : '';
+	if (!answerText) return abstention();
 
-	// Citations only for grounded answers, and only URLs that were truly
-	// retrieved — this is the hard guarantee against fabricated citations.
+	// Abstained: keep the model's own answer (it usually names where to look);
+	// never carries citations.
+	if (mode === 'abstained') return { answer: answerText, citations: [], mode: 'abstained' };
+
+	if (mode === 'fallback') {
+		// Guarantee the label regardless of whether the model added it.
+		const labeled = /not from the town's records/i.test(answerText)
+			? answerText
+			: `${FALLBACK_LABEL} ${answerText}`;
+		return { answer: labeled, citations: [], mode: 'fallback' };
+	}
+
+	// grounded: keep only URLs that were truly retrieved — the hard guarantee
+	// against fabricated citations.
 	const allowed = new Set(retrievedUrls);
-	const cited = Array.isArray(parsed.citations) ? parsed.citations : [];
-	const citations =
-		mode === 'grounded'
-			? [...new Set(cited.filter((u): u is string => typeof u === 'string' && allowed.has(u)))]
-			: [];
+	const citations = [
+		...new Set(
+			(Array.isArray(parsed.citations) ? parsed.citations : []).filter(
+				(u): u is string => typeof u === 'string' && allowed.has(u)
+			)
+		)
+	];
+	// A "grounded" claim with no surviving real citation is untrustworthy — every
+	// cited URL was fabricated — so we can't stand behind it. Abstain instead.
+	if (citations.length === 0) return abstention();
 
-	return { answer: answerText, citations, mode };
+	return { answer: answerText, citations, mode: 'grounded' };
 }
 
 interface RawAnswer {

--- a/src/lib/server/rag/answer.ts
+++ b/src/lib/server/rag/answer.ts
@@ -1,0 +1,182 @@
+// Answer generation — stage 4 of the RAG pipeline (#37). The GENERATION side:
+// given a question it uses #36's `retrieve()` to build grounded context, then
+// asks Claude for an answer that follows the grounding policy grilled out in #32.
+//
+// THE POLICY (three modes, faithfully implemented):
+//   • grounded  — the corpus covers it: answer from the retrieved passages and
+//                 cite the source URL(s) actually used.
+//   • fallback  — a CONTEXT/explanatory question the corpus doesn't cover: a
+//                 general-knowledge answer is allowed, but it MUST be labeled
+//                 "not from the town's records" and carries NO citations.
+//   • abstained — a HARD SPECIFIC not supported by context (a date, deadline,
+//                 fee, legal rule, or who holds an office): do NOT guess — say it
+//                 isn't in the town's records and point to where to look.
+//
+// Two invariants the code enforces regardless of what the model returns, so a
+// hallucinating model can't break the contract:
+//   • Citations are ALWAYS a subset of what was retrieved — we intersect the
+//     model's cited URLs with `sources`, dropping anything fabricated (criterion
+//     4). Only `grounded` answers carry citations; fallback/abstained carry none.
+//   • Mode is validated to the three-value enum; anything else degrades to
+//     `abstained` (the safe default — never assert an unsupported specific).
+import {
+	retrieve as defaultRetrieve,
+	type RetrievalResult,
+	type RetrieveOptions
+} from './retrieve';
+import {
+	selectLlm,
+	defaultAnswerModel,
+	DEFAULT_MAX_TOKENS,
+	type LlmClient,
+	type LlmCompletionRequest
+} from './llm';
+
+export type AnswerMode = 'grounded' | 'fallback' | 'abstained';
+
+/** A grounded, policy-compliant answer. */
+export interface Answer {
+	answer: string;
+	/** Source URLs actually used — always a subset of what retrieval returned.
+	 *  Non-empty only for `grounded` answers. */
+	citations: string[];
+	mode: AnswerMode;
+}
+
+export interface AnswerOptions {
+	/** Inject an LLM client (tests / explicit config). Defaults to `selectLlm()`. */
+	llm?: LlmClient;
+	/** Model id. Defaults to `defaultAnswerModel()` (RAG_ANSWER_MODEL / Haiku). */
+	model?: string;
+	/** Output cap passed to the model. Defaults to `DEFAULT_MAX_TOKENS`. */
+	maxTokens?: number;
+	/** Inject a retrieval fn (tests / seeded corpus). Defaults to #36's `retrieve()`. */
+	retrieve?: (question: string, opts?: RetrieveOptions) => Promise<RetrievalResult>;
+	/** Options forwarded to the retrieval fn (topK, injected client/embedder, …). */
+	retrieveOptions?: RetrieveOptions;
+}
+
+/**
+ * Answer `question`: retrieve grounded context, ask the model under the grounding
+ * policy, then enforce the citation/mode invariants on the result.
+ *
+ * A blank question short-circuits to an abstention (nothing to ground on).
+ */
+export async function answer(question: string, opts: AnswerOptions = {}): Promise<Answer> {
+	if (!question.trim()) {
+		return {
+			answer: "That question isn't answerable from the town's records.",
+			citations: [],
+			mode: 'abstained'
+		};
+	}
+
+	const retrieveFn = opts.retrieve ?? defaultRetrieve;
+	const retrieval = await retrieveFn(question, opts.retrieveOptions);
+	const retrievedUrls = retrieval.sources.map((s) => s.url);
+
+	const llm = selectLlm(opts.llm);
+	const req: LlmCompletionRequest = {
+		system: SYSTEM_PROMPT,
+		messages: [{ role: 'user', content: buildUserMessage(question, retrieval) }],
+		model: opts.model ?? defaultAnswerModel(),
+		maxTokens: opts.maxTokens ?? DEFAULT_MAX_TOKENS
+	};
+
+	const raw = await llm.complete(req);
+	return normalize(raw, retrievedUrls);
+}
+
+// The policy, encoded once. The model must return STRICT JSON matching the
+// contract below — we parse structure out of the text rather than relying on a
+// provider-specific structured-output feature, so the seam stays string-shaped
+// and every model (and the fake) speaks the same protocol.
+const SYSTEM_PROMPT = `You answer questions about the Town of Orleans using ONLY the town's own archived records, which are supplied to you as retrieved context. You are precise and you never invent civic facts.
+
+Decide one of three modes for each question:
+
+1. "grounded" — The retrieved context supports an answer. Answer from the context and cite the source URL(s) you actually used. Cite ONLY URLs listed under "Available source URLs"; never cite anything else.
+
+2. "fallback" — The question is explanatory or contextual (background, general "how does X work" / "why", definitions) and the retrieved context does NOT cover it. You may answer from general knowledge, but you MUST clearly label it as not coming from the town's records — begin the answer with "This is not from the town's records:". Do not cite any sources.
+
+3. "abstained" — The question asks for a HARD, SPECIFIC civic fact — a date, deadline, fee or dollar amount, legal rule or requirement, or who currently holds an office — and the retrieved context does NOT support it. Do NOT guess or state any specific figure, date, or name. Say it isn't in the town's records and point the person to where to look (e.g. the relevant town department, board, or the town website/clerk). Do not cite any sources.
+
+When in doubt between fallback and abstained for a specific civic fact you can't ground, choose "abstained" — never fabricate a specific.
+
+Respond with a single JSON object and nothing else:
+{"mode": "grounded" | "fallback" | "abstained", "answer": "<your answer as a string>", "citations": ["<source url>", ...]}
+"citations" must be an array of source URLs drawn only from the provided list (empty for fallback and abstained).`;
+
+/** Assemble the question + grounded context + the explicit allow-list of URLs. */
+function buildUserMessage(question: string, retrieval: RetrievalResult): string {
+	const context = retrieval.context.trim() || "(nothing was retrieved from the town's records)";
+	const urls =
+		retrieval.sources.length > 0 ? retrieval.sources.map((s) => `- ${s.url}`).join('\n') : '(none)';
+	return `Question: ${question}
+
+Retrieved context from the town's records:
+${context}
+
+Available source URLs (cite only these, verbatim):
+${urls}`;
+}
+
+/**
+ * Enforce the contract on the model's raw output: parse the JSON, validate the
+ * mode, and intersect citations with what was actually retrieved. A malformed or
+ * empty response degrades to a safe abstention rather than surfacing garbage.
+ */
+function normalize(raw: string, retrievedUrls: string[]): Answer {
+	const parsed = parseJsonObject(raw);
+	if (!parsed) {
+		return {
+			answer: "That question isn't answerable from the town's records.",
+			citations: [],
+			mode: 'abstained'
+		};
+	}
+
+	const mode: AnswerMode =
+		parsed.mode === 'grounded' || parsed.mode === 'fallback' ? parsed.mode : 'abstained';
+
+	const answerText =
+		typeof parsed.answer === 'string' && parsed.answer.trim()
+			? parsed.answer.trim()
+			: "That question isn't answerable from the town's records.";
+
+	// Citations only for grounded answers, and only URLs that were truly
+	// retrieved — this is the hard guarantee against fabricated citations.
+	const allowed = new Set(retrievedUrls);
+	const cited = Array.isArray(parsed.citations) ? parsed.citations : [];
+	const citations =
+		mode === 'grounded'
+			? [...new Set(cited.filter((u): u is string => typeof u === 'string' && allowed.has(u)))]
+			: [];
+
+	return { answer: answerText, citations, mode };
+}
+
+interface RawAnswer {
+	mode?: unknown;
+	answer?: unknown;
+	citations?: unknown;
+}
+
+/** Tolerant JSON extraction: parse the whole string, else the first {...} span.
+ *  Models occasionally wrap JSON in prose or code fences; this recovers it. */
+function parseJsonObject(raw: string): RawAnswer | null {
+	const attempt = (s: string): RawAnswer | null => {
+		try {
+			const v = JSON.parse(s);
+			return v && typeof v === 'object' ? (v as RawAnswer) : null;
+		} catch {
+			return null;
+		}
+	};
+	const whole = attempt(raw.trim());
+	if (whole) return whole;
+	const start = raw.indexOf('{');
+	const end = raw.lastIndexOf('}');
+	if (start >= 0 && end > start) return attempt(raw.slice(start, end + 1));
+	return null;
+}

--- a/src/lib/server/rag/llm.ts
+++ b/src/lib/server/rag/llm.ts
@@ -1,0 +1,113 @@
+// LLM client — the generation seam for the RAG answer stage (#37). A tiny
+// interface behind which the actual model lives, exactly mirroring the embedding
+// seam (worker/embeddings.ts → selectEmbedder): the answerer (answer.ts) never
+// names a provider — it asks `selectLlm()` for an `LlmClient` and calls
+// `.complete(req)`. Swapping models/providers is config (ANTHROPIC_API_KEY /
+// RAG_ANSWER_MODEL), not a code change, and tests inject a deterministic fake.
+//
+// Deliberately string-in / string-out. Grounding, citation policy, and the
+// JSON answer contract all live in answer.ts; keeping the transport dumb makes
+// the fake trivial to script and keeps this module provider-shaped, not
+// policy-shaped. Non-streaming for now — #38's chat UI can add a `stream()`
+// method to `LlmClient` without touching the answer policy.
+import Anthropic from '@anthropic-ai/sdk';
+
+/** A single conversational turn handed to the model. */
+export interface LlmMessage {
+	role: 'user' | 'assistant';
+	content: string;
+}
+
+/** A non-streaming completion request. `system` carries the grounding policy;
+ *  `messages` carries the grounded context + question. */
+export interface LlmCompletionRequest {
+	system: string;
+	messages: LlmMessage[];
+	/** Model id (e.g. `claude-haiku-4-5`). Chosen by the caller so cost/quality
+	 *  is a per-call decision, not baked into the client. */
+	model: string;
+	/** Output cap. Defaults to `DEFAULT_MAX_TOKENS`. */
+	maxTokens?: number;
+}
+
+/** The generation seam. `complete` returns the model's text output (all text
+ *  blocks concatenated); the answerer parses structure out of it. */
+export interface LlmClient {
+	/** Provenance id (e.g. `anthropic`, `fake`) — handy in logs/tests. */
+	readonly id: string;
+	complete(req: LlmCompletionRequest): Promise<string>;
+}
+
+/** Small/cheap default — the answer stage is a short, grounded generation, so a
+ *  Haiku-class model is the right cost point. Overridable via RAG_ANSWER_MODEL. */
+export const DEFAULT_ANSWER_MODEL = 'claude-haiku-4-5';
+/** Escalation target for when a call wants more headroom (harder synthesis).
+ *  Not auto-selected here — exposed so callers/config can opt in. */
+export const DEFAULT_ESCALATION_MODEL = 'claude-sonnet-5';
+/** Generous cap for a single grounded answer; JSON payload is small. */
+export const DEFAULT_MAX_TOKENS = 1024;
+
+/** The configured default answer model: RAG_ANSWER_MODEL or the cheap default. */
+export function defaultAnswerModel(): string {
+	return process.env.RAG_ANSWER_MODEL?.trim() || DEFAULT_ANSWER_MODEL;
+}
+
+/** The configured escalation model: RAG_ANSWER_ESCALATION_MODEL or the default. */
+export function escalationModel(): string {
+	return process.env.RAG_ANSWER_ESCALATION_MODEL?.trim() || DEFAULT_ESCALATION_MODEL;
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic (real). Needs ANTHROPIC_API_KEY. Non-streaming; no thinking/effort
+// params so the same call shape works across Haiku 4.5 / Sonnet / Opus (Haiku
+// 4.5 rejects `effort` and adaptive thinking — see the claude-api skill).
+// ---------------------------------------------------------------------------
+export function makeAnthropicLlm(opts?: { apiKey?: string }): LlmClient {
+	const apiKey = opts?.apiKey ?? process.env.ANTHROPIC_API_KEY;
+	if (!apiKey) throw new Error('anthropic llm needs ANTHROPIC_API_KEY');
+	const client = new Anthropic({ apiKey });
+	return {
+		id: 'anthropic',
+		async complete(req) {
+			const res = await client.messages.create({
+				model: req.model,
+				max_tokens: req.maxTokens ?? DEFAULT_MAX_TOKENS,
+				system: req.system,
+				messages: req.messages.map((m) => ({ role: m.role, content: m.content }))
+			});
+			return res.content
+				.filter((b): b is Anthropic.TextBlock => b.type === 'text')
+				.map((b) => b.text)
+				.join('');
+		}
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Fake (offline / tests). A scripted responder — you supply a function that maps
+// a request to the raw completion string, so a test can drive each answer mode
+// deterministically without a network or an API key. Mirrors makeFakeEmbedder.
+// ---------------------------------------------------------------------------
+export type FakeLlmHandler = (req: LlmCompletionRequest) => string;
+
+export function makeFakeLlm(handler: FakeLlmHandler, id = 'fake'): LlmClient {
+	return {
+		id,
+		async complete(req) {
+			return handler(req);
+		}
+	};
+}
+
+/**
+ * Pick an LLM client: an injected one (tests / explicit config) wins; otherwise
+ * the real Anthropic client when ANTHROPIC_API_KEY is set. Throws if neither is
+ * available — the answerer should never silently no-op.
+ */
+export function selectLlm(injected?: LlmClient): LlmClient {
+	if (injected) return injected;
+	if (process.env.ANTHROPIC_API_KEY) return makeAnthropicLlm();
+	throw new Error(
+		'no LLM configured: set ANTHROPIC_API_KEY or pass an injected LlmClient (opts.llm)'
+	);
+}


### PR DESCRIPTION
Closes #37

Stage 4 of the RAG epic (#32). Adds `src/lib/server/rag/answer.ts`: given a question it uses #36's `retrieve()` to build grounded context, prompts Claude under the grilled grounding policy, and returns `{ answer, citations, mode }` with `mode ∈ grounded | fallback | abstained`.

## What's here
- **`answer.ts`** — the policy + orchestration. System prompt encodes the three-mode grounding policy; a `normalize()` step then enforces the contract in code (not just the prompt), so a hallucinating model can't break it.
- **`llm.ts`** — a small string-in/string-out generation seam mirroring the embedding seam (`selectEmbedder` → `selectLlm`): real Anthropic client + a scriptable `makeFakeLlm` for offline tests. Non-streaming for now; a `stream()` method can be added for #38 without touching the answer policy.
- **`answer.test.ts`** — deterministic offline coverage of every mode + the invariants, plus a live smoke test gated on `ANTHROPIC_API_KEY`.
- Adds `@anthropic-ai/sdk` (0.112.1) as a dependency.

**Model:** default `claude-haiku-4-5` (small/cheap, per the brief), overridable via `RAG_ANSWER_MODEL`; escalation target `claude-sonnet-5` via `RAG_ANSWER_ESCALATION_MODEL` (exposed for callers/config). Model IDs sourced from the `claude-api` skill. Non-streaming `messages.create` with no `thinking`/`effort` params, so the same call shape works across Haiku 4.5 / Sonnet / Opus.

## Enforced invariants (code, not just prompt)
- Citations are **always a subset of what was retrieved** — fabricated URLs are dropped.
- A `grounded` answer must keep ≥1 real citation, else it **degrades to abstained** (no ungrounded claims).
- A `fallback` answer is **always prefixed** with the "not from the town's records" label, even if the model omits it.
- Unknown mode / malformed JSON → safe **abstention** that points the asker onward.

## Acceptance criteria
- [x] 1. Grounded question (covered) → cites correct source URL(s), `mode=grounded`.
- [x] 2. Context question not in corpus → labeled fallback, `mode=fallback`.
- [x] 3. Hard specific not in corpus → abstains (no guessed date/fee/name), `mode=abstained`, points to where to look.
- [x] 4. Cited sources always a subset of retrieved (no fabricated citations).
- [x] 5. Verified with deterministic fake LLM + fake retrieval offline; live smoke test present (gated on `ANTHROPIC_API_KEY`).

## Verify coverage
`bun run check` + `bun run lint` clean. 17 offline unit tests pass (all three modes, citation-subset guard, fallback-label enforcement, grounded→abstained downgrade, malformed/prose-wrapped JSON recovery, blank-question short-circuit, unknown-mode degrade). Also driven end-to-end with a fake LLM to observe real returned objects. **The live smoke test was not run — no `ANTHROPIC_API_KEY` / `ant` credential available in this environment**; it runs automatically wherever the key is set.

**Migration:** none (no schema change). No dashboard / `sync.ts` changes.

## Reviewer must-check
- `SYSTEM_PROMPT` wording — the policy prose is a judgement call worth a human read (esp. the fallback/abstained boundary for "hard specifics").
- The grounded→abstained downgrade when all citations are fabricated: confirm you want that behavior vs. returning grounded-with-empty-citations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)