### PR TITLE
feat(rag): eval harness — retrieval + answer/citation accuracy (#39)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"worker:estimate": "bun run worker/index.ts --mode estimate --once",
 		"worker:extract": "bun run worker/index.ts --mode extract --once",
 		"worker:embed": "bun run worker/index.ts --mode embed --once",
+		"eval": "bun run worker/eval/run.ts",
 		"blobs:sync": "bun run worker/sync-blobs.ts --both",
 		"blobs:push": "bun run worker/sync-blobs.ts --push",
 		"blobs:pull": "bun run worker/sync-blobs.ts --pull",

--- a/worker/eval/corpus.ts
+++ b/worker/eval/corpus.ts
@@ -13,8 +13,13 @@
 // abstain/fallback topics (shellfish fees, election dates, fireworks times,
 // zoning) — so the abstention bar is actually tested: the answerer only has real
 // records for the questions it should ground, and nothing to lean on for the rest.
-import type { Client } from '@libsql/client';
-import type { Embedder } from '../embeddings';
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createClient, type Client } from '@libsql/client';
+import { applyMigrations } from '../../src/lib/server/db/migrator';
+import { makeFakeEmbedder, type Embedder } from '../embeddings';
 import { makeFakeLlm, type LlmClient } from '../../src/lib/server/rag/llm';
 import { SOURCES } from './questions';
 
@@ -88,11 +93,11 @@ export async function seedCorpus(
 	const vectors = await embedder.embed(docs.map((d) => d.text));
 	for (let i = 0; i < docs.length; i++) {
 		const d = docs[i];
-		const path = new URL(d.url).pathname;
+		const u = new URL(d.url);
 		await client.execute({
 			sql: `INSERT INTO resource (id, url, url_hash, host, path, kind, title, state, priority)
 			      VALUES (?, ?, ?, ?, ?, 'page', ?, ?, 1)`,
-			args: [d.id, d.url, `h-${d.id}`, new URL(d.url).host, path, d.title, d.state]
+			args: [d.id, d.url, `h-${d.id}`, u.host, u.pathname, d.title, d.state]
 		});
 		await client.execute({
 			sql: `INSERT INTO chunk (id, resource_id, source_sha, chunk_index, text, char_start, char_end, embedding, embedder, url, title, kind, created_at)
@@ -111,6 +116,34 @@ export async function seedCorpus(
 			]
 		});
 	}
+}
+
+/** A ready-to-query offline fixture DB: a throwaway libSQL file with the real
+ *  migrations applied and the fixture corpus seeded (fake embedder). Returns the
+ *  client, the embedder used (reuse it so query and chunk vectors match), and a
+ *  `cleanup` that closes the client and removes the temp dir. */
+export function createFixtureDb(docs: FixtureDoc[] = fixtureDocs): Promise<{
+	client: Client;
+	embedder: Embedder;
+	cleanup: () => void;
+}> {
+	const drizzleDir = fileURLToPath(new URL('../../drizzle/', import.meta.url));
+	const tmp = mkdtempSync(join(tmpdir(), 'rag-eval-'));
+	const client = createClient({ url: `file:${join(tmp, 'eval.db')}` });
+	const embedder = makeFakeEmbedder();
+	const entries = readdirSync(drizzleDir)
+		.filter((f) => f.endsWith('.sql'))
+		.map((name) => ({ name, sql: readFileSync(join(drizzleDir, name), 'utf8') }));
+	return applyMigrations(client, entries)
+		.then(() => seedCorpus(client, embedder, docs))
+		.then(() => ({
+			client,
+			embedder,
+			cleanup: () => {
+				client.close();
+				rmSync(tmp, { recursive: true, force: true });
+			}
+		}));
 }
 
 // ---------------------------------------------------------------------------

--- a/worker/eval/corpus.ts
+++ b/worker/eval/corpus.ts
@@ -1,0 +1,299 @@
+// Offline fixtures for the eval harness (#39): a tiny hand-written archive plus a
+// deterministic "grounding" LLM, so the whole retrieve → answer pipeline can be
+// exercised in CI with NO network, NO API key, and NO DATABASE_URL.
+//
+// Why fixtures and not the real archive: the offline run must be reproducible and
+// self-contained. We seed a handful of resources + chunks (embedded with the fake
+// hashing embedder from #35) into a throwaway libSQL DB, then drive `retrieve()`
+// against it with the SAME fake embedder — exactly the seam the #36 retrieval
+// test uses.
+//
+// The corpus deliberately COVERS the grounded questions (beach stickers, town
+// meeting, dogs at Kent's Point, town government) and deliberately OMITS the
+// abstain/fallback topics (shellfish fees, election dates, fireworks times,
+// zoning) — so the abstention bar is actually tested: the answerer only has real
+// records for the questions it should ground, and nothing to lean on for the rest.
+import type { Client } from '@libsql/client';
+import type { Embedder } from '../embeddings';
+import { makeFakeLlm, type LlmClient } from '../../src/lib/server/rag/llm';
+import { SOURCES } from './questions';
+
+export interface FixtureDoc {
+	id: string;
+	url: string;
+	title: string;
+	/** 'active' (live, retrievable) | 'gone' (excluded by retrieval's state filter). */
+	state: string;
+	text: string;
+}
+
+// Six live resources: four cover the grounded questions, two (library, transfer
+// station) are unrelated filler so retrieval has to actually rank, not just return
+// the only thing present.
+export const fixtureDocs: FixtureDoc[] = [
+	{
+		id: 'res-beach',
+		url: SOURCES.beach,
+		title: 'Beach Stickers & Parking Permits',
+		state: 'active',
+		text: 'Nauset Beach and Skaket Beach resident parking stickers and beach permits. Residents may purchase an annual beach parking sticker for vehicle parking at the Nauset Beach gate. Apply for your beach parking sticker at the Parks and Beaches department at Town Hall.'
+	},
+	{
+		id: 'res-town-meeting',
+		url: SOURCES.townMeeting,
+		title: 'Annual Town Meeting',
+		state: 'active',
+		text: 'The Annual Town Meeting is held each spring at the Nauset Regional Middle School. Registered voters gather at the annual town meeting to vote on the town budget and the warrant articles. A special town meeting may also be called during the year.'
+	},
+	{
+		id: 'res-kents-point',
+		url: SOURCES.kentsPoint,
+		title: "Kent's Point Conservation Area",
+		state: 'active',
+		text: "Dogs are allowed at Kent's Point Conservation Area under voice control and off-leash during the off-season. In season, dog owners must leash dogs. Kent's Point rules cover dogs and pets on the conservation trails and the town landing."
+	},
+	{
+		id: 'res-government',
+		url: SOURCES.government,
+		title: 'Form of Government',
+		state: 'active',
+		text: 'The Town of Orleans is governed by a five-member Select Board together with a Town Administrator who runs the day-to-day operations. The Select Board sets policy while the Town Administrator manages the departments and staff. This open-town-meeting form of government gives voters the final say.'
+	},
+	{
+		id: 'res-library',
+		url: 'https://www.town.orleans.ma.us/snow-library',
+		title: 'Snow Library',
+		state: 'active',
+		text: 'Snow Library offers a summer reading program, museum passes, and childrens story hours. The library is open Tuesday through Saturday and lends books, audiobooks, and digital media to cardholders.'
+	},
+	{
+		id: 'res-transfer-station',
+		url: 'https://www.town.orleans.ma.us/transfer-station',
+		title: 'Transfer Station & Recycling',
+		state: 'active',
+		text: 'The Orleans Transfer Station and recycling center accepts household trash and recycling from residents who display a valid disposal sticker on their vehicle. Yard waste and bulky items are handled on posted days.'
+	}
+];
+
+/**
+ * Seed `docs` into a libSQL DB: one resource + one chunk each, embedded with
+ * `embedder`. Mirrors the insert shape used by the #36 retrieval test. The caller
+ * owns the client (typically a throwaway file/in-memory DB with migrations applied).
+ */
+export async function seedCorpus(
+	client: Client,
+	embedder: Embedder,
+	docs: FixtureDoc[] = fixtureDocs
+): Promise<void> {
+	const vectors = await embedder.embed(docs.map((d) => d.text));
+	for (let i = 0; i < docs.length; i++) {
+		const d = docs[i];
+		const path = new URL(d.url).pathname;
+		await client.execute({
+			sql: `INSERT INTO resource (id, url, url_hash, host, path, kind, title, state, priority)
+			      VALUES (?, ?, ?, ?, ?, 'page', ?, ?, 1)`,
+			args: [d.id, d.url, `h-${d.id}`, new URL(d.url).host, path, d.title, d.state]
+		});
+		await client.execute({
+			sql: `INSERT INTO chunk (id, resource_id, source_sha, chunk_index, text, char_start, char_end, embedding, embedder, url, title, kind, created_at)
+			      VALUES (?, ?, ?, 0, ?, 0, ?, vector32(?), ?, ?, ?, 'page', ?)`,
+			args: [
+				`chunk-${d.id}`,
+				d.id,
+				`sha-${d.id}`,
+				d.text,
+				d.text.length,
+				JSON.stringify(vectors[i]),
+				embedder.id,
+				d.url,
+				d.title,
+				Date.now()
+			]
+		});
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic "grounding" fake LLM.
+//
+// A real answer model reads the retrieved context and decides grounded /
+// fallback / abstained. This fake mimics that decision with a transparent
+// lexical rule so CI is reproducible: it measures how well the question's
+// content words are covered by the retrieved passages.
+//
+//   • strong coverage of a passage → grounded, citing that passage's source(s).
+//   • weak coverage + an explanatory phrasing ("in general", "how does X work",
+//     "why do …") → fallback (labeled general knowledge, no citation).
+//   • weak coverage otherwise → abstained (the safe default — never guess a
+//     specific the records don't support).
+//
+// This is not semantic understanding; it's a stand-in that makes the seeded
+// corpus design matter and keeps the offline eval honest and deterministic. Swap
+// in the real Anthropic client (creds present) for a semantic judgement.
+// ---------------------------------------------------------------------------
+const STOPWORDS = new Set([
+	'the',
+	'a',
+	'an',
+	'and',
+	'or',
+	'of',
+	'to',
+	'in',
+	'on',
+	'at',
+	'for',
+	'is',
+	'are',
+	'do',
+	'does',
+	'did',
+	'how',
+	'what',
+	'when',
+	'who',
+	'why',
+	'will',
+	'can',
+	'may',
+	'be',
+	'this',
+	'that',
+	'it',
+	'as',
+	'get',
+	'you',
+	'your',
+	'my',
+	'i',
+	'we',
+	'they',
+	'them',
+	'with',
+	'from',
+	'year',
+	'time',
+	'their'
+]);
+
+/** Lowercase → alphanumeric tokens → drop stopwords/short tokens → strip a
+ *  trailing plural 's', so "permits"/"permit" and "towns"/"town" match. */
+function contentWords(text: string): Set<string> {
+	const words = new Set<string>();
+	for (const raw of text.toLowerCase().match(/[\p{L}\p{N}]+/gu) ?? []) {
+		if (raw.length < 3 || STOPWORDS.has(raw)) continue;
+		words.add(raw.length > 3 && raw.endsWith('s') ? raw.slice(0, -1) : raw);
+	}
+	return words;
+}
+
+/** Fraction of the question's content words present in `text`. */
+function coverage(qWords: Set<string>, text: string): number {
+	if (qWords.size === 0) return 0;
+	const words = contentWords(text);
+	let hit = 0;
+	for (const w of qWords) if (words.has(w)) hit++;
+	return hit / qWords.size;
+}
+
+/** Explanatory / contextual phrasing that licenses a labeled fallback answer,
+ *  matching the answer-stage policy's "general how does X work / why" wording. */
+function isExplanatory(question: string): boolean {
+	return /\b(in general|generally|how does|how do .*\bwork|why do|why does|what does .* mean|explain)\b/i.test(
+		question
+	);
+}
+
+interface ParsedPassage {
+	text: string;
+	url: string;
+}
+
+/** Recover (passage text → source url) pairs from the assembled user message so
+ *  the fake can cite the specific sources it grounded on. Best-effort: returns []
+ *  when nothing was retrieved (context is the empty-corpus placeholder). */
+function parsePassages(userMessage: string): ParsedPassage[] {
+	// Map citation number → url from the "Sources:" section.
+	const urlByNum = new Map<number, string>();
+	for (const m of userMessage.matchAll(/^\[(\d+)\]\s+.*?—\s+(\S+)\s*$/gm)) {
+		urlByNum.set(Number(m[1]), m[2]);
+	}
+	// Body passages: "[n] text" spans, before the "Sources:" list. A source-list
+	// line also matches "[n] …" but carries an em-dash + url, so skip those.
+	const passages: ParsedPassage[] = [];
+	for (const m of userMessage.matchAll(/^\[(\d+)\]\s+([\s\S]*?)(?=\n\n\[\d+\]|\n\nSources:|$)/gm)) {
+		const num = Number(m[1]);
+		const text = m[2].trim();
+		if (/—\s+https?:\/\//.test(text)) continue; // this is a Sources: line
+		const url = urlByNum.get(num);
+		if (url) passages.push({ text, url });
+	}
+	return passages;
+}
+
+/** Pull the question back out of the assembled user message. */
+function parseQuestion(userMessage: string): string {
+	const m = userMessage.match(/^Question:\s*(.*)$/m);
+	return m ? m[1].trim() : '';
+}
+
+export interface GroundingFakeOptions {
+	/** Min per-passage content-word coverage to treat as grounded. Default 0.5. */
+	groundThreshold?: number;
+}
+
+/**
+ * Build a deterministic grounding LLM. Reads the assembled prompt, scores how well
+ * each retrieved passage covers the question, and returns the strict-JSON answer
+ * contract answer.ts expects — choosing grounded / fallback / abstained.
+ */
+export function makeGroundingFakeLlm(opts: GroundingFakeOptions = {}): LlmClient {
+	const threshold = opts.groundThreshold ?? 0.5;
+	return makeFakeLlm((req) => {
+		const user = req.messages.map((m) => m.content).join('\n');
+		const question = parseQuestion(user);
+		const qWords = contentWords(question);
+		const passages = parsePassages(user);
+
+		let best = 0;
+		const cited = new Set<string>();
+		for (const p of passages) {
+			const cov = coverage(qWords, p.text);
+			if (cov > best) best = cov;
+			if (cov >= threshold) cited.add(p.url);
+		}
+
+		if (best >= threshold && cited.size > 0) {
+			const supporting = passages.find((p) => coverage(qWords, p.text) >= threshold);
+			const snippet = supporting ? firstSentence(supporting.text) : '';
+			return JSON.stringify({
+				mode: 'grounded',
+				answer: `According to the town's records, ${snippet}`,
+				citations: [...cited]
+			});
+		}
+
+		if (isExplanatory(question)) {
+			return JSON.stringify({
+				mode: 'fallback',
+				answer: `In general terms: ${question.replace(/[?.]+$/, '')} depends on the applicable rules; the town's own records don't cover this.`,
+				citations: []
+			});
+		}
+
+		return JSON.stringify({
+			mode: 'abstained',
+			answer:
+				"That specific isn't in the town's records. Check the relevant town department or board, or contact the Town Clerk.",
+			citations: []
+		});
+	}, 'fake-grounding');
+}
+
+/** First sentence of a passage, for a plausible grounded answer body. */
+function firstSentence(text: string): string {
+	const trimmed = text.trim();
+	const dot = trimmed.indexOf('. ');
+	const s = dot > 0 ? trimmed.slice(0, dot + 1) : trimmed;
+	return s.charAt(0).toLowerCase() + s.slice(1);
+}

--- a/worker/eval/harness.test.ts
+++ b/worker/eval/harness.test.ts
@@ -6,47 +6,28 @@
 // scores abstained and a grounded one scores grounded+cited. All offline: no
 // network, no DATABASE_URL, no API key.
 import { afterAll, beforeAll, describe, it, expect } from 'vitest';
-import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { createClient, type Client } from '@libsql/client';
-import { applyMigrations } from '../../src/lib/server/db/migrator';
-import { makeFakeEmbedder } from '../embeddings';
 import { retrieve } from '../../src/lib/server/rag/retrieve';
 import { answer } from '../../src/lib/server/rag/answer';
 import { questions } from './questions';
-import { seedCorpus, makeGroundingFakeLlm } from './corpus';
+import { createFixtureDb, makeGroundingFakeLlm } from './corpus';
 import { runEval, computeMetrics, formatReport, type EvalReport } from './harness';
 
-const drizzleDir = fileURLToPath(new URL('../../drizzle/', import.meta.url));
-
-let tmp: string;
-let client: Client;
+let cleanup: () => void;
 let report: EvalReport;
 
 beforeAll(async () => {
-	tmp = mkdtempSync(join(tmpdir(), 'rag-eval-test-'));
-	client = createClient({ url: `file:${join(tmp, 'eval.db')}` });
-	const entries = readdirSync(drizzleDir)
-		.filter((f) => f.endsWith('.sql'))
-		.map((name) => ({ name, sql: readFileSync(join(drizzleDir, name), 'utf8') }));
-	await applyMigrations(client, entries);
-
-	const embedder = makeFakeEmbedder();
-	await seedCorpus(client, embedder);
-
+	const fixture = await createFixtureDb();
+	cleanup = fixture.cleanup;
 	report = await runEval(questions, {
 		retrieve,
 		answer,
-		retrieveOptions: { client, embedder, topK: 4 },
+		retrieveOptions: { client: fixture.client, embedder: fixture.embedder, topK: 4 },
 		answerOptions: { llm: makeGroundingFakeLlm() }
 	});
 });
 
 afterAll(() => {
-	client?.close();
-	if (tmp) rmSync(tmp, { recursive: true, force: true });
+	cleanup?.();
 });
 
 describe('eval harness', () => {

--- a/worker/eval/harness.test.ts
+++ b/worker/eval/harness.test.ts
@@ -1,0 +1,149 @@
+// Eval-harness test (#39). Applies the REAL drizzle migrations to a throwaway
+// libSQL DB, seeds the fixture corpus with the deterministic fake embedder, then
+// runs the full question set through retrieve() + answer() with the fake grounding
+// LLM. Proves the harness computes retrieval hit-rate, mode-correctness, and
+// citation-validity — and, crucially, that a should-abstain question actually
+// scores abstained and a grounded one scores grounded+cited. All offline: no
+// network, no DATABASE_URL, no API key.
+import { afterAll, beforeAll, describe, it, expect } from 'vitest';
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createClient, type Client } from '@libsql/client';
+import { applyMigrations } from '../../src/lib/server/db/migrator';
+import { makeFakeEmbedder } from '../embeddings';
+import { retrieve } from '../../src/lib/server/rag/retrieve';
+import { answer } from '../../src/lib/server/rag/answer';
+import { questions } from './questions';
+import { seedCorpus, makeGroundingFakeLlm } from './corpus';
+import { runEval, computeMetrics, formatReport, type EvalReport } from './harness';
+
+const drizzleDir = fileURLToPath(new URL('../../drizzle/', import.meta.url));
+
+let tmp: string;
+let client: Client;
+let report: EvalReport;
+
+beforeAll(async () => {
+	tmp = mkdtempSync(join(tmpdir(), 'rag-eval-test-'));
+	client = createClient({ url: `file:${join(tmp, 'eval.db')}` });
+	const entries = readdirSync(drizzleDir)
+		.filter((f) => f.endsWith('.sql'))
+		.map((name) => ({ name, sql: readFileSync(join(drizzleDir, name), 'utf8') }));
+	await applyMigrations(client, entries);
+
+	const embedder = makeFakeEmbedder();
+	await seedCorpus(client, embedder);
+
+	report = await runEval(questions, {
+		retrieve,
+		answer,
+		retrieveOptions: { client, embedder, topK: 4 },
+		answerOptions: { llm: makeGroundingFakeLlm() }
+	});
+});
+
+afterAll(() => {
+	client?.close();
+	if (tmp) rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('eval harness', () => {
+	it('scores every question in the set', () => {
+		expect(report.outcomes).toHaveLength(questions.length);
+		// The set spans all three expected modes — grounding AND abstention are tested.
+		const modes = new Set(questions.map((q) => q.expectedMode));
+		expect(modes).toEqual(new Set(['grounded', 'abstained', 'fallback']));
+	});
+
+	it('computes the three headline metrics as fractions in [0,1]', () => {
+		const m = report.metrics;
+		for (const v of [m.retrievalHitRate, m.modeCorrectness, m.citationValidity]) {
+			expect(v).toBeGreaterThanOrEqual(0);
+			expect(v).toBeLessThanOrEqual(1);
+		}
+		expect(m.total).toBe(questions.length);
+		expect(m.retrievalEligible).toBeGreaterThan(0);
+	});
+
+	it('every cited URL was actually retrieved (citation-validity holds)', () => {
+		// The hard #37 invariant — a failure here is a real regression.
+		expect(report.metrics.citationValidity).toBe(1);
+		for (const o of report.outcomes) {
+			for (const c of o.citations) expect(o.retrievedUrls).toContain(c);
+		}
+	});
+
+	it('a grounded question answers grounded, cited, and retrieves its source', () => {
+		const o = report.outcomes.find((x) => x.question.includes('beach parking sticker'));
+		expect(o).toBeDefined();
+		expect(o!.actualMode).toBe('grounded');
+		expect(o!.citations.length).toBeGreaterThan(0);
+		expect(o!.retrievalHit).toBe(true);
+	});
+
+	it('a should-abstain hard-specific question actually abstains', () => {
+		// The abstention bar: a fee the archive does not cover must NOT be answered.
+		const o = report.outcomes.find((x) => x.question.includes('shellfish permit'));
+		expect(o).toBeDefined();
+		expect(o!.expectedMode).toBe('abstained');
+		expect(o!.actualMode).toBe('abstained');
+		expect(o!.citations).toEqual([]);
+	});
+
+	it('an explanatory question falls back with a labeled, uncited answer', () => {
+		const o = report.outcomes.find((x) => x.question.includes('coastal towns'));
+		expect(o).toBeDefined();
+		expect(o!.actualMode).toBe('fallback');
+		expect(o!.citations).toEqual([]);
+		expect(o!.answer.toLowerCase()).toContain("not from the town's records");
+	});
+
+	it('grounded and abstained cohorts are both fully correct offline', () => {
+		// Deterministic fixtures → the fake pipeline nails these two cohorts, which
+		// is what guards the accuracy/abstention bar in CI.
+		const { byMode } = report.metrics;
+		expect(byMode.grounded.correct).toBe(byMode.grounded.total);
+		expect(byMode.abstained.correct).toBe(byMode.abstained.total);
+	});
+
+	it('formatReport renders per-question lines and the aggregate metrics', () => {
+		const text = formatReport(report);
+		expect(text).toContain('retrieval hit-rate:');
+		expect(text).toContain('mode-correctness:');
+		expect(text).toContain('citation-validity:');
+		expect(text).toContain(questions[0].question);
+	});
+
+	it('computeMetrics counts hit-rate only over questions with an expected source', () => {
+		const m = computeMetrics([
+			{
+				question: 'q1',
+				expectedMode: 'grounded',
+				actualMode: 'grounded',
+				modeCorrect: true,
+				expectedSource: 'https://x/a',
+				retrievalHit: true,
+				citations: ['https://x/a'],
+				citationValid: true,
+				retrievedUrls: ['https://x/a'],
+				answer: 'a'
+			},
+			{
+				question: 'q2',
+				expectedMode: 'abstained',
+				actualMode: 'abstained',
+				modeCorrect: true,
+				retrievalHit: null,
+				citations: [],
+				citationValid: true,
+				retrievedUrls: [],
+				answer: 'b'
+			}
+		]);
+		expect(m.retrievalEligible).toBe(1);
+		expect(m.retrievalHitRate).toBe(1);
+		expect(m.modeCorrectness).toBe(1);
+	});
+});

--- a/worker/eval/harness.ts
+++ b/worker/eval/harness.ts
@@ -54,11 +54,12 @@ export interface EvalReport {
 export interface RunEvalDeps {
 	retrieve: (question: string, opts?: RetrieveOptions) => Promise<RetrievalResult>;
 	answer: (question: string, opts?: AnswerOptions) => Promise<Answer>;
-	/** Retrieval knobs (injected client/embedder, topK) — shared by both calls so
-	 *  the hit-rate we measure is the same retrieval the answerer grounded on. */
+	/** Retrieval knobs (injected client/embedder, topK) for the harness's own
+	 *  retrieval call. */
 	retrieveOptions?: RetrieveOptions;
-	/** Answer knobs (injected llm, model). `retrieveOptions` is forwarded for you. */
-	answerOptions?: Omit<AnswerOptions, 'retrieveOptions'>;
+	/** Answer knobs (injected llm, model). Retrieval is wired in by the harness —
+	 *  see below — so `retrieve`/`retrieveOptions` are not accepted here. */
+	answerOptions?: Omit<AnswerOptions, 'retrieve' | 'retrieveOptions'>;
 }
 
 /** Run the whole question set, scoring each question. Deterministic given
@@ -66,13 +67,16 @@ export interface RunEvalDeps {
 export async function runEval(questions: EvalQuestion[], deps: RunEvalDeps): Promise<EvalReport> {
 	const outcomes: EvalOutcome[] = [];
 	for (const q of questions) {
-		// One retrieval for the hit-rate metric; the answerer runs its own retrieval
-		// with the SAME options, so — being deterministic — it grounds on the same set.
+		// Retrieve ONCE and hand the very same result to the answerer (answer()
+		// accepts a `retrieve` override). So the citations we validate are grounded
+		// in exactly the passages we scored for hit-rate — sound even in real mode,
+		// where a second embed+ANN call could otherwise diverge — and we don't pay
+		// for two retrievals per question.
 		const retrieval = await deps.retrieve(q.question, deps.retrieveOptions);
 		const retrievedUrls = retrieval.sources.map((s) => s.url);
 		const a = await deps.answer(q.question, {
 			...deps.answerOptions,
-			retrieveOptions: deps.retrieveOptions
+			retrieve: async () => retrieval
 		});
 
 		const retrievalHit = q.expectedSource ? retrievedUrls.includes(q.expectedSource) : null;
@@ -102,7 +106,11 @@ export function computeMetrics(outcomes: EvalOutcome[]): EvalMetrics {
 	const modeCorrect = outcomes.filter((o) => o.modeCorrect).length;
 	const citationValid = outcomes.filter((o) => o.citationValid).length;
 
-	const byMode = { grounded: z(), fallback: z(), abstained: z() } as EvalMetrics['byMode'];
+	const byMode = {
+		grounded: zeroCounter(),
+		fallback: zeroCounter(),
+		abstained: zeroCounter()
+	} as EvalMetrics['byMode'];
 	for (const o of outcomes) {
 		byMode[o.expectedMode].total++;
 		if (o.modeCorrect) byMode[o.expectedMode].correct++;
@@ -121,7 +129,7 @@ export function computeMetrics(outcomes: EvalOutcome[]): EvalMetrics {
 	};
 }
 
-function z(): { total: number; correct: number } {
+function zeroCounter(): { total: number; correct: number } {
 	return { total: 0, correct: 0 };
 }
 
@@ -154,6 +162,7 @@ export function formatReport(report: EvalReport, title = 'RAG eval'): string {
 				o.citationValid ? `${o.citations.length} valid` : 'INVALID'
 			}`
 		);
+		if (o.note) lines.push(`    · ${o.note}`);
 	}
 	lines.push('─'.repeat(72));
 	lines.push(

--- a/worker/eval/harness.ts
+++ b/worker/eval/harness.ts
@@ -1,0 +1,196 @@
+// The eval engine (#39): runs a question set through retrieval + answer and
+// scores three things the RAG epic (#32) cares about —
+//
+//   • retrieval hit-rate — for questions that name an expected source, did that
+//     source actually surface in retrieval? (Is the right document findable?)
+//   • mode-correctness   — did the answerer choose the expected mode? i.e. did it
+//     ground when the archive covers the question AND abstain when it doesn't.
+//   • citation-validity  — is every cited URL one that retrieval actually returned?
+//     (#37 enforces this, so a failure here is a real regression.)
+//
+// The engine is pure and injectable: it takes `retrieve`/`answer` functions plus
+// their options, so the offline runner wires in a seeded DB + fakes and a real
+// run wires in the live DB + real models — the scoring code is identical either way.
+import type { RetrievalResult, RetrieveOptions } from '../../src/lib/server/rag/retrieve';
+import type { Answer, AnswerMode, AnswerOptions } from '../../src/lib/server/rag/answer';
+import type { EvalQuestion } from './questions';
+
+export interface EvalOutcome {
+	question: string;
+	expectedMode: AnswerMode;
+	actualMode: AnswerMode;
+	modeCorrect: boolean;
+	/** null when the question names no expected source (not part of hit-rate). */
+	expectedSource?: string;
+	retrievalHit: boolean | null;
+	citations: string[];
+	citationValid: boolean;
+	retrievedUrls: string[];
+	answer: string;
+	note?: string;
+}
+
+export interface EvalMetrics {
+	total: number;
+	/** Retrieval hit-rate over questions that declare an expected source. */
+	retrievalHitRate: number;
+	retrievalHits: number;
+	retrievalEligible: number;
+	/** Fraction of questions whose answer mode matched expectation. */
+	modeCorrectness: number;
+	modeCorrect: number;
+	/** Fraction of questions whose citations were all genuinely retrieved. */
+	citationValidity: number;
+	citationValid: number;
+	/** Per-expected-mode correctness, so abstention can be read separately. */
+	byMode: Record<AnswerMode, { total: number; correct: number }>;
+}
+
+export interface EvalReport {
+	outcomes: EvalOutcome[];
+	metrics: EvalMetrics;
+}
+
+export interface RunEvalDeps {
+	retrieve: (question: string, opts?: RetrieveOptions) => Promise<RetrievalResult>;
+	answer: (question: string, opts?: AnswerOptions) => Promise<Answer>;
+	/** Retrieval knobs (injected client/embedder, topK) — shared by both calls so
+	 *  the hit-rate we measure is the same retrieval the answerer grounded on. */
+	retrieveOptions?: RetrieveOptions;
+	/** Answer knobs (injected llm, model). `retrieveOptions` is forwarded for you. */
+	answerOptions?: Omit<AnswerOptions, 'retrieveOptions'>;
+}
+
+/** Run the whole question set, scoring each question. Deterministic given
+ *  deterministic deps (fake embedder + fake LLM). */
+export async function runEval(questions: EvalQuestion[], deps: RunEvalDeps): Promise<EvalReport> {
+	const outcomes: EvalOutcome[] = [];
+	for (const q of questions) {
+		// One retrieval for the hit-rate metric; the answerer runs its own retrieval
+		// with the SAME options, so — being deterministic — it grounds on the same set.
+		const retrieval = await deps.retrieve(q.question, deps.retrieveOptions);
+		const retrievedUrls = retrieval.sources.map((s) => s.url);
+		const a = await deps.answer(q.question, {
+			...deps.answerOptions,
+			retrieveOptions: deps.retrieveOptions
+		});
+
+		const retrievalHit = q.expectedSource ? retrievedUrls.includes(q.expectedSource) : null;
+		const citationValid = a.citations.every((c) => retrievedUrls.includes(c));
+
+		outcomes.push({
+			question: q.question,
+			expectedMode: q.expectedMode,
+			actualMode: a.mode,
+			modeCorrect: a.mode === q.expectedMode,
+			expectedSource: q.expectedSource,
+			retrievalHit,
+			citations: a.citations,
+			citationValid,
+			retrievedUrls,
+			answer: a.answer,
+			note: q.note
+		});
+	}
+	return { outcomes, metrics: computeMetrics(outcomes) };
+}
+
+export function computeMetrics(outcomes: EvalOutcome[]): EvalMetrics {
+	const total = outcomes.length;
+	const eligible = outcomes.filter((o) => o.retrievalHit !== null);
+	const retrievalHits = eligible.filter((o) => o.retrievalHit === true).length;
+	const modeCorrect = outcomes.filter((o) => o.modeCorrect).length;
+	const citationValid = outcomes.filter((o) => o.citationValid).length;
+
+	const byMode = { grounded: z(), fallback: z(), abstained: z() } as EvalMetrics['byMode'];
+	for (const o of outcomes) {
+		byMode[o.expectedMode].total++;
+		if (o.modeCorrect) byMode[o.expectedMode].correct++;
+	}
+
+	return {
+		total,
+		retrievalEligible: eligible.length,
+		retrievalHits,
+		retrievalHitRate: eligible.length ? retrievalHits / eligible.length : NaN,
+		modeCorrect,
+		modeCorrectness: total ? modeCorrect / total : NaN,
+		citationValid,
+		citationValidity: total ? citationValid / total : NaN,
+		byMode
+	};
+}
+
+function z(): { total: number; correct: number } {
+	return { total: 0, correct: 0 };
+}
+
+// ---------------------------------------------------------------------------
+// Reporting
+// ---------------------------------------------------------------------------
+const pct = (n: number): string => (Number.isNaN(n) ? 'n/a' : `${(n * 100).toFixed(0)}%`);
+
+function modeTag(o: EvalOutcome): string {
+	if (o.modeCorrect) return `${o.actualMode}`;
+	return `${o.actualMode} (want ${o.expectedMode})`;
+}
+
+function hitTag(o: EvalOutcome): string {
+	if (o.retrievalHit === null) return '—';
+	return o.retrievalHit ? 'hit' : 'MISS';
+}
+
+/** A readable per-question + aggregate plain-text report for the terminal. */
+export function formatReport(report: EvalReport, title = 'RAG eval'): string {
+	const { outcomes, metrics } = report;
+	const lines: string[] = [];
+	lines.push(`\n${title} — ${outcomes.length} questions`);
+	lines.push('─'.repeat(72));
+	for (const o of outcomes) {
+		const ok = o.modeCorrect && o.citationValid && o.retrievalHit !== false;
+		lines.push(`${ok ? '✓' : '✗'} ${o.question}`);
+		lines.push(
+			`    mode: ${modeTag(o)}   retrieval: ${hitTag(o)}   citations: ${
+				o.citationValid ? `${o.citations.length} valid` : 'INVALID'
+			}`
+		);
+	}
+	lines.push('─'.repeat(72));
+	lines.push(
+		`retrieval hit-rate:   ${pct(metrics.retrievalHitRate)}  (${metrics.retrievalHits}/${metrics.retrievalEligible} sourced questions)`
+	);
+	lines.push(
+		`mode-correctness:     ${pct(metrics.modeCorrectness)}  (${metrics.modeCorrect}/${metrics.total})`
+	);
+	lines.push(
+		`citation-validity:    ${pct(metrics.citationValidity)}  (${metrics.citationValid}/${metrics.total})`
+	);
+	lines.push('by expected mode:');
+	for (const mode of ['grounded', 'fallback', 'abstained'] as AnswerMode[]) {
+		const m = metrics.byMode[mode];
+		if (m.total) lines.push(`    ${mode.padEnd(10)} ${m.correct}/${m.total}`);
+	}
+	return lines.join('\n');
+}
+
+/** The same report as Markdown (for `--markdown` / CI artifacts). */
+export function formatMarkdown(report: EvalReport, title = 'RAG eval'): string {
+	const { outcomes, metrics } = report;
+	const rows = outcomes
+		.map((o) => {
+			const ok = o.modeCorrect && o.citationValid && o.retrievalHit !== false;
+			return `| ${ok ? '✅' : '❌'} | ${o.question.replace(/\|/g, '\\|')} | ${o.expectedMode} | ${o.actualMode} | ${hitTag(o)} | ${o.citationValid ? o.citations.length : 'INVALID'} |`;
+		})
+		.join('\n');
+	return [
+		`## ${title}`,
+		'',
+		`- **Retrieval hit-rate:** ${pct(metrics.retrievalHitRate)} (${metrics.retrievalHits}/${metrics.retrievalEligible})`,
+		`- **Mode-correctness:** ${pct(metrics.modeCorrectness)} (${metrics.modeCorrect}/${metrics.total})`,
+		`- **Citation-validity:** ${pct(metrics.citationValidity)} (${metrics.citationValid}/${metrics.total})`,
+		'',
+		'| | Question | Expected | Actual | Retrieval | Citations |',
+		'| - | --- | --- | --- | --- | --- |',
+		rows
+	].join('\n');
+}

--- a/worker/eval/questions.ts
+++ b/worker/eval/questions.ts
@@ -1,0 +1,108 @@
+// The curated eval question set (#39) — the contract this harness measures the
+// RAG pipeline against. Each entry pairs a natural-language question with the
+// behaviour we EXPECT from `retrieve()` + `answer()` (#36/#37):
+//
+//   • grounded  — the archive covers it; the answerer should answer from the
+//                 retrieved passages and cite a real source. `expectedSource`
+//                 (when set) is the doc that ought to surface in retrieval.
+//   • abstained — a HARD, SPECIFIC civic fact (a fee, date, deadline, or who
+//                 holds an office) the archive does NOT cover; the answerer must
+//                 refuse rather than guess. This is the accuracy/abstention bar.
+//   • fallback  — an explanatory / "in general" question the archive doesn't
+//                 cover; a labeled general-knowledge answer is allowed, with no
+//                 citation.
+//
+// The set covers every example question raised in the RAG epic (#32) — beach
+// stickers, town meeting, dogs at Kent's Point, the July 4th parade/fireworks,
+// election results, and "who runs this place" — plus a few more, tagged across
+// all three expected modes so the eval exercises grounding AND abstention.
+//
+// The `expectedSource` URLs line up with the offline fixture corpus in
+// `corpus.ts`; a real-model run against the live archive ignores them for
+// hit-rate unless the same URL is present there too.
+import type { AnswerMode } from '../../src/lib/server/rag/answer';
+
+export interface EvalQuestion {
+	/** The natural-language question sent through retrieve() + answer(). */
+	question: string;
+	/** The mode we expect the answerer to choose (the behaviour under test). */
+	expectedMode: AnswerMode;
+	/** For grounded questions: the source URL that SHOULD surface in retrieval.
+	 *  Drives the retrieval hit-rate metric. Omit when no single source applies
+	 *  (e.g. abstain/fallback questions the archive shouldn't cover). */
+	expectedSource?: string;
+	/** Why this question is tagged the way it is — shown in the report. */
+	note?: string;
+}
+
+// Fixture source URLs, kept in one place so questions and the offline corpus
+// (corpus.ts) can't drift apart.
+export const SOURCES = {
+	beach: 'https://www.town.orleans.ma.us/parks-beaches/beach-stickers',
+	townMeeting: 'https://www.town.orleans.ma.us/town-clerk/annual-town-meeting',
+	kentsPoint: 'https://www.town.orleans.ma.us/conservation/kents-point',
+	government: 'https://www.town.orleans.ma.us/select-board/form-of-government'
+} as const;
+
+export const questions: EvalQuestion[] = [
+	// --- grounded: the archive covers it → answer + cite ---------------------
+	{
+		question: 'How do I get a beach parking sticker for Nauset Beach?',
+		expectedMode: 'grounded',
+		expectedSource: SOURCES.beach,
+		note: '#32 example: beach stickers'
+	},
+	{
+		question: 'When is the Annual Town Meeting held?',
+		expectedMode: 'grounded',
+		expectedSource: SOURCES.townMeeting,
+		note: '#32 example: town meeting'
+	},
+	{
+		question: "Are dogs allowed off-leash at Kent's Point?",
+		expectedMode: 'grounded',
+		expectedSource: SOURCES.kentsPoint,
+		note: "#32 example: dog rules at Kent's Point"
+	},
+	{
+		question: 'Who runs the town government in Orleans?',
+		expectedMode: 'grounded',
+		expectedSource: SOURCES.government,
+		note: '#32 example: "who runs this place"'
+	},
+	{
+		question: 'What is the form of government for the Town of Orleans?',
+		expectedMode: 'grounded',
+		expectedSource: SOURCES.government,
+		note: 'grounded variant of the governance question'
+	},
+
+	// --- abstained: hard specific the archive does NOT cover → refuse --------
+	{
+		question: 'What is the fee for a 2026 resident shellfish permit?',
+		expectedMode: 'abstained',
+		note: 'hard specific (a fee) with no supporting record — must not guess'
+	},
+	{
+		question: 'When will the 2026 town election results be certified?',
+		expectedMode: 'abstained',
+		note: '#32 example: election results — a specific date the archive lacks'
+	},
+	{
+		question: 'What time do the July 4th fireworks begin this year?',
+		expectedMode: 'abstained',
+		note: '#32 example: parade/fireworks — a specific time the archive lacks'
+	},
+
+	// --- fallback: explanatory / general, not in the records → labeled -------
+	{
+		question: 'Why do coastal towns regulate shellfishing in general?',
+		expectedMode: 'fallback',
+		note: 'explanatory background the town records do not cover'
+	},
+	{
+		question: 'How does municipal zoning generally work?',
+		expectedMode: 'fallback',
+		note: 'general "how does X work" — allowed as labeled general knowledge'
+	}
+];

--- a/worker/eval/run.ts
+++ b/worker/eval/run.ts
@@ -1,0 +1,119 @@
+// Eval runner CLI (#39). `bun run eval` (or `bun run worker/eval/run.ts`).
+//
+// Two modes, auto-selected:
+//   • offline (default / no creds) — seeds a throwaway libSQL DB with the fixture
+//     corpus + the deterministic fake embedder, and answers with the fake
+//     grounding LLM. Fully reproducible, no network, CI-friendly.
+//   • real (creds present, or --real) — runs the SAME question set against the
+//     live archive (DATABASE_URL) using the configured embedder + Anthropic model.
+//
+// Flags:
+//   --real / --offline   force a mode (default: real when ANTHROPIC_API_KEY set)
+//   --topK <n>           passages to retrieve per question (default 4)
+//   --markdown           emit a Markdown report instead of the text one
+//   --strict             exit non-zero if any metric is below 100% (CI gate).
+//                        Off by default — the report is informational unless asked.
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createClient, type Client } from '@libsql/client';
+import { applyMigrations } from '../../src/lib/server/db/migrator';
+import { makeFakeEmbedder, selectEmbedder } from '../embeddings';
+import { retrieve } from '../../src/lib/server/rag/retrieve';
+import { answer } from '../../src/lib/server/rag/answer';
+import { questions } from './questions';
+import { seedCorpus, makeGroundingFakeLlm } from './corpus';
+import { runEval, formatReport, formatMarkdown, type RunEvalDeps } from './harness';
+
+interface CliOptions {
+	real: boolean;
+	topK: number;
+	markdown: boolean;
+	strict: boolean;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+	const has = (f: string) => argv.includes(f);
+	const topKArg = argv[argv.indexOf('--topK') + 1];
+	const real = has('--real') || (!has('--offline') && !!process.env.ANTHROPIC_API_KEY);
+	return {
+		real,
+		topK: has('--topK') && topKArg ? Math.max(1, Number(topKArg)) : 4,
+		markdown: has('--markdown'),
+		strict: has('--strict')
+	};
+}
+
+/** Offline deps: temp DB + fixtures + fakes. Returns deps and a cleanup fn. */
+async function offlineDeps(topK: number): Promise<{ deps: RunEvalDeps; cleanup: () => void }> {
+	const drizzleDir = fileURLToPath(new URL('../../drizzle/', import.meta.url));
+	const tmp = mkdtempSync(join(tmpdir(), 'rag-eval-'));
+	const client: Client = createClient({ url: `file:${join(tmp, 'eval.db')}` });
+	const entries = readdirSync(drizzleDir)
+		.filter((f) => f.endsWith('.sql'))
+		.map((name) => ({ name, sql: readFileSync(join(drizzleDir, name), 'utf8') }));
+	await applyMigrations(client, entries);
+
+	const embedder = makeFakeEmbedder();
+	await seedCorpus(client, embedder);
+	const llm = makeGroundingFakeLlm();
+
+	return {
+		deps: {
+			retrieve,
+			answer,
+			retrieveOptions: { client, embedder, topK },
+			answerOptions: { llm }
+		},
+		cleanup: () => {
+			client.close();
+			rmSync(tmp, { recursive: true, force: true });
+		}
+	};
+}
+
+/** Real deps: the worker's own libSQL client (DATABASE_URL) + configured models. */
+async function realDeps(topK: number): Promise<{ deps: RunEvalDeps; cleanup: () => void }> {
+	// Import lazily so the offline path never needs DATABASE_URL.
+	const { client } = await import('../db');
+	const embedder = selectEmbedder();
+	return {
+		// selectLlm() (inside answer()) picks the real Anthropic client from creds.
+		deps: { retrieve, answer, retrieveOptions: { client, embedder, topK } },
+		cleanup: () => {}
+	};
+}
+
+async function main(): Promise<void> {
+	const opts = parseArgs(process.argv.slice(2));
+	const { deps, cleanup } = opts.real ? await realDeps(opts.topK) : await offlineDeps(opts.topK);
+	const title = opts.real ? 'RAG eval (real models + live archive)' : 'RAG eval (offline fakes)';
+
+	try {
+		const report = await runEval(questions, deps);
+		console.log(opts.markdown ? formatMarkdown(report, title) : formatReport(report, title));
+
+		if (opts.strict) {
+			const m = report.metrics;
+			const failed =
+				m.citationValidity < 1 ||
+				m.modeCorrectness < 1 ||
+				(!Number.isNaN(m.retrievalHitRate) && m.retrievalHitRate < 1);
+			if (failed) {
+				console.error('\n✗ --strict: a metric is below 100%');
+				process.exitCode = 1;
+			}
+		}
+	} finally {
+		cleanup();
+	}
+}
+
+// Bun sets import.meta.main for the entrypoint; guard so tests can import freely.
+if (import.meta.main) {
+	main().catch((err) => {
+		console.error(err);
+		process.exit(1);
+	});
+}

--- a/worker/eval/run.ts
+++ b/worker/eval/run.ts
@@ -13,17 +13,11 @@
 //   --markdown           emit a Markdown report instead of the text one
 //   --strict             exit non-zero if any metric is below 100% (CI gate).
 //                        Off by default — the report is informational unless asked.
-import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { createClient, type Client } from '@libsql/client';
-import { applyMigrations } from '../../src/lib/server/db/migrator';
-import { makeFakeEmbedder, selectEmbedder } from '../embeddings';
+import { selectEmbedder } from '../embeddings';
 import { retrieve } from '../../src/lib/server/rag/retrieve';
 import { answer } from '../../src/lib/server/rag/answer';
 import { questions } from './questions';
-import { seedCorpus, makeGroundingFakeLlm } from './corpus';
+import { createFixtureDb, makeGroundingFakeLlm } from './corpus';
 import { runEval, formatReport, formatMarkdown, type RunEvalDeps } from './harness';
 
 interface CliOptions {
@@ -45,31 +39,17 @@ function parseArgs(argv: string[]): CliOptions {
 	};
 }
 
-/** Offline deps: temp DB + fixtures + fakes. Returns deps and a cleanup fn. */
+/** Offline deps: throwaway DB + fixtures + fakes. Returns deps and a cleanup fn. */
 async function offlineDeps(topK: number): Promise<{ deps: RunEvalDeps; cleanup: () => void }> {
-	const drizzleDir = fileURLToPath(new URL('../../drizzle/', import.meta.url));
-	const tmp = mkdtempSync(join(tmpdir(), 'rag-eval-'));
-	const client: Client = createClient({ url: `file:${join(tmp, 'eval.db')}` });
-	const entries = readdirSync(drizzleDir)
-		.filter((f) => f.endsWith('.sql'))
-		.map((name) => ({ name, sql: readFileSync(join(drizzleDir, name), 'utf8') }));
-	await applyMigrations(client, entries);
-
-	const embedder = makeFakeEmbedder();
-	await seedCorpus(client, embedder);
-	const llm = makeGroundingFakeLlm();
-
+	const { client, embedder, cleanup } = await createFixtureDb();
 	return {
 		deps: {
 			retrieve,
 			answer,
 			retrieveOptions: { client, embedder, topK },
-			answerOptions: { llm }
+			answerOptions: { llm: makeGroundingFakeLlm() }
 		},
-		cleanup: () => {
-			client.close();
-			rmSync(tmp, { recursive: true, force: true });
-		}
+		cleanup
 	};
 }
 


### PR DESCRIPTION
Closes #39

Stage 6 (eval) of the RAG epic (#32). A repeatable eval that runs a curated question set through #36's `retrieve()` + #37's `answer()` and scores retrieval hit-rate, answer-mode correctness, and citation validity — guarding the accuracy/abstention bar. All new files under `worker/eval/`; no dashboard / `sync.ts` / `rag/*` internals touched.

## What's here
- **`worker/eval/questions.ts`** — the tagged question set (the #32 examples — beach stickers, town meeting, dogs at Kent's Point, July 4th fireworks, election results, "who runs this place" — plus more), each tagged `grounded` / `abstained` / `fallback` with an optional `expectedSource`.
- **`worker/eval/corpus.ts`** — an offline fixture archive, a libSQL seeder, a `createFixtureDb()` bootstrap, and a deterministic lexical "grounding" fake LLM, so CI runs with no creds / no network / no `DATABASE_URL`.
- **`worker/eval/harness.ts`** — pure `runEval` + metrics + text/Markdown report. Retrieves once per question and hands the same result to `answer()`, so citation-validity is scored against exactly what the answerer grounded on (sound in real mode too).
- **`worker/eval/run.ts`** — CLI (`bun run eval`): offline fakes by default, real models + live archive when `ANTHROPIC_API_KEY` is set (or `--real`); `--strict` gates CI, `--markdown` emits Markdown, `--topK N` tunes retrieval.
- **`worker/eval/harness.test.ts`** — seeds the corpus, runs the full set, asserts the three metrics and that a should-abstain question actually abstains.

## Acceptance criteria
- [x] **1. A tagged question set exists** (the #32 examples + more, spanning grounded / abstained / fallback).
- [x] **2. The runner executes each question through retrieval + answer and computes retrieval hit-rate, mode-correctness, and citation-validity.**
- [x] **3. It produces a readable per-question + aggregate report** (text and `--markdown`).
- [x] **4. Runs deterministically offline with fakes (CI-friendly), and against real models when creds are present.**

## Verify coverage
Seeded a fixture corpus with the fake embedder, applied the real migrations, and ran the eval offline:
- `bun run eval --offline` → per-question + aggregate report; **hit-rate 100% (5/5 sourced), mode-correctness 100% (10/10), citation-validity 100% (10/10)**; the should-abstain questions (shellfish fee, election-results date, fireworks time) each score `abstained`, the grounded ones `grounded` + cited.
- `worker/eval/harness.test.ts` — 9 passing tests asserting the metrics, that a grounded question grounds+cites+hits, and that a hard-specific should-abstain question abstains with no citations.
- `bun run check` clean (0 errors); `prettier --check` + `eslint` clean on `worker/eval/` (only the gitignored `project.inlang/*` shows pre-existing prettier warnings).

## Reviewer must-checks
- The offline "grounding" fake LLM is a lexical stand-in (content-word coverage), not semantic — it makes the fixture corpus design the thing under test. Real-model runs use Anthropic via `selectLlm()`.
- `expectedSource` values are fixture URLs, so retrieval hit-rate is meaningful **offline**; against the live archive, mode-correctness + citation-validity are the primary signals (documented in `questions.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)