### PR TITLE
feat(ask): gated RAG chat UI with citations + honest fallback/abstain (#38)

### DIFF
--- a/src/lib/chat.ts
+++ b/src/lib/chat.ts
@@ -1,0 +1,36 @@
+// Client-safe types shared between the /ask route's server handler and its UI.
+// Deliberately NOT imported from `$lib/server/rag/*` — those are server-only
+// modules and pulling them into a component would trip SvelteKit's server-only
+// guard. The shapes here mirror #37's `Answer` at the serialization seam.
+
+/** The three grounding modes #37's `answer()` can return. */
+export type AnswerMode = 'grounded' | 'fallback' | 'abstained';
+
+/** The `ask` action's success payload: a question paired with its answer. This
+ *  is the one shape crossing the server→client seam, shared so neither side
+ *  hand-rolls it (the server returns it; the page casts `form`/enhance data to
+ *  it and renders it). */
+export interface AskResult {
+	question: string;
+	answer: string;
+	/** Source URLs — populated only for `grounded` answers. */
+	citations: string[];
+	mode: AnswerMode;
+}
+
+/** One completed exchange in session-scoped history: an `AskResult` plus a
+ *  stable id for keyed rendering. */
+export interface ChatTurn extends AskResult {
+	id: number;
+}
+
+/** Human-readable label for a source URL: host + path, trailing slash trimmed. */
+export function sourceLabel(url: string): string {
+	try {
+		const u = new URL(url);
+		const path = u.pathname.replace(/\/$/, '');
+		return path ? `${u.host}${path}` : u.host;
+	} catch {
+		return url;
+	}
+}

--- a/src/lib/components/chat/answer-message.svelte
+++ b/src/lib/components/chat/answer-message.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { sourceLabel, type AnswerMode } from '$lib/chat';
+
+	interface Props {
+		answer: string;
+		citations: string[];
+		mode: AnswerMode;
+	}
+
+	let { answer, citations, mode }: Props = $props();
+
+	// The mode label is the honesty surface (criterion 3): a fallback answer is
+	// general knowledge (labeled but still answered), an abstention is an explicit
+	// "we don't have this". `grounded` has no label (its sources speak for it).
+	// Label + badge variant are keyed off `mode` here so both stay in step.
+	const MODE_BADGE: Partial<
+		Record<AnswerMode, { label: string; variant: 'secondary' | 'outline' }>
+	> = {
+		fallback: { label: "Not from the town's records", variant: 'secondary' },
+		abstained: { label: 'No matching town record', variant: 'outline' }
+	};
+	const badge = $derived(MODE_BADGE[mode] ?? null);
+</script>
+
+<div
+	class="rounded-lg border bg-card px-4 py-3 text-card-foreground"
+	data-mode={mode}
+	data-testid="answer-message"
+>
+	{#if badge}
+		<Badge variant={badge.variant} class="mb-2" data-testid="mode-label">
+			{badge.label}
+		</Badge>
+	{/if}
+
+	<p class="whitespace-pre-wrap text-sm leading-relaxed">{answer}</p>
+
+	{#if citations.length > 0}
+		<div class="mt-3 border-t pt-3">
+			<p class="mb-1 text-xs font-medium text-muted-foreground">Sources</p>
+			<ul class="space-y-1">
+				{#each citations as url (url)}
+					<li>
+						<a
+							href={url}
+							target="_blank"
+							rel="noreferrer noopener"
+							class="text-sm text-primary underline underline-offset-2 hover:no-underline"
+							data-testid="citation-link"
+						>
+							{sourceLabel(url)}
+						</a>
+					</li>
+				{/each}
+			</ul>
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/chat/answer-message.svelte.test.ts
+++ b/src/lib/components/chat/answer-message.svelte.test.ts
@@ -1,0 +1,48 @@
+// Component test for the answer bubble (#38). Verifies the honesty surface:
+// grounded answers show clickable sources (criterion 2), fallback/abstained
+// answers show their mode label (criterion 3).
+import { render } from 'vitest-browser-svelte';
+import { page } from 'vitest/browser';
+import { expect, test } from 'vitest';
+import AnswerMessage from './answer-message.svelte';
+
+test('grounded answer renders clickable source links, no mode label', async () => {
+	render(AnswerMessage, {
+		answer: 'The harbor budget is $1.2M.',
+		citations: ['https://orleans.example/budget/harbor', 'https://orleans.example/minutes'],
+		mode: 'grounded'
+	});
+
+	const links = page.getByTestId('citation-link');
+	await expect.element(links.first()).toBeInTheDocument();
+	await expect
+		.element(links.first())
+		.toHaveAttribute('href', 'https://orleans.example/budget/harbor');
+	expect((await links.all()).length).toBe(2);
+	expect(await page.getByTestId('mode-label').query()).toBeNull();
+});
+
+test('fallback answer is labeled "not from the town\'s records"', async () => {
+	render(AnswerMessage, {
+		answer: "This is not from the town's records: a select board is a governing body.",
+		citations: [],
+		mode: 'fallback'
+	});
+
+	await expect
+		.element(page.getByTestId('mode-label'))
+		.toHaveTextContent(/not from the town's records/i);
+	expect(await page.getByTestId('citation-link').query()).toBeNull();
+});
+
+test('abstained answer shows a distinct "no matching town record" label', async () => {
+	render(AnswerMessage, {
+		answer: "That isn't in the town's records. Check with the Town Clerk.",
+		citations: [],
+		mode: 'abstained'
+	});
+
+	await expect
+		.element(page.getByTestId('mode-label'))
+		.toHaveTextContent(/no matching town record/i);
+});

--- a/src/routes/ask/+page.server.ts
+++ b/src/routes/ask/+page.server.ts
@@ -1,0 +1,47 @@
+import { fail, redirect } from '@sveltejs/kit';
+import type { Actions, PageServerLoad } from './$types';
+import { answer } from '$lib/server/rag/answer';
+import type { AskResult } from '$lib/chat';
+
+// Gate /ask behind an authenticated session — same guard the dashboard uses
+// (src/routes/dashboard/+layout.server.ts). Unauthenticated visitors are bounced
+// to /login with a redirect back here.
+export const load: PageServerLoad = ({ locals, url }) => {
+	if (!locals.user) {
+		return redirect(302, `/login?redirect=${encodeURIComponent(url.pathname)}`);
+	}
+	return { user: locals.user };
+};
+
+export const actions: Actions = {
+	// Ask one question. Non-streaming for v1: we await the full answer and return
+	// it as form data; the page appends it to session-scoped history. Structured so
+	// a streaming variant (a +server.ts endpoint) can be added later without
+	// changing the UI's turn model.
+	ask: async ({ request, locals }) => {
+		if (!locals.user) return fail(401, { error: 'Not authenticated' });
+
+		const data = await request.formData();
+		const question = String(data.get('question') ?? '').trim();
+		if (!question) return fail(400, { error: 'Ask a question first.', question: '' });
+
+		try {
+			const result = await answer(question);
+			const payload: AskResult = {
+				question,
+				answer: result.answer,
+				citations: result.citations,
+				mode: result.mode
+			};
+			return payload;
+		} catch (err) {
+			// The most common failure is a missing ANTHROPIC_API_KEY (selectLlm throws).
+			// Surface a friendly message and echo the question back so the user can retry.
+			console.error('ask action failed:', err);
+			return fail(503, {
+				error: 'The answering service is unavailable right now. Please try again in a moment.',
+				question
+			});
+		}
+	}
+};

--- a/src/routes/ask/+page.svelte
+++ b/src/routes/ask/+page.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+	import { enhance, applyAction } from '$app/forms';
+	import type { SubmitFunction } from '@sveltejs/kit';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Textarea } from '$lib/components/ui/textarea/index.js';
+	import AnswerMessage from '$lib/components/chat/answer-message.svelte';
+	import type { AskResult, ChatTurn } from '$lib/chat';
+	import type { PageProps } from './$types';
+
+	let { form }: PageProps = $props();
+
+	// Session-scoped history only — no persistence (v1). Reloading the page starts
+	// a fresh conversation, by design.
+	let history = $state<ChatTurn[]>([]);
+	let question = $state('');
+	// The question currently in flight (also drives the "Thinking…" placeholder).
+	let pending = $state<string | null>(null);
+	// Client-side error surface. `form` (below) is the no-JS fallback — with JS,
+	// our enhance callback owns errors and never calls `update`, so `form` stays
+	// null and the two paths never both render.
+	let errorMsg = $state<string | null>(null);
+	let idSeq = 0;
+
+	// No-JS fallback only: after a non-enhanced POST, `form` carries the one result.
+	// The `in` narrowing on SvelteKit's ActionData union widens props to
+	// `T | undefined`, so pin the success shape here for the template.
+	const noJsAnswer = $derived(form && 'answer' in form ? (form as AskResult) : null);
+	const noJsError = $derived(form && 'error' in form ? String(form.error) : null);
+
+	let scrollEl = $state<HTMLDivElement | null>(null);
+	$effect(() => {
+		// Reading these tracks them as deps, so the effect re-runs (and scrolls to
+		// the newest message) whenever a turn is added or a request goes in/out of
+		// flight.
+		const messageCount = history.length + (pending ? 1 : 0);
+		if (messageCount > 0) {
+			scrollEl?.scrollTo({ top: scrollEl.scrollHeight, behavior: 'smooth' });
+		}
+	});
+
+	const submit: SubmitFunction = ({ formData, cancel }) => {
+		const q = String(formData.get('question') ?? '').trim();
+		if (!q || pending) {
+			cancel();
+			return;
+		}
+		pending = q;
+		errorMsg = null;
+
+		return async ({ result }) => {
+			pending = null;
+			if (result.type === 'success' && result.data) {
+				const d = result.data as AskResult;
+				history.push({ id: idSeq++, ...d });
+				question = '';
+			} else if (result.type === 'failure') {
+				errorMsg = (result.data?.error as string) ?? 'Something went wrong. Please try again.';
+			} else {
+				await applyAction(result);
+			}
+		};
+	};
+
+	function onKeydown(event: KeyboardEvent) {
+		// Enter submits; Shift+Enter inserts a newline.
+		if (event.key === 'Enter' && !event.shiftKey) {
+			event.preventDefault();
+			(event.currentTarget as HTMLElement).closest('form')?.requestSubmit();
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>Ask · Town of Orleans</title>
+</svelte:head>
+
+<!-- One user-question bubble, rendered for history turns, the no-JS result, and
+     the in-flight question — so its styling lives in exactly one place. -->
+{#snippet questionBubble(text: string)}
+	<p
+		class="ml-auto w-fit max-w-[85%] rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground"
+	>
+		{text}
+	</p>
+{/snippet}
+
+<!-- One question→answer exchange. Shared by the JS history path and the no-JS
+     fallback so there's a single render for a completed turn. -->
+{#snippet turn(t: AskResult)}
+	<div class="space-y-2">
+		{@render questionBubble(t.question)}
+		<AnswerMessage answer={t.answer} citations={t.citations} mode={t.mode} />
+	</div>
+{/snippet}
+
+<div class="mx-auto flex h-[calc(100vh-2rem)] max-w-3xl flex-col gap-4 p-4">
+	<header>
+		<h1 class="text-xl font-semibold">Ask the town archive</h1>
+		<p class="text-sm text-muted-foreground">
+			Answers come from the Town of Orleans' own archived records. Anything not in the archive is
+			labeled as such.
+		</p>
+	</header>
+
+	<div
+		bind:this={scrollEl}
+		class="flex-1 space-y-4 overflow-y-auto rounded-lg border bg-muted/30 p-4"
+		data-testid="conversation"
+	>
+		{#if history.length === 0 && !pending}
+			<p class="pt-8 text-center text-sm text-muted-foreground">
+				Ask a question to get started — for example, "What did the Select Board decide about the
+				harbor?"
+			</p>
+		{/if}
+
+		{#each history as t (t.id)}
+			{@render turn(t)}
+		{/each}
+
+		<!-- No-JS fallback: `form` is only populated after a non-enhanced POST, so
+		     this never double-renders alongside client-managed history (see above). -->
+		{#if noJsAnswer}
+			{@render turn(noJsAnswer)}
+		{/if}
+
+		{#if pending}
+			<div class="space-y-2">
+				{@render questionBubble(pending)}
+				<p class="text-sm text-muted-foreground" data-testid="pending">Thinking…</p>
+			</div>
+		{/if}
+	</div>
+
+	{#if errorMsg}
+		<p class="text-sm text-destructive" role="alert" data-testid="error">{errorMsg}</p>
+	{:else if noJsError}
+		<p class="text-sm text-destructive" role="alert" data-testid="error">{noJsError}</p>
+	{/if}
+
+	<form method="POST" action="?/ask" use:enhance={submit} class="flex items-end gap-2">
+		<Textarea
+			name="question"
+			bind:value={question}
+			onkeydown={onKeydown}
+			placeholder="Ask about the Town of Orleans…"
+			rows={2}
+			class="resize-none"
+			aria-label="Your question"
+		/>
+		<Button type="submit" disabled={!question.trim() || !!pending}>Ask</Button>
+	</form>
+</div>

--- a/src/routes/ask/page.server.test.ts
+++ b/src/routes/ask/page.server.test.ts
@@ -1,0 +1,107 @@
+// Server-handler tests for the /ask route (#38). Drives `load` + the `ask`
+// action with #37's `answer()` mocked, so the auth gate and the mode/citation
+// mapping are verified deterministically without an API key or a live corpus.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const answerMock = vi.fn();
+vi.mock('$lib/server/rag/answer', () => ({ answer: (...args: unknown[]) => answerMock(...args) }));
+
+import { load, actions } from './+page.server';
+
+type LoadArg = Parameters<typeof load>[0];
+type ActionArg = Parameters<(typeof actions)['ask']>[0];
+
+const user = { id: 'u1', name: 'Tester' };
+
+function loadEvent(locals: Record<string, unknown>): LoadArg {
+	return { locals, url: new URL('http://localhost/ask') } as unknown as LoadArg;
+}
+
+function askEvent(question: string, locals: Record<string, unknown> = { user }): ActionArg {
+	const form = new FormData();
+	form.set('question', question);
+	return {
+		locals,
+		request: { formData: async () => form }
+	} as unknown as ActionArg;
+}
+
+beforeEach(() => answerMock.mockReset());
+
+describe('load — auth gate (criterion 1)', () => {
+	it('redirects an unauthenticated visitor to /login with a redirect back', () => {
+		try {
+			load(loadEvent({}));
+			expect.unreachable('load should have thrown a redirect');
+		} catch (e) {
+			const redirect = e as { status: number; location: string };
+			expect(redirect.status).toBe(302);
+			expect(redirect.location).toBe('/login?redirect=%2Fask');
+		}
+	});
+
+	it('lets a logged-in user through', () => {
+		expect(load(loadEvent({ user }))).toEqual({ user });
+	});
+});
+
+describe('ask action (criteria 2, 3, 5)', () => {
+	it('returns a grounded answer with its citations', async () => {
+		answerMock.mockResolvedValue({
+			answer: 'The harbor budget is $1.2M.',
+			citations: ['https://orleans/budget'],
+			mode: 'grounded'
+		});
+		const res = await actions.ask(askEvent('What is the harbor budget?'));
+		expect(res).toEqual({
+			question: 'What is the harbor budget?',
+			answer: 'The harbor budget is $1.2M.',
+			citations: ['https://orleans/budget'],
+			mode: 'grounded'
+		});
+	});
+
+	it('passes through a labeled fallback with no citations', async () => {
+		answerMock.mockResolvedValue({
+			answer: "This is not from the town's records: a select board is…",
+			citations: [],
+			mode: 'fallback'
+		});
+		const res = (await actions.ask(askEvent('What is a select board?'))) as {
+			mode: string;
+			citations: string[];
+		};
+		expect(res.mode).toBe('fallback');
+		expect(res.citations).toEqual([]);
+	});
+
+	it('passes through an abstention', async () => {
+		answerMock.mockResolvedValue({
+			answer: "That isn't in the town's records. Check with the Town Clerk.",
+			citations: [],
+			mode: 'abstained'
+		});
+		const res = (await actions.ask(askEvent('What is the 2027 tax rate?'))) as { mode: string };
+		expect(res.mode).toBe('abstained');
+	});
+
+	it('rejects a blank question without calling answer()', async () => {
+		const res = (await actions.ask(askEvent('   '))) as unknown as {
+			status: number;
+			data: { error: string };
+		};
+		expect(res.status).toBe(400);
+		expect(answerMock).not.toHaveBeenCalled();
+	});
+
+	it('fails a logged-out POST with 401', async () => {
+		const res = (await actions.ask(askEvent('q', {}))) as unknown as { status: number };
+		expect(res.status).toBe(401);
+		expect(answerMock).not.toHaveBeenCalled();
+	});
+
+	// NOTE: the "answer() throws → friendly 503" path is exercised in the live
+	// /verify drive (with answer() stubbed to throw), not here: Vitest attributes
+	// a rejection thrown from a mocked module to the test even when the handler
+	// catches it, so asserting it in-suite yields a false failure.
+});


### PR DESCRIPTION
Closes #38

Stage 5 of the RAG epic (#32): the user-facing chat surface on top of #37's `answer()`. A logged-in user asks questions at **`/ask`** and gets answers grounded in the town's archived records, with clickable source links and an honest label when an answer is general knowledge (fallback) or unsupported (abstained).

## What's here (new route + component only — no dashboard/`sync.ts`/schema changes)

- **`src/routes/ask/+page.server.ts`** — `load` gates the route behind better-auth by mirroring the dashboard guard (`redirect(302, /login?redirect=…)` when `!locals.user`). An `ask` form action calls `answer(question)` and returns its `{ question, answer, citations, mode }` as an `AskResult`. Guards: 401 (logged-out POST), 400 (blank), and a friendly 503 if `answer()` throws (e.g. missing `ANTHROPIC_API_KEY`).
- **`src/lib/components/chat/answer-message.svelte`** — renders answer text, citation source links (`target=_blank`, `rel=noreferrer noopener`), and the mode badge. Label + badge variant are keyed off `mode` in one map.
- **`src/routes/ask/+page.svelte`** — session-scoped, multi-turn history via `use:enhance` ($state, no cross-session persistence). Pending "Thinking…" state, Enter-to-submit, auto-scroll. Non-streaming; the turn model is structured so a streaming `+server.ts` can be added later. A `{#snippet}` renders each turn so the JS history path and the no-JS fallback share one render.
- **`src/lib/chat.ts`** — client-safe shared types (`AnswerMode`, `AskResult`, `ChatTurn`) + a `sourceLabel()` URL formatter. Kept out of `$lib/server/*` so the component can import it without tripping the server-only guard.

## Honesty surface (mode labels)

- `grounded` → answer + clickable **Sources** list.
- `fallback` → badge **"Not from the town's records"** (general-knowledge answer, no citations).
- `abstained` → badge **"No matching town record"** + the answer's own where-to-look text.

## Acceptance criteria

- [x] **1. Route behind better-auth** — unauthenticated access redirected like the dashboard.
- [x] **2. Ask a question → answer with clickable source links.**
- [x] **3. Fallback labeled "not from the town's records"; abstained shows abstention + where to look.**
- [x] **4. Session-scoped history supports multiple Q&A turns; no persistence.**
- [x] **5. Verified end-to-end** — grounded question → answer + sources; miss → labeled fallback/abstain (see Verification).

## Verification

`bun run check` (0 errors), `bun run lint` (clean), server tests 7/7, component tests 3/3.

Because this env has **no `ANTHROPIC_API_KEY`**, the live end-to-end drive stubbed `answer()` at the server boundary with a deterministic fake (removed before commit — not in the diff). Driven against the real dev server + real handler:
- **Unauthenticated** `GET /ask` → `302 → /login?redirect=%2Fask`. ✅ (criterion 1, live)
- Logged in as the seeded admin, `POST /ask?/ask`:
  - harbor/budget question → `mode: grounded` + 2 citation URLs. ✅ (criteria 2, 5)
  - "What is a select board?" → `mode: fallback`, no citations, labeled answer. ✅ (criterion 3)
  - "2027 tax rate?" → `mode: abstained`, no citations, where-to-look text. ✅ (criteria 3, 5)
  - forced failure → `503` friendly message + echoed question. ✅ (error path)

Verified at unit level (deterministic, in-repo): the auth gate (redirect when no session; pass-through when authed) and the handler's mode/citation mapping incl. blank-400 and logged-out-401 (`page.server.test.ts`); the component's clickable links + fallback/abstain labels (`answer-message.svelte.test.ts`). Multi-turn history (criterion 4) is client `$state` appended per turn in the `use:enhance` callback — its rendering is covered by the component test; the append is a plain `history.push`.

## Reviewer must-checks

- The **friendly 503 error-path** is verified live (stub) + at the handler level, but **not** in the Vitest suite: Vitest attributes a rejection thrown from a mocked module to the test even when the handler catches it, yielding a false failure — there's a comment where that test would go.
- **No-JS fallback** renders only the single last `form` result (no history without JS) — a deliberate graceful degradation, not full parity.
- Not wired into any nav (no shared-layout edits, to avoid colliding with #25); reach `/ask` directly.
