### PR TITLE
feat: worker registry + progress-stall warning on the dashboard

### DIFF
--- a/drizzle/0007_careless_karnak.sql
+++ b/drizzle/0007_careless_karnak.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `worker` (
+	`id` text PRIMARY KEY NOT NULL,
+	`host` text NOT NULL,
+	`pid` integer NOT NULL,
+	`role` text DEFAULT 'standby' NOT NULL,
+	`run_id` text,
+	`phase` text,
+	`started_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`last_seen_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `worker_last_seen_idx` ON `worker` (`last_seen_at`);--> statement-breakpoint
+ALTER TABLE `sync_run` ADD `progress_at` integer;

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,1622 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "8828dcd8-8bb2-4c09-9c2e-d96297a2c26f",
+  "prevId": "b4909a27-73fc-43b2-8c65-9a0a7ea3ba9c",
+  "tables": {
+    "task": {
+      "name": "task",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blob": {
+      "name": "blob",
+      "columns": {
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_count": {
+          "name": "ref_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "r2_synced_at": {
+          "name": "r2_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "blob_r2_synced_idx": {
+          "name": "blob_r2_synced_idx",
+          "columns": [
+            "r2_synced_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chunk": {
+      "name": "chunk",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_sha": {
+          "name": "source_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "char_start": {
+          "name": "char_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "char_end": {
+          "name": "char_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "F32_BLOB(768)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedder": {
+          "name": "embedder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "chunk_resource_idx": {
+          "name": "chunk_resource_idx",
+          "columns": [
+            "resource_id"
+          ],
+          "isUnique": false
+        },
+        "chunk_source_sha_idx": {
+          "name": "chunk_source_sha_idx",
+          "columns": [
+            "source_sha"
+          ],
+          "isUnique": false
+        },
+        "chunk_resource_index_unique": {
+          "name": "chunk_resource_index_unique",
+          "columns": [
+            "resource_id",
+            "chunk_index"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "chunk_resource_id_resource_id_fk": {
+          "name": "chunk_resource_id_resource_id_fk",
+          "tableFrom": "chunk",
+          "tableTo": "resource",
+          "columnsFrom": [
+            "resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "crawl_event": {
+      "name": "crawl_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "at": {
+          "name": "at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "crawl_event_run_idx": {
+          "name": "crawl_event_run_idx",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": false
+        },
+        "crawl_event_kind_idx": {
+          "name": "crawl_event_kind_idx",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "link": {
+      "name": "link",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_resource_id": {
+          "name": "from_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_resource_id": {
+          "name": "to_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_url": {
+          "name": "to_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rel": {
+          "name": "rel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'href'"
+        },
+        "first_run_id": {
+          "name": "first_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "link_from_to_unique": {
+          "name": "link_from_to_unique",
+          "columns": [
+            "from_resource_id",
+            "to_url"
+          ],
+          "isUnique": true
+        },
+        "link_to_idx": {
+          "name": "link_to_idx",
+          "columns": [
+            "to_resource_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "link_from_resource_id_resource_id_fk": {
+          "name": "link_from_resource_id_resource_id_fk",
+          "tableFrom": "link",
+          "tableTo": "resource",
+          "columnsFrom": [
+            "from_resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "link_to_resource_id_resource_id_fk": {
+          "name": "link_to_resource_id_resource_id_fk",
+          "tableFrom": "link",
+          "tableTo": "resource",
+          "columnsFrom": [
+            "to_resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "resource": {
+      "name": "resource",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url_hash": {
+          "name": "url_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'page'"
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "next_fetch_at": {
+          "name": "next_fetch_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "etag": {
+          "name": "etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latest_version_id": {
+          "name": "latest_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_changed_at": {
+          "name": "last_changed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_run_id": {
+          "name": "first_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "resource_url_unique": {
+          "name": "resource_url_unique",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "resource_kind_idx": {
+          "name": "resource_kind_idx",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": false
+        },
+        "resource_state_idx": {
+          "name": "resource_state_idx",
+          "columns": [
+            "state"
+          ],
+          "isUnique": false
+        },
+        "resource_host_idx": {
+          "name": "resource_host_idx",
+          "columns": [
+            "host"
+          ],
+          "isUnique": false
+        },
+        "resource_changed_idx": {
+          "name": "resource_changed_idx",
+          "columns": [
+            "last_changed_at"
+          ],
+          "isUnique": false
+        },
+        "resource_frontier_idx": {
+          "name": "resource_frontier_idx",
+          "columns": [
+            "priority",
+            "next_fetch_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "resource_text": {
+      "name": "resource_text",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "char_count": {
+          "name": "char_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "extractor": {
+          "name": "extractor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "resource_text_resource_unique": {
+          "name": "resource_text_resource_unique",
+          "columns": [
+            "resource_id"
+          ],
+          "isUnique": true
+        },
+        "resource_text_sha_idx": {
+          "name": "resource_text_sha_idx",
+          "columns": [
+            "sha256"
+          ],
+          "isUnique": false
+        },
+        "resource_text_status_idx": {
+          "name": "resource_text_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "resource_text_resource_id_resource_id_fk": {
+          "name": "resource_text_resource_id_resource_id_fk",
+          "tableFrom": "resource_text",
+          "tableTo": "resource",
+          "columnsFrom": [
+            "resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "resource_version": {
+      "name": "resource_version",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "change_kind": {
+          "name": "change_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "etag": {
+          "name": "etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blob_sha256": {
+          "name": "blob_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rv_resource_idx": {
+          "name": "rv_resource_idx",
+          "columns": [
+            "resource_id"
+          ],
+          "isUnique": false
+        },
+        "rv_run_idx": {
+          "name": "rv_run_idx",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": false
+        },
+        "rv_observed_idx": {
+          "name": "rv_observed_idx",
+          "columns": [
+            "observed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "resource_version_resource_id_resource_id_fk": {
+          "name": "resource_version_resource_id_resource_id_fk",
+          "tableFrom": "resource_version",
+          "tableTo": "resource",
+          "columnsFrom": [
+            "resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "resource_version_blob_sha256_blob_sha256_fk": {
+          "name": "resource_version_blob_sha256_blob_sha256_fk",
+          "tableFrom": "resource_version",
+          "tableTo": "blob",
+          "columnsFrom": [
+            "blob_sha256"
+          ],
+          "columnsTo": [
+            "sha256"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_run": {
+      "name": "sync_run",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "control": {
+          "name": "control",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "discovery_enabled": {
+          "name": "discovery_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_pages": {
+          "name": "max_pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "params": {
+          "name": "params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "progress_at": {
+          "name": "progress_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_url": {
+          "name": "current_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_phase": {
+          "name": "current_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requests_made": {
+          "name": "requests_made",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pages": {
+          "name": "pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "documents": {
+          "name": "documents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "discovered": {
+          "name": "discovered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "fetched": {
+          "name": "fetched",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "new_count": {
+          "name": "new_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "changed_count": {
+          "name": "changed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "unchanged_count": {
+          "name": "unchanged_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "gone_count": {
+          "name": "gone_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "bytes_downloaded": {
+          "name": "bytes_downloaded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "bytes_stored": {
+          "name": "bytes_stored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "bytes_estimated": {
+          "name": "bytes_estimated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sync_run_status_idx": {
+          "name": "sync_run_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "sync_run_requested_idx": {
+          "name": "sync_run_requested_idx",
+          "columns": [
+            "requested_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "worker": {
+      "name": "worker",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pid": {
+          "name": "pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'standby'"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "worker_last_seen_idx": {
+          "name": "worker_last_seen_idx",
+          "columns": [
+            "last_seen_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1784255696212,
       "tag": "0006_loud_dreaming_celestial",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1784256467816,
+      "tag": "0007_careless_karnak",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/server/db/crawl.schema.ts
+++ b/src/lib/server/db/crawl.schema.ts
@@ -291,6 +291,11 @@ export const syncRun = sqliteTable(
 		finishedAt: integer('finished_at', { mode: 'timestamp_ms' }),
 		workerId: text('worker_id'),
 		heartbeatAt: integer('heartbeat_at', { mode: 'timestamp_ms' }),
+		// Last time a forward-progress counter (requests-made / fetched) advanced —
+		// bumped by the heartbeat ONLY when progress moved, never on a progress-less
+		// beat. A run that keeps heartbeating while this stays put is "stalled" (a
+		// dashboard warning; the worker never auto-fails on it). See writeHeartbeat.
+		progressAt: integer('progress_at', { mode: 'timestamp_ms' }),
 		currentUrl: text('current_url'),
 		currentPhase: text('current_phase'),
 		// rollups
@@ -313,6 +318,31 @@ export const syncRun = sqliteTable(
 		index('sync_run_status_idx').on(t.status),
 		index('sync_run_requested_idx').on(t.requestedAt)
 	]
+);
+
+// ---------------------------------------------------------------------------
+// worker — lightweight process registry. One row per live worker process,
+// active AND standby. The single-writer guard means only the claiming worker
+// touches a run row (see claimNext in worker/index.ts), so standbys and the
+// total process count were previously invisible. Every worker upserts its own
+// row (identity + role + last-seen) on the maintenance tick; the active worker
+// also refreshes it on each crawl heartbeat so a long run never looks dead. A
+// sweep drops rows older than the stale-run threshold, and a worker best-effort
+// deletes its own row on shutdown, so the table reflects the live set.
+// ---------------------------------------------------------------------------
+export const worker = sqliteTable(
+	'worker',
+	{
+		id: text('id').primaryKey(), // stable per-process id (host-pid-rand)
+		host: text('host').notNull(),
+		pid: integer('pid').notNull(),
+		role: text('role').notNull().default('standby'), // active | standby
+		runId: text('run_id'), // the run this worker owns, when active
+		phase: text('phase'), // that run's current phase, when active
+		startedAt: integer('started_at', { mode: 'timestamp_ms' }).default(nowMs).notNull(),
+		lastSeenAt: integer('last_seen_at', { mode: 'timestamp_ms' }).default(nowMs).notNull()
+	},
+	(t) => [index('worker_last_seen_idx').on(t.lastSeenAt)]
 );
 
 // ---------------------------------------------------------------------------
@@ -344,4 +374,5 @@ export type Chunk = typeof chunk.$inferSelect;
 export type Blob = typeof blob.$inferSelect;
 export type Link = typeof link.$inferSelect;
 export type SyncRun = typeof syncRun.$inferSelect;
+export type Worker = typeof worker.$inferSelect;
 export type CrawlEvent = typeof crawlEvent.$inferSelect;

--- a/src/lib/server/sync.ts
+++ b/src/lib/server/sync.ts
@@ -1,9 +1,17 @@
 // Server-side control plane + read models for the sync dashboard. The web app
 // never talks to the worker directly: it enqueues sync_run rows and writes the
 // `control` column; the worker polls, executes, and writes back progress here.
-import { and, count, desc, eq, inArray, isNotNull, isNull, like, or, sql } from 'drizzle-orm';
+import { and, asc, count, desc, eq, inArray, isNotNull, isNull, like, or, sql } from 'drizzle-orm';
 import { db } from '$lib/server/db';
-import { blob, crawlEvent, link, resource, resourceVersion, syncRun } from '$lib/server/db/schema';
+import {
+	blob,
+	crawlEvent,
+	link,
+	resource,
+	resourceVersion,
+	syncRun,
+	worker
+} from '$lib/server/db/schema';
 
 export type SyncMode = 'sync' | 'estimate' | 'crawl' | 'recrawl';
 export type ControlAction = 'pause' | 'resume' | 'cancel';
@@ -57,6 +65,123 @@ export async function getActiveRun() {
 		.orderBy(desc(syncRun.requestedAt))
 		.limit(1);
 	return row ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Worker health
+// ---------------------------------------------------------------------------
+// Thresholds, derived from the same env vars the worker uses (kept here rather
+// than imported so the app/worker boundary stays a Turso-only contract):
+//   - WORKER_STALE_MINUTES  — a registry row not refreshed within this window is
+//     dead (the worker sweeps it; the read model stops counting it as live).
+//   - WORKER_STALL_MINUTES  — a running run still heartbeating but whose
+//     progress marker hasn't advanced this long is "stalled" (a warning).
+// HEARTBEAT_STALE_MS mirrors the dashboard chip's own 30s heartbeat window.
+const WORKER_STALE_MS = Number(process.env.WORKER_STALE_MINUTES ?? 5) * 60_000;
+const PROGRESS_STALL_MS = Number(process.env.WORKER_STALL_MINUTES ?? 3) * 60_000;
+const HEARTBEAT_STALE_MS = 30_000;
+
+export interface WorkerEntry {
+	id: string;
+	host: string;
+	pid: number;
+	role: 'active' | 'standby';
+	runId: string | null;
+	phase: string | null;
+	/** Epoch ms; null only for a malformed row. */
+	startedAt: number | null;
+	lastSeenAt: number | null;
+	uptimeMs: number;
+	lastSeenAgeMs: number;
+	/** Last-seen older than the stale window — awaiting the sweep, not counted live. */
+	stale: boolean;
+}
+
+/** Derived worker-health flags for the dashboard. All warnings — none of them
+ *  change worker behavior (the worker never auto-fails on any of these). */
+export interface WorkerFlags {
+	/** An active run exists but no live worker holds the active role (unclaimed
+	 *  queue, or the claiming worker vanished). */
+	noActiveWorker: boolean;
+	/** The active run is running/paused but its heartbeat has gone stale. */
+	staleHeartbeat: boolean;
+	/** The active run is running with a FRESH heartbeat but its progress marker
+	 *  hasn't advanced for PROGRESS_STALL_MS — heartbeating but stuck. */
+	stalled: boolean;
+	/** More than one live worker claims the active role — the single-writer guard
+	 *  should make this impossible, so it's surfaced as an anomaly. */
+	multipleActive: boolean;
+}
+
+export interface WorkerHealth {
+	/** The live-plus-recently-seen worker set, active first then by start time. */
+	workers: WorkerEntry[];
+	activeCount: number;
+	standbyCount: number;
+	staleThresholdMs: number;
+	stallThresholdMs: number;
+	flags: WorkerFlags;
+}
+
+/** Read model for the worker-health area of the sync-status card: the process
+ *  registry (roles, uptime, last-seen age, phase) plus the derived health flags.
+ *  Standby count is reported but is NOT itself an alert. */
+export async function getWorkerHealth(): Promise<WorkerHealth> {
+	const now = Date.now();
+	const rows = await db.select().from(worker).orderBy(asc(worker.role), asc(worker.startedAt)); // 'active' < 'standby'
+	const workers: WorkerEntry[] = rows.map((w) => {
+		const startedAt = w.startedAt?.getTime() ?? null;
+		const lastSeenAt = w.lastSeenAt?.getTime() ?? null;
+		const lastSeenAgeMs = lastSeenAt != null ? now - lastSeenAt : Infinity;
+		return {
+			id: w.id,
+			host: w.host,
+			pid: w.pid,
+			role: w.role === 'active' ? 'active' : 'standby',
+			runId: w.runId,
+			phase: w.phase,
+			startedAt,
+			lastSeenAt,
+			uptimeMs: startedAt != null ? now - startedAt : 0,
+			lastSeenAgeMs,
+			stale: lastSeenAgeMs > WORKER_STALE_MS
+		};
+	});
+
+	// Only fresh rows count toward the live tallies; a just-died worker lingers in
+	// the list (shown stale) until the sweep drops it, but isn't counted live.
+	const live = workers.filter((w) => !w.stale);
+	const activeCount = live.filter((w) => w.role === 'active').length;
+	const standbyCount = live.filter((w) => w.role === 'standby').length;
+
+	// Run-based signals need the active run's heartbeat + progress marker.
+	const active = await getActiveRun();
+	const isRunning = !!active && (active.status === 'running' || active.status === 'paused');
+	const beatMs = active?.heartbeatAt?.getTime() ?? null;
+	const heartbeatFresh = beatMs != null && now - beatMs <= HEARTBEAT_STALE_MS;
+	const progressMs = active?.progressAt?.getTime() ?? null;
+
+	const flags: WorkerFlags = {
+		noActiveWorker: !!active && activeCount === 0,
+		staleHeartbeat: isRunning && (beatMs == null || now - beatMs > HEARTBEAT_STALE_MS),
+		// Warning only — never auto-fails the run.
+		stalled:
+			!!active &&
+			active.status === 'running' &&
+			heartbeatFresh &&
+			progressMs != null &&
+			now - progressMs > PROGRESS_STALL_MS,
+		multipleActive: activeCount > 1
+	};
+
+	return {
+		workers,
+		activeCount,
+		standbyCount,
+		staleThresholdMs: WORKER_STALE_MS,
+		stallThresholdMs: PROGRESS_STALL_MS,
+		flags
+	};
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/server/sync.ts
+++ b/src/lib/server/sync.ts
@@ -164,7 +164,9 @@ export async function getWorkerHealth(): Promise<WorkerHealth> {
 	const flags: WorkerFlags = {
 		noActiveWorker: !!active && activeCount === 0,
 		staleHeartbeat: isRunning && (beatMs == null || now - beatMs > HEARTBEAT_STALE_MS),
-		// Warning only — never auto-fails the run.
+		// Warning only — never auto-fails the run. The `progressMs != null` guard also
+		// scopes this to crawl-family runs: only those write the progress marker, so
+		// extract/embed runs (progress_at stays null) are never flagged stalled.
 		stalled:
 			!!active &&
 			active.status === 'running' &&

--- a/src/routes/dashboard/+page.server.ts
+++ b/src/routes/dashboard/+page.server.ts
@@ -14,7 +14,8 @@ export const load: PageServerLoad = async () => {
 		storageHealth,
 		feed,
 		progress,
-		processing
+		processing,
+		workerHealth
 	] = await Promise.all([
 		sync.getOverview(),
 		sync.getActiveRun(),
@@ -26,7 +27,8 @@ export const load: PageServerLoad = async () => {
 		sync.getStorageHealth(),
 		sync.getChangeFeed(10),
 		sync.getSyncProgress(),
-		sync.getProcessingRecords()
+		sync.getProcessingRecords(),
+		sync.getWorkerHealth()
 	]);
 
 	// The worker-health hint (is anything actually processing this run?) is derived
@@ -43,7 +45,8 @@ export const load: PageServerLoad = async () => {
 		storageHealth,
 		feed,
 		progress,
-		processing
+		processing,
+		workerHealth
 	};
 };
 

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -20,6 +20,10 @@
 	let streamedProgress = $state<typeof data.progress | undefined>(undefined);
 	let streamedProcessing = $state<typeof data.processing | undefined>(undefined);
 	const processing = $derived(streamedProcessing ?? data.processing);
+	// Worker registry + derived health flags, streamed on the aggregate cadence and
+	// falling back to the server-loaded snapshot until the first tick arrives.
+	let streamedWorkerHealth = $state<typeof data.workerHealth | undefined>(undefined);
+	const wh = $derived(streamedWorkerHealth ?? data.workerHealth);
 	// New URLs discovered since the last aggregate tick — a nonzero value means the
 	// frontier (and the Overall denominator) is still growing, not converged yet.
 	let recentDelta = $state(0);
@@ -62,6 +66,7 @@
 				streamedProgress = p.progress;
 			}
 			if (p?.processing) streamedProcessing = p.processing;
+			if (p?.workerHealth) streamedWorkerHealth = p.workerHealth;
 			// When the active run ends, refresh aggregates (tiles, feed, alert).
 			if (wasActive && !run) invalidateAll();
 		});
@@ -113,6 +118,41 @@
 		idle: { label: 'idle', dot: 'bg-muted-foreground/50', ping: false }
 	};
 	const status = $derived(STATUS[statusKind]);
+
+	// Worker-health alerts, derived from the read model's flags. All are warnings —
+	// none change worker behavior (a stall is never auto-failed). Standby count is
+	// shown separately (below) and is deliberately NOT an alert.
+	const whAlerts = $derived.by(() => {
+		const f = wh.flags;
+		const out: { key: string; label: string; detail: string }[] = [];
+		if (f.noActiveWorker)
+			out.push({
+				key: 'no-active-worker',
+				label: 'No active worker',
+				detail: 'A run is active but no worker is processing it — start one with `bun run worker`.'
+			});
+		if (f.staleHeartbeat)
+			out.push({
+				key: 'stale-heartbeat',
+				label: 'Stale heartbeat',
+				detail: "The active run hasn't heartbeat recently — the worker may have stopped."
+			});
+		if (f.stalled)
+			out.push({
+				key: 'stalled',
+				label: 'Stalled',
+				detail:
+					'The worker is still heartbeating but progress has not advanced — it may be stuck. (Warning only; the run is never auto-failed.)'
+			});
+		if (f.multipleActive)
+			out.push({
+				key: 'multiple-active',
+				label: '>1 active worker',
+				detail:
+					'More than one worker holds the active role — the single-writer guard should prevent this.'
+			});
+		return out;
+	});
 
 	const maxStorage = $derived(Math.max(1, ...data.storage.map((s) => Number(s.bytes))));
 
@@ -375,6 +415,60 @@
 			{:else}
 				<p class="text-sm text-muted-foreground">No runs yet. Start one below.</p>
 			{/if}
+
+			<!-- Worker health: the live process registry (active + standby) plus derived
+			     warnings. Standby count is shown but is never itself an alert. -->
+			<div class="mt-4 space-y-2 border-t pt-4">
+				<div class="flex items-center justify-between">
+					<p class="text-xs font-medium">Workers</p>
+					<span class="text-xs text-muted-foreground tabular-nums">
+						{wh.activeCount} active · {wh.standbyCount} standby
+					</span>
+				</div>
+
+				{#if whAlerts.length}
+					<div class="flex flex-wrap gap-2">
+						{#each whAlerts as a (a.key)}
+							<Badge variant="destructive" title={a.detail}>{a.label}</Badge>
+						{/each}
+					</div>
+				{/if}
+
+				{#if wh.workers.length}
+					<ul class="divide-y">
+						{#each wh.workers as w (w.id)}
+							<li class="flex items-center gap-2 py-1.5 text-xs">
+								<Badge
+									variant={w.role === 'active' ? 'default' : 'outline'}
+									class="w-16 shrink-0 justify-center capitalize"
+								>
+									{w.role}
+								</Badge>
+								<span class="min-w-0 flex-1 truncate font-mono text-muted-foreground" title={w.id}>
+									{w.host}:{w.pid}{#if w.phase}
+										· {w.phase}{/if}
+								</span>
+								<span class="shrink-0 tabular-nums text-muted-foreground">
+									up {formatDuration(w.startedAt)}
+								</span>
+								<span
+									class={`shrink-0 tabular-nums ${w.stale ? 'text-amber-600 dark:text-amber-500' : 'text-muted-foreground'}`}
+									title="time since this worker last refreshed its registration"
+								>
+									seen {formatRelative(w.lastSeenAt)}{#if w.stale}
+										· stale{/if}
+								</span>
+							</li>
+						{/each}
+					</ul>
+				{:else}
+					<p class="text-xs text-muted-foreground">
+						No workers registered. Start one with <code
+							class="rounded bg-muted px-1 py-0.5 font-mono">bun run worker</code
+						>.
+					</p>
+				{/if}
+			</div>
 		</Card.Content>
 	</Card.Root>
 

--- a/src/routes/dashboard/stream/+server.ts
+++ b/src/routes/dashboard/stream/+server.ts
@@ -70,6 +70,7 @@ export const GET: RequestHandler = async ({ locals, request }) => {
 			let lastAgg = 0;
 			let agg: sync.SyncProgress | null = null;
 			let processing: sync.ProcessingPanel | null = null;
+			let workerHealth: sync.WorkerHealth | null = null;
 			const tick = async () => {
 				try {
 					const active = await sync.getActiveRun();
@@ -77,15 +78,19 @@ export const GET: RequestHandler = async ({ locals, request }) => {
 					if (Date.now() - lastAgg >= AGG_MS) {
 						lastAgg = Date.now();
 						fresh = true;
-						[agg, processing] = await Promise.all([
+						[agg, processing, workerHealth] = await Promise.all([
 							sync.getSyncProgress(),
-							sync.getProcessingRecords()
+							sync.getProcessingRecords(),
+							sync.getWorkerHealth()
 						]);
 					}
 					send('progress', {
 						run: active ? serialize(active) : null,
 						progress: agg,
-						processing: fresh ? processing : undefined
+						processing: fresh ? processing : undefined,
+						// Included only on the refreshed ticks; the client keeps its last copy
+						// otherwise (same cadence rationale as `processing`).
+						workerHealth: fresh ? workerHealth : undefined
 					});
 				} catch {
 					// transient DB error — next tick retries

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -112,7 +112,15 @@ export const SYNC_SCHEDULE_MS = Number(process.env.SYNC_SCHEDULE_MINUTES ?? 0) *
 
 // A run whose heartbeat is older than this is considered dead and reaped, so a
 // crashed worker doesn't leave a `running` row blocking the schedule forever.
+// Also the sweep threshold for the worker registry: a worker row not refreshed
+// within this window is dropped (see sweepStaleWorkers in worker/index.ts).
 export const STALE_RUN_MS = Number(process.env.WORKER_STALE_MINUTES ?? 5) * 60_000;
+
+// A running run that keeps heartbeating but whose forward-progress counter hasn't
+// advanced for this long is flagged "stalled" on the dashboard. WARNING ONLY —
+// the worker never auto-fails a run on a stall. Read-model concern only (the
+// dashboard derives the flag); the worker just records the progress marker.
+export const PROGRESS_STALL_MS = Number(process.env.WORKER_STALL_MINUTES ?? 3) * 60_000;
 
 // ---------------------------------------------------------------------------
 // Embedding pipeline (mode = "embed"): chunking + embedding knobs. The vector

--- a/worker/crawl.ts
+++ b/worker/crawl.ts
@@ -10,8 +10,7 @@ import {
 	link,
 	resource,
 	resourceVersion,
-	syncRun,
-	worker
+	syncRun
 } from '../src/lib/server/db/schema';
 import type { SyncRun } from '../src/lib/server/db/crawl.schema';
 import { makeBlobWriter, type BlobWriter } from './storage';
@@ -43,6 +42,7 @@ import {
 	Robots,
 	sha256Hex
 } from './http';
+import { refreshActiveWorker } from './registry';
 
 const HEARTBEAT_MS = 2000;
 
@@ -723,14 +723,8 @@ async function writeHeartbeat(
 	ctx: { workerId: string | null; phase: string; progressAdvanced: boolean }
 ): Promise<{ control: string; discoveryEnabled: boolean }> {
 	const now = new Date();
-	if (ctx.workerId) {
-		// Best-effort registry refresh — a failure here must never break crawling.
-		await db
-			.update(worker)
-			.set({ role: 'active', runId, phase: ctx.phase, lastSeenAt: now })
-			.where(eq(worker.id, ctx.workerId))
-			.catch(() => {});
-	}
+	// Keep the active worker's registry row fresh (best-effort; see registry.ts).
+	await refreshActiveWorker(ctx.workerId, runId, ctx.phase);
 	const [row] = await db
 		.update(syncRun)
 		.set({

--- a/worker/crawl.ts
+++ b/worker/crawl.ts
@@ -10,7 +10,8 @@ import {
 	link,
 	resource,
 	resourceVersion,
-	syncRun
+	syncRun,
+	worker
 } from '../src/lib/server/db/schema';
 import type { SyncRun } from '../src/lib/server/db/crawl.schema';
 import { makeBlobWriter, type BlobWriter } from './storage';
@@ -263,18 +264,33 @@ export async function executeRun(run: SyncRun, opts: { publish?: boolean } = {})
 	// Live frontier-discovery switch, refreshed each heartbeat (see executeSync).
 	let discoveryEnabled = run.discoveryEnabled;
 	let lastBeat = 0;
+	// Forward-progress watermark for the stall marker: the last requestsMade value
+	// we recorded a progress bump for. -1 so the first beat always initializes it.
+	let lastProgress = -1;
+	const workerId = run.workerId;
 
 	async function beat(currentUrl: string | null): Promise<void> {
 		const nowMs = Date.now();
 		if (nowMs - lastBeat < HEARTBEAT_MS) return;
 		lastBeat = nowMs;
-		({ control, discoveryEnabled } = await writeHeartbeat(runId, currentUrl, stats));
+		const progressAdvanced = stats.requestsMade > lastProgress;
+		if (progressAdvanced) lastProgress = stats.requestsMade;
+		({ control, discoveryEnabled } = await writeHeartbeat(runId, currentUrl, stats, {
+			workerId,
+			phase: 'crawling',
+			progressAdvanced
+		}));
 	}
 
-	// Mark running.
+	// Mark running. Seed progress_at so a run is never "stalled" before its first beat.
 	await db
 		.update(syncRun)
-		.set({ status: 'running', startedAt: new Date(), currentPhase: 'crawling' })
+		.set({
+			status: 'running',
+			startedAt: new Date(),
+			currentPhase: 'crawling',
+			progressAt: new Date()
+		})
 		.where(eq(syncRun.id, runId));
 
 	while (queue.length > 0 && stats.requestsMade < maxPages) {
@@ -414,12 +430,21 @@ export async function executeSync(run: SyncRun, opts: { publish?: boolean } = {}
 	// still fetches/refreshes known resources but ingests no newly-discovered URLs.
 	let discoveryEnabled = run.discoveryEnabled;
 	let lastBeat = 0;
+	// Forward-progress watermark for the stall marker (see executeRun.beat).
+	let lastProgress = -1;
+	const workerId = run.workerId;
 
 	async function beat(currentUrl: string | null): Promise<void> {
 		const nowMs = Date.now();
 		if (nowMs - lastBeat < HEARTBEAT_MS) return;
 		lastBeat = nowMs;
-		({ control, discoveryEnabled } = await writeHeartbeat(runId, currentUrl, stats));
+		const progressAdvanced = stats.requestsMade > lastProgress;
+		if (progressAdvanced) lastProgress = stats.requestsMade;
+		({ control, discoveryEnabled } = await writeHeartbeat(runId, currentUrl, stats, {
+			workerId,
+			phase: 'sync',
+			progressAdvanced
+		}));
 	}
 
 	/** Wait out a pause; returns false if the run was canceled. */
@@ -443,9 +468,10 @@ export async function executeSync(run: SyncRun, opts: { publish?: boolean } = {}
 			.set({ nextFetchAt: new Date(Date.now() + ttlFor(priority)) })
 			.where(eq(resource.id, id));
 
+	// Mark running. Seed progress_at so a run is never "stalled" before its first beat.
 	await db
 		.update(syncRun)
-		.set({ status: 'running', startedAt: new Date(), currentPhase: 'sync' })
+		.set({ status: 'running', startedAt: new Date(), currentPhase: 'sync', progressAt: new Date() })
 		.where(eq(syncRun.id, runId));
 
 	// Backfill: give any legacy rows a priority tier (they were all default 1).
@@ -681,16 +707,37 @@ function backfillLinkTargets(): Promise<unknown> {
 
 /** Write heartbeat + rollup counters; returns the live steering flags (control +
  *  whether frontier discovery is currently enabled) so the loop reacts without a
- *  restart. */
+ *  restart.
+ *
+ *  Two extra jobs ride on the heartbeat (both dashboard health signals, neither
+ *  affecting the crawl):
+ *  - `progressAdvanced` bumps `sync_run.progress_at` ONLY when a forward-progress
+ *    counter moved this beat; a run that keeps beating with this frozen is the
+ *    "stalled" signal (a warning — never an auto-fail).
+ *  - `worker`/`phase` refresh the active worker's registry row, so a long run
+ *    never lets its last-seen go stale and get swept by another worker. */
 async function writeHeartbeat(
 	runId: string,
 	currentUrl: string | null,
-	stats: Stats
+	stats: Stats,
+	ctx: { workerId: string | null; phase: string; progressAdvanced: boolean }
 ): Promise<{ control: string; discoveryEnabled: boolean }> {
+	const now = new Date();
+	if (ctx.workerId) {
+		// Best-effort registry refresh — a failure here must never break crawling.
+		await db
+			.update(worker)
+			.set({ role: 'active', runId, phase: ctx.phase, lastSeenAt: now })
+			.where(eq(worker.id, ctx.workerId))
+			.catch(() => {});
+	}
 	const [row] = await db
 		.update(syncRun)
 		.set({
-			heartbeatAt: new Date(),
+			heartbeatAt: now,
+			// Bump the progress marker only on a beat that actually advanced, so a
+			// stuck-but-heartbeating run leaves progress_at behind (→ stalled).
+			...(ctx.progressAdvanced ? { progressAt: now } : {}),
 			currentUrl,
 			requestsMade: stats.requestsMade,
 			pages: stats.pages,

--- a/worker/embed.ts
+++ b/worker/embed.ts
@@ -12,18 +12,12 @@
 // its chunks removed too. So a re-run over unchanged content does no work.
 import { and, asc, eq, gt, or, sql } from 'drizzle-orm';
 import { db } from './db';
-import {
-	chunk,
-	crawlEvent,
-	resource,
-	resourceText,
-	syncRun,
-	worker
-} from '../src/lib/server/db/schema';
+import { chunk, crawlEvent, resource, resourceText, syncRun } from '../src/lib/server/db/schema';
 import type { SyncRun } from '../src/lib/server/db/crawl.schema';
 import { EMBED_BATCH } from './config';
 import { chunkText } from './chunk';
 import { selectEmbedder, type Embedder } from './embeddings';
+import { refreshActiveWorker } from './registry';
 
 const HEARTBEAT_MS = 2000;
 const BATCH = 200; // resources per DB round-trip
@@ -114,13 +108,7 @@ export async function executeEmbed(
 		lastBeat = nowMs;
 		// Keep the active worker's registry row fresh so a long embed run isn't swept
 		// from the live set (best-effort — must not disturb embedding).
-		if (run.workerId) {
-			await db
-				.update(worker)
-				.set({ role: 'active', runId, phase: 'embedding', lastSeenAt: new Date() })
-				.where(eq(worker.id, run.workerId))
-				.catch(() => {});
-		}
+		await refreshActiveWorker(run.workerId, runId, 'embedding');
 		const [r] = await db
 			.update(syncRun)
 			.set({ heartbeatAt: new Date(), currentUrl })

--- a/worker/embed.ts
+++ b/worker/embed.ts
@@ -12,7 +12,14 @@
 // its chunks removed too. So a re-run over unchanged content does no work.
 import { and, asc, eq, gt, or, sql } from 'drizzle-orm';
 import { db } from './db';
-import { chunk, crawlEvent, resource, resourceText, syncRun } from '../src/lib/server/db/schema';
+import {
+	chunk,
+	crawlEvent,
+	resource,
+	resourceText,
+	syncRun,
+	worker
+} from '../src/lib/server/db/schema';
 import type { SyncRun } from '../src/lib/server/db/crawl.schema';
 import { EMBED_BATCH } from './config';
 import { chunkText } from './chunk';
@@ -105,6 +112,15 @@ export async function executeEmbed(
 		const nowMs = Date.now();
 		if (nowMs - lastBeat < HEARTBEAT_MS) return;
 		lastBeat = nowMs;
+		// Keep the active worker's registry row fresh so a long embed run isn't swept
+		// from the live set (best-effort — must not disturb embedding).
+		if (run.workerId) {
+			await db
+				.update(worker)
+				.set({ role: 'active', runId, phase: 'embedding', lastSeenAt: new Date() })
+				.where(eq(worker.id, run.workerId))
+				.catch(() => {});
+		}
 		const [r] = await db
 			.update(syncRun)
 			.set({ heartbeatAt: new Date(), currentUrl })

--- a/worker/extract.ts
+++ b/worker/extract.ts
@@ -18,16 +18,10 @@ import { Readability } from '@mozilla/readability';
 import { parseHTML } from 'linkedom';
 import { extractText as pdfExtractText, getDocumentProxy } from 'unpdf';
 import { db } from './db';
-import {
-	blob,
-	crawlEvent,
-	resource,
-	resourceText,
-	syncRun,
-	worker
-} from '../src/lib/server/db/schema';
+import { blob, crawlEvent, resource, resourceText, syncRun } from '../src/lib/server/db/schema';
 import type { ExtractionStatus, SyncRun } from '../src/lib/server/db/crawl.schema';
 import { localDir, makeLocalStorage, makeR2Storage } from './storage';
+import { refreshActiveWorker } from './registry';
 
 const HEARTBEAT_MS = 2000;
 const BATCH = 200; // resources per DB round-trip
@@ -201,13 +195,7 @@ export async function executeExtract(run: SyncRun): Promise<void> {
 		lastBeat = nowMs;
 		// Keep the active worker's registry row fresh so a long extract run isn't
 		// swept from the live set (best-effort — must not disturb extraction).
-		if (run.workerId) {
-			await db
-				.update(worker)
-				.set({ role: 'active', runId, phase: 'extracting', lastSeenAt: new Date() })
-				.where(eq(worker.id, run.workerId))
-				.catch(() => {});
-		}
+		await refreshActiveWorker(run.workerId, runId, 'extracting');
 		const [row] = await db
 			.update(syncRun)
 			.set({ heartbeatAt: new Date(), currentUrl })

--- a/worker/extract.ts
+++ b/worker/extract.ts
@@ -18,7 +18,14 @@ import { Readability } from '@mozilla/readability';
 import { parseHTML } from 'linkedom';
 import { extractText as pdfExtractText, getDocumentProxy } from 'unpdf';
 import { db } from './db';
-import { blob, crawlEvent, resource, resourceText, syncRun } from '../src/lib/server/db/schema';
+import {
+	blob,
+	crawlEvent,
+	resource,
+	resourceText,
+	syncRun,
+	worker
+} from '../src/lib/server/db/schema';
 import type { ExtractionStatus, SyncRun } from '../src/lib/server/db/crawl.schema';
 import { localDir, makeLocalStorage, makeR2Storage } from './storage';
 
@@ -192,6 +199,15 @@ export async function executeExtract(run: SyncRun): Promise<void> {
 		const nowMs = Date.now();
 		if (nowMs - lastBeat < HEARTBEAT_MS) return;
 		lastBeat = nowMs;
+		// Keep the active worker's registry row fresh so a long extract run isn't
+		// swept from the live set (best-effort — must not disturb extraction).
+		if (run.workerId) {
+			await db
+				.update(worker)
+				.set({ role: 'active', runId, phase: 'extracting', lastSeenAt: new Date() })
+				.where(eq(worker.id, run.workerId))
+				.catch(() => {});
+		}
 		const [row] = await db
 			.update(syncRun)
 			.set({ heartbeatAt: new Date(), currentUrl })

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -15,16 +15,18 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { and, asc, desc, eq, gt, inArray, lt } from 'drizzle-orm';
 import { client, db } from './db';
-import { syncRun, worker } from '../src/lib/server/db/schema';
+import { syncRun } from '../src/lib/server/db/schema';
 import type { SyncRun } from '../src/lib/server/db/crawl.schema';
 import { applyMigrations } from '../src/lib/server/db/migrator';
 import { SYNC_SCHEDULE_MS, STALE_RUN_MS } from './config';
 import { executeRun, executeSync } from './crawl';
 import { executeExtract } from './extract';
 import { executeEmbed } from './embed';
+import { deregisterWorker, sweepStaleWorkers, upsertWorker, type WorkerIdentity } from './registry';
 
 const WORKER_HOST = process.env.HOSTNAME ?? hostname();
 const WORKER_ID = `${WORKER_HOST}-${process.pid}-${crypto.randomUUID().slice(0, 8)}`;
+const IDENTITY: WorkerIdentity = { id: WORKER_ID, host: WORKER_HOST, pid: process.pid };
 const POLL_INTERVAL_MS = 3000;
 const MAINTENANCE_INTERVAL_MS = 30_000;
 const ACTIVE = ['queued', 'running', 'paused'] as const;
@@ -131,59 +133,6 @@ async function reapStaleRuns(): Promise<void> {
 	if (reaped.length) console.log(`reaped ${reaped.length} stale run(s)`);
 }
 
-/** Upsert this process's registry row (identity + role + last-seen). Called from
- *  the maintenance tick (as a standby refresh) and on each claim/standby/finish
- *  transition, so the live worker set is observable even though the single-writer
- *  guard keeps standbys from touching any run row. The active worker additionally
- *  refreshes this row on every crawl heartbeat (see writeHeartbeat), so a long run
- *  never lets its last-seen go stale and get swept. Best-effort: a registry write
- *  failing must never disturb crawling. */
-async function registerWorker(
-	role: 'active' | 'standby',
-	runId: string | null,
-	phase: string | null
-): Promise<void> {
-	try {
-		const now = new Date();
-		await db
-			.insert(worker)
-			.values({
-				id: WORKER_ID,
-				host: WORKER_HOST,
-				pid: process.pid,
-				role,
-				runId,
-				phase,
-				lastSeenAt: now
-			})
-			.onConflictDoUpdate({ target: worker.id, set: { role, runId, phase, lastSeenAt: now } });
-	} catch (e) {
-		console.error('worker registry upsert failed:', e instanceof Error ? e.message : e);
-	}
-}
-
-/** Drop registry rows whose last-seen is older than the stale threshold — an
- *  exited/killed worker (no graceful self-removal) leaves the live set here. Uses
- *  the same STALE_RUN_MS window as reapStaleRuns, so a dead worker and its
- *  abandoned run age out together. */
-async function sweepStaleWorkers(): Promise<void> {
-	const swept = await db
-		.delete(worker)
-		.where(lt(worker.lastSeenAt, new Date(Date.now() - STALE_RUN_MS)))
-		.returning({ id: worker.id });
-	if (swept.length) console.log(`swept ${swept.length} stale worker registration(s)`);
-}
-
-/** Best-effort self-removal so a graceful shutdown leaves the live set promptly
- *  (a hard kill is handled by sweepStaleWorkers instead). */
-async function deregisterWorker(): Promise<void> {
-	try {
-		await db.delete(worker).where(eq(worker.id, WORKER_ID));
-	} catch {
-		/* best-effort — the sweep will drop it within STALE_RUN_MS regardless */
-	}
-}
-
 /** Auto-schedule: enqueue a `sync` run when enabled, idle, and one is due. */
 async function maybeScheduleSync(): Promise<void> {
 	if (SYNC_SCHEDULE_MS <= 0) return;
@@ -214,23 +163,23 @@ async function pollLoop(publish: boolean): Promise<void> {
 		if (Date.now() - lastMaintenance > MAINTENANCE_INTERVAL_MS) {
 			lastMaintenance = Date.now();
 			await reapStaleRuns();
-			await sweepStaleWorkers();
+			await sweepStaleWorkers(STALE_RUN_MS);
 			// Refresh this process's registry row. Between jobs a worker is a standby
 			// (idle or standing down behind the single-writer guard); the active role is
-			// stamped on claim + each crawl heartbeat, so this refresh is always standby.
-			await registerWorker('standby', null, null);
+			// stamped on claim + each heartbeat, so this refresh is always standby.
+			await upsertWorker(IDENTITY, 'standby', null, null);
 			await maybeScheduleSync();
 		}
 		const run = await claimNext();
 		if (run) {
-			// Flip to active immediately (the crawl heartbeat keeps it fresh mid-run),
+			// Flip to active immediately (the heartbeat keeps it fresh mid-run),
 			// then back to standby when the run returns.
-			await registerWorker('active', run.id, run.currentPhase ?? null);
+			await upsertWorker(IDENTITY, 'active', run.id, run.currentPhase ?? null);
 			await runOne(run, publish);
-			await registerWorker('standby', null, null);
+			await upsertWorker(IDENTITY, 'standby', null, null);
 		} else await Bun.sleep(POLL_INTERVAL_MS);
 	}
-	await deregisterWorker();
+	await deregisterWorker(WORKER_ID);
 	console.log('stopped.');
 }
 

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -10,11 +10,12 @@
 // Publishing is opt-in: without --publish the worker holds blobs in the LOCAL
 // backend only (r2_synced_at null); with --publish it writes through to R2 (the
 // canonical archive) and stamps r2_synced_at. Prod runs pass --publish.
+import { hostname } from 'node:os';
 import { readdirSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { and, asc, desc, eq, gt, inArray, lt } from 'drizzle-orm';
 import { client, db } from './db';
-import { syncRun } from '../src/lib/server/db/schema';
+import { syncRun, worker } from '../src/lib/server/db/schema';
 import type { SyncRun } from '../src/lib/server/db/crawl.schema';
 import { applyMigrations } from '../src/lib/server/db/migrator';
 import { SYNC_SCHEDULE_MS, STALE_RUN_MS } from './config';
@@ -22,7 +23,8 @@ import { executeRun, executeSync } from './crawl';
 import { executeExtract } from './extract';
 import { executeEmbed } from './embed';
 
-const WORKER_ID = `${process.env.HOSTNAME ?? 'worker'}-${process.pid}-${crypto.randomUUID().slice(0, 8)}`;
+const WORKER_HOST = process.env.HOSTNAME ?? hostname();
+const WORKER_ID = `${WORKER_HOST}-${process.pid}-${crypto.randomUUID().slice(0, 8)}`;
 const POLL_INTERVAL_MS = 3000;
 const MAINTENANCE_INTERVAL_MS = 30_000;
 const ACTIVE = ['queued', 'running', 'paused'] as const;
@@ -129,6 +131,59 @@ async function reapStaleRuns(): Promise<void> {
 	if (reaped.length) console.log(`reaped ${reaped.length} stale run(s)`);
 }
 
+/** Upsert this process's registry row (identity + role + last-seen). Called from
+ *  the maintenance tick (as a standby refresh) and on each claim/standby/finish
+ *  transition, so the live worker set is observable even though the single-writer
+ *  guard keeps standbys from touching any run row. The active worker additionally
+ *  refreshes this row on every crawl heartbeat (see writeHeartbeat), so a long run
+ *  never lets its last-seen go stale and get swept. Best-effort: a registry write
+ *  failing must never disturb crawling. */
+async function registerWorker(
+	role: 'active' | 'standby',
+	runId: string | null,
+	phase: string | null
+): Promise<void> {
+	try {
+		const now = new Date();
+		await db
+			.insert(worker)
+			.values({
+				id: WORKER_ID,
+				host: WORKER_HOST,
+				pid: process.pid,
+				role,
+				runId,
+				phase,
+				lastSeenAt: now
+			})
+			.onConflictDoUpdate({ target: worker.id, set: { role, runId, phase, lastSeenAt: now } });
+	} catch (e) {
+		console.error('worker registry upsert failed:', e instanceof Error ? e.message : e);
+	}
+}
+
+/** Drop registry rows whose last-seen is older than the stale threshold — an
+ *  exited/killed worker (no graceful self-removal) leaves the live set here. Uses
+ *  the same STALE_RUN_MS window as reapStaleRuns, so a dead worker and its
+ *  abandoned run age out together. */
+async function sweepStaleWorkers(): Promise<void> {
+	const swept = await db
+		.delete(worker)
+		.where(lt(worker.lastSeenAt, new Date(Date.now() - STALE_RUN_MS)))
+		.returning({ id: worker.id });
+	if (swept.length) console.log(`swept ${swept.length} stale worker registration(s)`);
+}
+
+/** Best-effort self-removal so a graceful shutdown leaves the live set promptly
+ *  (a hard kill is handled by sweepStaleWorkers instead). */
+async function deregisterWorker(): Promise<void> {
+	try {
+		await db.delete(worker).where(eq(worker.id, WORKER_ID));
+	} catch {
+		/* best-effort — the sweep will drop it within STALE_RUN_MS regardless */
+	}
+}
+
 /** Auto-schedule: enqueue a `sync` run when enabled, idle, and one is due. */
 async function maybeScheduleSync(): Promise<void> {
 	if (SYNC_SCHEDULE_MS <= 0) return;
@@ -159,12 +214,23 @@ async function pollLoop(publish: boolean): Promise<void> {
 		if (Date.now() - lastMaintenance > MAINTENANCE_INTERVAL_MS) {
 			lastMaintenance = Date.now();
 			await reapStaleRuns();
+			await sweepStaleWorkers();
+			// Refresh this process's registry row. Between jobs a worker is a standby
+			// (idle or standing down behind the single-writer guard); the active role is
+			// stamped on claim + each crawl heartbeat, so this refresh is always standby.
+			await registerWorker('standby', null, null);
 			await maybeScheduleSync();
 		}
 		const run = await claimNext();
-		if (run) await runOne(run, publish);
-		else await Bun.sleep(POLL_INTERVAL_MS);
+		if (run) {
+			// Flip to active immediately (the crawl heartbeat keeps it fresh mid-run),
+			// then back to standby when the run returns.
+			await registerWorker('active', run.id, run.currentPhase ?? null);
+			await runOne(run, publish);
+			await registerWorker('standby', null, null);
+		} else await Bun.sleep(POLL_INTERVAL_MS);
 	}
+	await deregisterWorker();
 	console.log('stopped.');
 }
 

--- a/worker/registry.ts
+++ b/worker/registry.ts
@@ -1,0 +1,83 @@
+// Worker-process registry helpers, shared by the poll loop (worker/index.ts) and
+// the per-mode heartbeats (crawl / extract / embed). Centralizing the row's shape
+// and the best-effort write policy here means adding a field or changing the
+// failure handling is a one-file edit, not four. Every write is best-effort: a
+// registry failure must never disturb an in-flight run.
+import { eq, lt } from 'drizzle-orm';
+import { db } from './db';
+import { worker } from '../src/lib/server/db/schema';
+
+export type WorkerRole = 'active' | 'standby';
+
+export interface WorkerIdentity {
+	id: string;
+	host: string;
+	pid: number;
+}
+
+/** Upsert this process's registry row (identity + role + last-seen). The insert
+ *  path stamps host/pid + started-at; the update path refreshes role/run/phase and
+ *  last-seen. Called on the maintenance tick (standby refresh) and on each
+ *  claim/finish transition. */
+export async function upsertWorker(
+	identity: WorkerIdentity,
+	role: WorkerRole,
+	runId: string | null,
+	phase: string | null
+): Promise<void> {
+	try {
+		const now = new Date();
+		await db
+			.insert(worker)
+			.values({
+				id: identity.id,
+				host: identity.host,
+				pid: identity.pid,
+				role,
+				runId,
+				phase,
+				lastSeenAt: now
+			})
+			.onConflictDoUpdate({ target: worker.id, set: { role, runId, phase, lastSeenAt: now } });
+	} catch (e) {
+		console.error('worker registry upsert failed:', e instanceof Error ? e.message : e);
+	}
+}
+
+/** Refresh the active worker's row from a heartbeat, so a long run never lets its
+ *  last-seen go stale and get swept by another worker. No-op without a worker id
+ *  (e.g. an unclaimed CLI run). Shared by every mode's heartbeat. */
+export async function refreshActiveWorker(
+	workerId: string | null,
+	runId: string,
+	phase: string
+): Promise<void> {
+	if (!workerId) return;
+	await db
+		.update(worker)
+		.set({ role: 'active', runId, phase, lastSeenAt: new Date() })
+		.where(eq(worker.id, workerId))
+		.catch(() => {});
+}
+
+/** Drop registry rows whose last-seen is older than the stale window — an
+ *  exited/killed worker with no graceful self-removal leaves the live set here.
+ *  Callers pass STALE_RUN_MS so a dead worker and its abandoned run age out
+ *  together (see reapStaleRuns). */
+export async function sweepStaleWorkers(olderThanMs: number): Promise<void> {
+	const swept = await db
+		.delete(worker)
+		.where(lt(worker.lastSeenAt, new Date(Date.now() - olderThanMs)))
+		.returning({ id: worker.id });
+	if (swept.length) console.log(`swept ${swept.length} stale worker registration(s)`);
+}
+
+/** Best-effort self-removal so a graceful shutdown leaves the live set promptly
+ *  (a hard kill is handled by sweepStaleWorkers instead). */
+export async function deregisterWorker(id: string): Promise<void> {
+	try {
+		await db.delete(worker).where(eq(worker.id, id));
+	} catch {
+		/* best-effort — the sweep drops it within the stale window regardless */
+	}
+}


### PR DESCRIPTION
Closes #25

Last child of the #17 dashboard epic. Adds a lightweight **worker registry** (active + standby) and a **progress-stall warning** so worker count, standbys, and heartbeating-but-stuck runs are observable on the dashboard. Single-writer claim/guard behavior is unchanged.

## What changed

- **Schema** (`crawl.schema.ts`): new `worker` registry table (`id`, `host`, `pid`, `role` active|standby, `run_id`, `phase`, `started_at`, `last_seen_at`) + `sync_run.progress_at` marker. Migration `0007_careless_karnak.sql`.
- **Worker** (`index.ts`): every process upserts its own row on the maintenance tick (standby refresh) and on claim/finish transitions; a sweep drops rows older than `STALE_RUN_MS`; best-effort self-removal on SIGINT/SIGTERM. The active worker additionally refreshes its row on each heartbeat (`crawl.ts`/`extract.ts`/`embed.ts`) so a long run never lets its last-seen go stale and get swept.
- **Progress marker** (`crawl.ts`): the heartbeat bumps `progress_at` only when a forward-progress counter (`requestsMade`) advances — never on a progress-less beat. `config.ts` adds `PROGRESS_STALL_MS` (`WORKER_STALL_MINUTES`, default 3).
- **Read model** (`sync.ts`): `getWorkerHealth()` returns the worker set (role, uptime, last-seen age, phase, stale) + derived flags `noActiveWorker` / `staleHeartbeat` / `stalled` / `multipleActive`. Warning only — never auto-fails a run.
- **Dashboard** (`+page.svelte`, `+page.server.ts`, `stream/+server.ts`): a worker-health area in the sync-status card renders the live set + flag badges; standby count is shown but is not itself an alert. Streamed on the aggregate SSE cadence (falls back to the server-load snapshot).

## Acceptance criteria

- [x] 1. Two worker processes show two registry entries — one `active`, one `standby`, correct roles.
- [x] 2. Each worker refreshes last-seen on the maintenance interval; an exited/killed worker leaves the live set within the stale threshold.
- [x] 3. A running worker whose progress counters don't advance for the configured interval, while still heartbeating, is flagged `stalled` and is NOT auto-failed.
- [x] 4. A worker making normal progress is never flagged stalled.
- [x] 5. The dashboard surfaces `no-active-worker`, `stale-heartbeat`, `stalled`, `>1-active-worker`; standby count shown without an alert.
- [x] 6. The single-writer claim/guard behavior is unchanged — extra workers still stand down, no double-processing.

## Verify coverage

Migration: **`0007_careless_karnak.sql`** (`db:generate`; applies cleanly — worker startup applied all 8 migrations against a fresh local DB).

- **Integration (two real worker processes, one local DB):** hostA claimed a queued sync run → registered `active` (phase=sync, heartbeat-fresh); hostB saw the live run → stood down as `standby`. The run's `workerId` was hostA only, single running row — single-writer guard intact (criteria 1, 6). SIGTERM on the standby → its row self-removed ("stopped."); a 30-min-stale bogus row was swept by the live worker's maintenance tick ("swept 1 stale worker registration(s)") (criterion 2). After the run, hostA flipped `active → standby`; SIGTERM → registry empty.
- **Read model (real `getWorkerHealth` against controlled rows):** normal progress → not stalled (4); fresh heartbeat + frozen `progress_at` → `stalled` true AND the run row stays `running` (not auto-failed) (3); active run + zero active workers → `noActiveWorker`; two active rows → `multipleActive`; stale row not counted live but still listed; old heartbeat → `staleHeartbeat`, not `stalled` (5). All checks passed.
- `bun run check` (only pre-existing paraglide/i18n build-artifact errors, none in changed files) · `bun run lint` clean · Svelte MCP autofixer clean on the new markup.

## Code review

Ran `/code-review` (Standards + Spec axes). Spec: faithful, all 6 criteria met, no scope creep, nothing implemented wrong (claim guard body confirmed untouched). Standards: no hard violations; flagged the registry-refresh block as Duplicated Code / Shotgun Surgery.

Addressed in commit `refactor: extract shared worker-registry helpers`: the refresh + upsert/sweep/deregister now live in one module (`worker/registry.ts`, with a shared `WorkerRole` type), called from every mode's heartbeat and the poll loop — one place to touch the row shape or write policy. Re-verified after the refactor (read-model flags + two-process active/standby). The minor "double `getActiveRun` per tick" note is left as-is: `getWorkerHealth` stays a self-contained read model; the extra fetch is one lightweight row on the SSE cadence.

## Notes for the reviewer

- The active worker's registry row is kept fresh from inside the heartbeat in **three** modes (`crawl`/`extract`/`embed`) via the shared `refreshActiveWorker`, so a long non-crawl run isn't falsely swept out of the live set. Those modes never write the progress marker, so they can't false-trigger `stalled`.
- Read-model thresholds are re-derived from the same env vars the worker uses (not imported) to keep the app/worker boundary a Turso-only contract (per CLAUDE.md).
