### PR TITLE
feat(worker): shared pino structured logger + migrate sync worker (#16)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,15 @@ BETTER_AUTH_SECRET=""
 DATABASE_AUTH_TOKEN=""
 
 # ---------------------------------------------------------------------------
+# Structured logging (src/lib/server/log.ts, pino). Shared by the worker (and,
+# later, the app). Prod emits one JSON object per line to stdout; dev pretty-
+# prints with a stable per-namespace color.
+# ---------------------------------------------------------------------------
+# LOG_LEVEL=info     # debug | info | warn | error — below-threshold logs dropped
+# LOG_PRETTY=        # unset = pretty unless NODE_ENV=production; 1/true forces
+#                    # pretty, 0/false forces JSON (e.g. to eyeball prod locally)
+
+# ---------------------------------------------------------------------------
 # Sync worker (worker/) — a standalone `bun run worker` process. It reads the
 # same DATABASE_URL / DATABASE_AUTH_TOKEN above, plus:
 # ---------------------------------------------------------------------------

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@mozilla/readability": "^0.6.0",
         "aws4fetch": "^1.0.20",
         "linkedom": "^0.18.13",
+        "pino": "^10.3.1",
         "unpdf": "^1.6.2",
       },
       "devDependencies": {
@@ -51,6 +52,7 @@
         "lint-staged": "^17.0.8",
         "mode-watcher": "^1.1.0",
         "paneforge": "^1.0.2",
+        "pino-pretty": "^13.1.3",
         "playwright": "^1.60.0",
         "prettier": "^3.8.3",
         "prettier-plugin-svelte": "^4.1.0",
@@ -503,6 +505,8 @@
 
     "@oxc-resolver/binding-win32-x64-msvc": ["@oxc-resolver/binding-win32-x64-msvc@11.23.0", "", { "os": "win32", "cpu": "x64" }, "sha512-gUGJpr+Rn6zMxm5juApV0K3U845i8t47o8k+rbO0BHbi4PoJIfSPeQmrE2dgohQm2g5k6iviNFyXCGqvmaYUpw=="],
 
+    "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
+
     "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
@@ -747,6 +751,8 @@
 
     "async-sema": ["async-sema@3.1.1", "", {}, "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg=="],
 
+    "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
+
     "aws4fetch": ["aws4fetch@1.0.20", "", {}, "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g=="],
 
     "axe-core": ["axe-core@4.12.1", "", {}, "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA=="],
@@ -808,6 +814,8 @@
     "cli-truncate": ["cli-truncate@5.2.0", "", { "dependencies": { "slice-ansi": "^8.0.0", "string-width": "^8.2.0" } }, "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 
     "commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
@@ -886,6 +894,8 @@
     "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
 
     "d3-tricontour": ["d3-tricontour@1.1.0", "", { "dependencies": { "d3-delaunay": "6", "d3-scale": "4" } }, "sha512-G7gHKj89n2owmkGb6WX6ixcnQ0Kf/0wpa9VIh9DGdbHu8wdrlaHU4ir3/bFNERl8N8nn4G7e7qbtBG8N9caihQ=="],
+
+    "dateformat": ["dateformat@4.6.3", "", {}, "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -1005,11 +1015,15 @@
 
     "exsolve": ["exsolve@1.1.0", "", {}, "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw=="],
 
+    "fast-copy": ["fast-copy@4.0.4", "", {}, "sha512-eVAiWVNPSEGIzDl5yPuLrx8fNMogScXvD9xp1Kzd41FjRIz2I3sSIcxsFeM5EzFfHAfobdvs8ZySffUopljvIA=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
 
     "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
 
@@ -1048,6 +1062,8 @@
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
 
     "html-escaper": ["html-escaper@3.0.3", "", {}, "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="],
 
@@ -1102,6 +1118,8 @@
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
     "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+
+    "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
 
     "js-base64": ["js-base64@3.8.1", "", {}, "sha512-5xVjhUZlHHeuO2W7w2rDFj/Kl1xLX+HjZxdOQwCsUOifl6UaoH1o1wsbsTMz+r0aeC7gCijvru02j6TfKZWzKg=="],
 
@@ -1245,6 +1263,8 @@
 
     "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
 
+    "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
+
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
@@ -1297,6 +1317,14 @@
 
     "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
+    "pino": ["pino@10.3.1", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^4.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg=="],
+
+    "pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
+
+    "pino-pretty": ["pino-pretty@13.1.3", "", { "dependencies": { "colorette": "^2.0.7", "dateformat": "^4.6.3", "fast-copy": "^4.0.0", "fast-safe-stringify": "^2.1.1", "help-me": "^5.0.0", "joycon": "^3.1.1", "minimist": "^1.2.6", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pump": "^3.0.0", "secure-json-parse": "^4.0.0", "sonic-boom": "^4.0.1", "strip-json-comments": "^5.0.2" }, "bin": { "pino-pretty": "bin.js" } }, "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg=="],
+
+    "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
+
     "pkg-types": ["pkg-types@2.3.1", "", { "dependencies": { "confbox": "^0.2.4", "exsolve": "^1.0.8", "pathe": "^2.0.3" } }, "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg=="],
 
     "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
@@ -1335,6 +1363,8 @@
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
+    "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
+
     "promise-limit": ["promise-limit@2.7.0", "", {}, "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw=="],
 
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
@@ -1342,6 +1372,8 @@
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
 
     "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
@@ -1356,6 +1388,8 @@
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
+    "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 
     "recast": ["recast@0.23.12", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-dEWRjcINDu/F4l2dYx57ugBtD7HV9KXESyxhzw/MqWLeglJrsjJKqACPyUPg+6AF8mIgm+Zi0dZ3ACoIg+QtpA=="],
 
@@ -1389,11 +1423,15 @@
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "scule": ["scule@1.3.0", "", {}, "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g=="],
+
+    "secure-json-parse": ["secure-json-parse@4.1.0", "", {}, "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="],
 
     "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
@@ -1420,6 +1458,8 @@
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "slice-ansi": ["slice-ansi@8.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg=="],
+
+    "sonic-boom": ["sonic-boom@4.2.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
@@ -1449,7 +1489,7 @@
 
     "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
-    "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
+    "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
 
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
 
@@ -1486,6 +1526,8 @@
     "tar-fs": ["tar-fs@2.1.5", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw=="],
 
     "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
+
+    "thread-stream": ["thread-stream@4.2.0", "", { "dependencies": { "real-require": "^1.0.0" } }, "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ=="],
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
@@ -1729,6 +1771,8 @@
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
+    "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
+
     "shadcn-svelte/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "sharp/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
@@ -1752,6 +1796,8 @@
     "tar/chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
     "tar/yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
+
+    "thread-stream/real-require": ["real-require@1.0.0", "", {}, "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="],
 
     "tsx/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
 		"lint-staged": "^17.0.8",
 		"mode-watcher": "^1.1.0",
 		"paneforge": "^1.0.2",
+		"pino-pretty": "^13.1.3",
 		"playwright": "^1.60.0",
 		"prettier": "^3.8.3",
 		"prettier-plugin-svelte": "^4.1.0",
@@ -104,6 +105,7 @@
 		"@mozilla/readability": "^0.6.0",
 		"aws4fetch": "^1.0.20",
 		"linkedom": "^0.18.13",
+		"pino": "^10.3.1",
 		"unpdf": "^1.6.2"
 	}
 }

--- a/src/lib/server/log.ts
+++ b/src/lib/server/log.ts
@@ -1,0 +1,111 @@
+// Shared structured logger (pino), server-side only. One logger, used by BOTH the
+// standalone Bun sync worker (worker/*) and — as of a follow-up (#52) — the
+// SvelteKit app. Import it, name a namespace, log with a level:
+//
+//     import { logger } from '$lib/server/log'; // or '../src/lib/server/log' from worker/
+//     const log = logger('crawl');
+//     log.info('run started');
+//     log.child({ runId, mode }).warn('slow response');
+//
+// Output shape:
+//   • prod  — one JSON object per line to stdout (level, time, ns, msg + bound
+//     context). Machine-parseable for aggregation / alerting / diagnostics.
+//   • dev   — pretty-printed, one line each, with the namespace colored a STABLE
+//     per-namespace color (same idea as the `debug` npm module: hash the namespace
+//     to a fixed color) so modules are distinguishable at a glance.
+//
+// Level threshold comes from LOG_LEVEL (default 'info'); below-threshold calls are
+// dropped. Pretty vs JSON is chosen by LOG_PRETTY (explicit), else NODE_ENV.
+//
+// Correlation is done with child loggers, not per-call fields: bind workerId (+
+// host/pid) once on a base logger, add runId/mode/phase on a per-run child, and
+// every line downstream self-locates. See worker/ for how the sync worker binds
+// these.
+//
+// Bun note: pino-pretty is attached as an in-process stream (single thread), NOT
+// via pino.transport() — pino's worker-thread transports are unreliable under Bun,
+// and a synchronous/single-thread destination sidesteps that entirely.
+import pino from 'pino';
+import pretty from 'pino-pretty';
+
+/** Field key carrying a logger's namespace (e.g. "worker:crawl"). */
+const NS_KEY = 'ns';
+
+// ---------------------------------------------------------------------------
+// Stable per-namespace color (dev pretty only). Mirrors the `debug` module:
+// hash the namespace to an index into a fixed 256-color palette, so a given
+// namespace always renders in the same, distinct color.
+// ---------------------------------------------------------------------------
+// The `debug` module's curated 256-color set (skips low-contrast colors).
+const NS_COLORS = [
+	20, 21, 26, 27, 32, 33, 38, 39, 40, 41, 42, 43, 44, 45, 56, 57, 62, 63, 68, 69, 74, 75, 76, 77,
+	78, 79, 80, 81, 92, 93, 98, 99, 112, 113, 128, 129, 134, 135, 148, 149, 160, 161, 162, 163, 164,
+	165, 166, 167, 168, 169, 170, 171, 172, 173, 178, 179, 184, 185, 196, 197, 198, 199, 200, 201,
+	202, 203, 204, 205, 206, 207, 208, 209, 214, 215, 220, 221
+];
+
+/** Deterministic hash → palette index (the `debug` module's djb2-ish variant). */
+function colorFor(namespace: string): number {
+	let hash = 0;
+	for (let i = 0; i < namespace.length; i++) {
+		hash = (hash << 5) - hash + namespace.charCodeAt(i);
+		hash |= 0; // keep it a 32-bit int
+	}
+	return NS_COLORS[Math.abs(hash) % NS_COLORS.length];
+}
+
+/** Wrap a namespace in its stable 256-color ANSI code (dev only). */
+function paintNamespace(namespace: string): string {
+	return `\x1b[38;5;${colorFor(namespace)}m${namespace}\x1b[0m`;
+}
+
+// ---------------------------------------------------------------------------
+// Configuration from the environment.
+// ---------------------------------------------------------------------------
+const LEVEL = process.env.LOG_LEVEL?.toLowerCase() || 'info';
+
+/** Pretty output when LOG_PRETTY is set truthy; otherwise whenever we're not in
+ *  production. LOG_PRETTY=false/0 forces JSON even in dev (e.g. to eyeball prod
+ *  output locally). */
+function usePretty(): boolean {
+	const flag = process.env.LOG_PRETTY;
+	if (flag != null && flag !== '') return flag !== 'false' && flag !== '0';
+	return process.env.NODE_ENV !== 'production';
+}
+
+function makeRoot(): pino.Logger {
+	if (usePretty()) {
+		const stream = pretty({
+			colorize: true,
+			singleLine: true, // keep bound correlation fields on the same line
+			translateTime: 'SYS:HH:MM:ss.l',
+			// `ns` is rendered (colored) by messageFormat; host/pid are constant per
+			// process and only clutter the dev stream (they remain in prod JSON).
+			ignore: `${NS_KEY},pid,hostname,host`,
+			messageFormat: (log, messageKey) => {
+				const ns = log[NS_KEY] ? `${paintNamespace(String(log[NS_KEY]))} ` : '';
+				return `${ns}${log[messageKey] ?? ''}`;
+			}
+		});
+		return pino({ level: LEVEL }, stream);
+	}
+	// Prod: newline-delimited JSON to stdout. `base: null` drops pino's default
+	// pid/hostname bindings so callers bind exactly the correlation they want.
+	return pino({ level: LEVEL, base: null });
+}
+
+/** The process-wide base logger. Namespaced/correlation children descend from it. */
+export const rootLogger: pino.Logger = makeRoot();
+
+/**
+ * A namespaced child logger. The namespace is carried as the `ns` field (a stable
+ * color in dev, a plain field in prod JSON). Add correlation with `.child(...)`:
+ *
+ *     const log = logger('crawl').child({ workerId, runId, mode, phase });
+ */
+export function logger(namespace: string): pino.Logger {
+	return rootLogger.child({ [NS_KEY]: namespace });
+}
+
+/** Re-exported for convenient type annotations at call sites. */
+export type Logger = pino.Logger;

--- a/worker/crawl.ts
+++ b/worker/crawl.ts
@@ -43,7 +43,7 @@ import {
 	sha256Hex
 } from './http';
 import { refreshActiveWorker } from './registry';
-import { logger } from '../src/lib/server/log';
+import { runLogger } from './log';
 
 const HEARTBEAT_MS = 2000;
 
@@ -238,13 +238,8 @@ export async function executeRun(run: SyncRun, opts: { publish?: boolean } = {})
 	const mode = run.mode as Mode;
 	const runId = run.id;
 	const maxPages = run.maxPages ?? MAX_PAGES;
-	// Correlation for the whole crawl — workerId/runId/mode/phase on every line.
-	const log = logger('crawl').child({
-		workerId: run.workerId ?? undefined,
-		runId,
-		mode,
-		phase: 'crawling'
-	});
+	// workerId/runId/mode/phase ride on every line (see worker/log.ts).
+	const log = runLogger('crawl', run, 'crawling');
 
 	// Optional document size limit: docs bigger than this are recorded but not
 	// downloaded (HTML is always fetched). Per-run params override the env default.
@@ -433,13 +428,8 @@ export async function executeSync(run: SyncRun, opts: { publish?: boolean } = {}
 	const maxPages = run.maxPages ?? MAX_PAGES;
 	const params = run.params ? (JSON.parse(run.params) as { maxDocBytes?: number }) : {};
 	const maxDocBytes = typeof params.maxDocBytes === 'number' ? params.maxDocBytes : MAX_DOC_BYTES;
-	// Correlation for the whole sync run — workerId/runId/mode/phase on every line.
-	const log = logger('crawl').child({
-		workerId: run.workerId ?? undefined,
-		runId,
-		mode: run.mode,
-		phase: 'crawling'
-	});
+	// workerId/runId/mode/phase ride on every line (see worker/log.ts).
+	const log = runLogger('crawl', run, 'crawling');
 	// Blobs always land in the local backend; R2 write-through is opt-in (--publish).
 	const writer = makeBlobWriter({ publish: opts.publish ?? false });
 	log.info({ blobStore: writer.label }, 'blob store');

--- a/worker/crawl.ts
+++ b/worker/crawl.ts
@@ -43,6 +43,7 @@ import {
 	sha256Hex
 } from './http';
 import { refreshActiveWorker } from './registry';
+import { logger } from '../src/lib/server/log';
 
 const HEARTBEAT_MS = 2000;
 
@@ -237,6 +238,13 @@ export async function executeRun(run: SyncRun, opts: { publish?: boolean } = {})
 	const mode = run.mode as Mode;
 	const runId = run.id;
 	const maxPages = run.maxPages ?? MAX_PAGES;
+	// Correlation for the whole crawl — workerId/runId/mode/phase on every line.
+	const log = logger('crawl').child({
+		workerId: run.workerId ?? undefined,
+		runId,
+		mode,
+		phase: 'crawling'
+	});
 
 	// Optional document size limit: docs bigger than this are recorded but not
 	// downloaded (HTML is always fetched). Per-run params override the env default.
@@ -246,7 +254,7 @@ export async function executeRun(run: SyncRun, opts: { publish?: boolean } = {})
 	// Blobs always land in the local backend; R2 write-through is opt-in (--publish).
 	// Only crawl/recrawl write bodies; estimate never touches storage.
 	const writer = makeBlobWriter({ publish: opts.publish ?? false });
-	if (mode !== 'estimate') console.log(`blob store: ${writer.label}`);
+	if (mode !== 'estimate') log.info({ blobStore: writer.label }, 'blob store');
 
 	const robots = await Robots.load(BASE_URL);
 	const stats = zeroStats();
@@ -315,6 +323,7 @@ export async function executeRun(run: SyncRun, opts: { publish?: boolean } = {})
 
 		if (!robots.canFetch(url)) {
 			await logEvent(runId, url, 'robots_blocked', null, null);
+			log.debug({ url }, 'robots blocked');
 			continue;
 		}
 
@@ -344,11 +353,15 @@ export async function executeRun(run: SyncRun, opts: { publish?: boolean } = {})
 
 		const { resp, throttled, error } = await politeFetch(url, headers);
 		stats.requestsMade++;
-		if (throttled) await logEvent(runId, url, 'throttled', null, null);
+		if (throttled) {
+			await logEvent(runId, url, 'throttled', null, null);
+			log.debug({ url }, 'throttled');
+		}
 
 		if (!resp) {
 			stats.errorCount++;
 			await logEvent(runId, url, 'fetch_error', null, error ?? 'no response');
+			log.warn({ url, error: error ?? 'no response' }, 'fetch error');
 			await recordFailure(runId, url, prev?.id, 0, 'error');
 			await politeDelay();
 			continue;
@@ -364,6 +377,7 @@ export async function executeRun(run: SyncRun, opts: { publish?: boolean } = {})
 			resp.body?.cancel();
 			stats.errorCount++;
 			await logEvent(runId, url, 'http_error', resp.status, null);
+			log.warn({ url, status: resp.status }, 'http error');
 			if (resp.status === 404 || resp.status === 410) {
 				stats.goneCount++;
 				await recordGone(runId, url, prev?.id, resp.status);
@@ -419,9 +433,16 @@ export async function executeSync(run: SyncRun, opts: { publish?: boolean } = {}
 	const maxPages = run.maxPages ?? MAX_PAGES;
 	const params = run.params ? (JSON.parse(run.params) as { maxDocBytes?: number }) : {};
 	const maxDocBytes = typeof params.maxDocBytes === 'number' ? params.maxDocBytes : MAX_DOC_BYTES;
+	// Correlation for the whole sync run — workerId/runId/mode/phase on every line.
+	const log = logger('crawl').child({
+		workerId: run.workerId ?? undefined,
+		runId,
+		mode: run.mode,
+		phase: 'crawling'
+	});
 	// Blobs always land in the local backend; R2 write-through is opt-in (--publish).
 	const writer = makeBlobWriter({ publish: opts.publish ?? false });
-	console.log(`blob store: ${writer.label}`);
+	log.info({ blobStore: writer.label }, 'blob store');
 
 	const robots = await Robots.load(BASE_URL);
 	const stats = zeroStats();
@@ -529,6 +550,7 @@ export async function executeSync(run: SyncRun, opts: { publish?: boolean } = {}
 			}
 			if (!robots.canFetch(r.url)) {
 				await logEvent(runId, r.url, 'robots_blocked', null, null);
+				log.debug({ url: r.url }, 'robots blocked');
 				await schedule(r.id, r.priority);
 				continue;
 			}
@@ -540,11 +562,15 @@ export async function executeSync(run: SyncRun, opts: { publish?: boolean } = {}
 
 			const { resp, throttled, error } = await politeFetch(r.url, headers);
 			stats.requestsMade++;
-			if (throttled) await logEvent(runId, r.url, 'throttled', null, null);
+			if (throttled) {
+				await logEvent(runId, r.url, 'throttled', null, null);
+				log.debug({ url: r.url }, 'throttled');
+			}
 
 			if (!resp) {
 				stats.errorCount++;
 				await logEvent(runId, r.url, 'fetch_error', null, error ?? 'no response');
+				log.warn({ url: r.url, error: error ?? 'no response' }, 'fetch error');
 				await recordFailure(runId, r.url, r.id, 0, 'error');
 				await db
 					.update(resource)
@@ -565,6 +591,7 @@ export async function executeSync(run: SyncRun, opts: { publish?: boolean } = {}
 				resp.body?.cancel();
 				stats.errorCount++;
 				await logEvent(runId, r.url, 'http_error', resp.status, null);
+				log.warn({ url: r.url, status: resp.status }, 'http error');
 				if (resp.status === 404 || resp.status === 410) {
 					stats.goneCount++;
 					await recordGone(runId, r.url, r.id, resp.status);

--- a/worker/embed.ts
+++ b/worker/embed.ts
@@ -18,6 +18,7 @@ import { EMBED_BATCH } from './config';
 import { chunkText } from './chunk';
 import { selectEmbedder, type Embedder } from './embeddings';
 import { refreshActiveWorker } from './registry';
+import { logger } from '../src/lib/server/log';
 
 const HEARTBEAT_MS = 2000;
 const BATCH = 200; // resources per DB round-trip
@@ -94,6 +95,13 @@ export async function executeEmbed(
 ): Promise<void> {
 	const runId = run.id;
 	const maxPages = run.maxPages ?? Infinity; // --max caps processed resources (testing)
+	// Correlation for the whole embed run — workerId/runId/mode/phase on every line.
+	const log = logger('embed').child({
+		workerId: run.workerId ?? undefined,
+		runId,
+		mode: run.mode,
+		phase: 'embedding'
+	});
 	const embedder = selectEmbedder(opts.embedder);
 	const stats = zero();
 	let control: string = run.control;
@@ -122,7 +130,7 @@ export async function executeEmbed(
 		.set({ status: 'running', startedAt: new Date(), currentPhase: 'embedding' })
 		.where(eq(syncRun.id, runId));
 
-	console.log(`embedder: ${embedder.id} (${embedder.dimensions} dims)`);
+	log.info({ embedder: embedder.id, dimensions: embedder.dimensions }, 'embedder selected');
 
 	// A resource_text row needs work when either:
 	//   • status 'ok' but no chunk carries its current sha (never embedded, or the
@@ -212,7 +220,9 @@ export async function executeEmbed(
 					kind: 'embed_error',
 					message: `embed failed: ${msg}`.slice(0, 500)
 				});
-				console.error(`✗ embed ${r.url}: ${msg}`);
+				// Mirror the crawl_event onto the operational stream (crawl_event itself
+				// is unchanged — this is an additional, matching-level diagnostic).
+				log.error({ err: e, url: r.url, resourceId: r.resourceId }, 'embed failed');
 			}
 		}
 	}
@@ -229,8 +239,15 @@ export async function executeEmbed(
 		})
 		.where(eq(syncRun.id, runId));
 
-	console.log(
-		`✓ embed ${runId} ${status}: ${stats.processed} processed ` +
-			`(${stats.rebuilt} rebuilt → ${stats.chunks} chunks, ${stats.cleared} cleared), ${stats.errors} errors`
+	log.info(
+		{
+			status,
+			processed: stats.processed,
+			rebuilt: stats.rebuilt,
+			chunks: stats.chunks,
+			cleared: stats.cleared,
+			errors: stats.errors
+		},
+		'embed finished'
 	);
 }

--- a/worker/embed.ts
+++ b/worker/embed.ts
@@ -18,7 +18,7 @@ import { EMBED_BATCH } from './config';
 import { chunkText } from './chunk';
 import { selectEmbedder, type Embedder } from './embeddings';
 import { refreshActiveWorker } from './registry';
-import { logger } from '../src/lib/server/log';
+import { runLogger } from './log';
 
 const HEARTBEAT_MS = 2000;
 const BATCH = 200; // resources per DB round-trip
@@ -95,13 +95,8 @@ export async function executeEmbed(
 ): Promise<void> {
 	const runId = run.id;
 	const maxPages = run.maxPages ?? Infinity; // --max caps processed resources (testing)
-	// Correlation for the whole embed run — workerId/runId/mode/phase on every line.
-	const log = logger('embed').child({
-		workerId: run.workerId ?? undefined,
-		runId,
-		mode: run.mode,
-		phase: 'embedding'
-	});
+	// workerId/runId/mode/phase ride on every line (see worker/log.ts).
+	const log = runLogger('embed', run, 'embedding');
 	const embedder = selectEmbedder(opts.embedder);
 	const stats = zero();
 	let control: string = run.control;

--- a/worker/embeddings.ts
+++ b/worker/embeddings.ts
@@ -13,9 +13,9 @@
 // column width, so the store never has to care which produced a given vector.
 import { CLOUDFLARE_EMBED_MODEL, EMBEDDING_PROVIDER, OPENAI_EMBED_MODEL } from './config';
 import { EMBED_DIM } from '../src/lib/server/db/crawl.schema';
-import { logger } from '../src/lib/server/log';
+import { workerLogger } from './log';
 
-const log = logger('embed');
+const log = workerLogger('embed');
 
 export interface Embedder {
 	/** Provenance id stored on each chunk (e.g. `cloudflare:@cf/baai/bge-base-en-v1.5`). */

--- a/worker/embeddings.ts
+++ b/worker/embeddings.ts
@@ -13,6 +13,9 @@
 // column width, so the store never has to care which produced a given vector.
 import { CLOUDFLARE_EMBED_MODEL, EMBEDDING_PROVIDER, OPENAI_EMBED_MODEL } from './config';
 import { EMBED_DIM } from '../src/lib/server/db/crawl.schema';
+import { logger } from '../src/lib/server/log';
+
+const log = logger('embed');
 
 export interface Embedder {
 	/** Provenance id stored on each chunk (e.g. `cloudflare:@cf/baai/bge-base-en-v1.5`). */
@@ -176,9 +179,9 @@ export function selectEmbedder(override?: Embedder): Embedder {
 	}
 	if (process.env.OPENAI_API_KEY) return makeOpenAIEmbedder();
 
-	console.warn(
-		'⚠ no embedding credentials found — using the deterministic fake embedder. ' +
-			'Set EMBEDDING_PROVIDER=cloudflare|openai (+ credentials) for real embeddings.'
+	log.warn(
+		'no embedding credentials found — using the deterministic fake embedder; ' +
+			'set EMBEDDING_PROVIDER=cloudflare|openai (+ credentials) for real embeddings'
 	);
 	return makeFakeEmbedder();
 }

--- a/worker/extract.ts
+++ b/worker/extract.ts
@@ -22,6 +22,7 @@ import { blob, crawlEvent, resource, resourceText, syncRun } from '../src/lib/se
 import type { ExtractionStatus, SyncRun } from '../src/lib/server/db/crawl.schema';
 import { localDir, makeLocalStorage, makeR2Storage } from './storage';
 import { refreshActiveWorker } from './registry';
+import { logger } from '../src/lib/server/log';
 
 const HEARTBEAT_MS = 2000;
 const BATCH = 200; // resources per DB round-trip
@@ -179,6 +180,13 @@ async function writeResult(
 export async function executeExtract(run: SyncRun): Promise<void> {
 	const runId = run.id;
 	const maxPages = run.maxPages ?? Infinity; // --max caps processed count (testing)
+	// Correlation for the whole extract run — workerId/runId/mode/phase on every line.
+	const log = logger('extract').child({
+		workerId: run.workerId ?? undefined,
+		runId,
+		mode: run.mode,
+		phase: 'extracting'
+	});
 	const readBlob = makeBlobReader();
 	const stats = zero();
 	let control: string = run.control;
@@ -260,6 +268,7 @@ export async function executeExtract(run: SyncRun): Promise<void> {
 				if (!bytes) {
 					stats.missingBlob++;
 					await logEvent(runId, r.url, r.id, 'blob bytes not found in any backend');
+					log.warn({ url: r.url, resourceId: r.id }, 'blob bytes not found in any backend');
 					continue;
 				}
 				const result = await extractFromBlob(r.contentType, bytes);
@@ -270,6 +279,7 @@ export async function executeExtract(run: SyncRun): Promise<void> {
 				stats.errors++;
 				const msg = e instanceof Error ? e.message : String(e);
 				await logEvent(runId, r.url, r.id, `extract failed: ${msg}`.slice(0, 500));
+				log.error({ err: e, url: r.url, resourceId: r.id }, 'extract failed');
 			}
 		}
 	}
@@ -286,10 +296,18 @@ export async function executeExtract(run: SyncRun): Promise<void> {
 		})
 		.where(eq(syncRun.id, runId));
 
-	console.log(
-		`✓ extract ${runId} ${status}: ${stats.processed} processed ` +
-			`(${stats.ok} ok, ${stats.empty} empty, ${stats.scanned} scanned, ` +
-			`${stats.unsupported} unsupported), ${stats.missingBlob} missing-blob, ${stats.errors} errors`
+	log.info(
+		{
+			status,
+			processed: stats.processed,
+			ok: stats.ok,
+			empty: stats.empty,
+			scanned: stats.scanned,
+			unsupported: stats.unsupported,
+			missingBlob: stats.missingBlob,
+			errors: stats.errors
+		},
+		'extract finished'
 	);
 }
 

--- a/worker/extract.ts
+++ b/worker/extract.ts
@@ -22,7 +22,7 @@ import { blob, crawlEvent, resource, resourceText, syncRun } from '../src/lib/se
 import type { ExtractionStatus, SyncRun } from '../src/lib/server/db/crawl.schema';
 import { localDir, makeLocalStorage, makeR2Storage } from './storage';
 import { refreshActiveWorker } from './registry';
-import { logger } from '../src/lib/server/log';
+import { runLogger } from './log';
 
 const HEARTBEAT_MS = 2000;
 const BATCH = 200; // resources per DB round-trip
@@ -180,13 +180,8 @@ async function writeResult(
 export async function executeExtract(run: SyncRun): Promise<void> {
 	const runId = run.id;
 	const maxPages = run.maxPages ?? Infinity; // --max caps processed count (testing)
-	// Correlation for the whole extract run — workerId/runId/mode/phase on every line.
-	const log = logger('extract').child({
-		workerId: run.workerId ?? undefined,
-		runId,
-		mode: run.mode,
-		phase: 'extracting'
-	});
+	// workerId/runId/mode/phase ride on every line (see worker/log.ts).
+	const log = runLogger('extract', run, 'extracting');
 	const readBlob = makeBlobReader();
 	const stats = zero();
 	let control: string = run.control;

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -23,6 +23,7 @@ import { executeRun, executeSync } from './crawl';
 import { executeExtract } from './extract';
 import { executeEmbed } from './embed';
 import { deregisterWorker, sweepStaleWorkers, upsertWorker, type WorkerIdentity } from './registry';
+import { logger } from '../src/lib/server/log';
 
 const WORKER_HOST = process.env.HOSTNAME ?? hostname();
 const WORKER_ID = `${WORKER_HOST}-${process.pid}-${crypto.randomUUID().slice(0, 8)}`;
@@ -31,12 +32,16 @@ const POLL_INTERVAL_MS = 3000;
 const MAINTENANCE_INTERVAL_MS = 30_000;
 const ACTIVE = ['queued', 'running', 'paused'] as const;
 
+// Base logger for the poll loop, bound with this process's identity — every line
+// below (and every per-run child) self-locates by workerId/host/pid.
+const log = logger('index').child({ workerId: WORKER_ID, host: WORKER_HOST, pid: process.pid });
+
 let stopping = false;
 let standby = false;
-process.on(
-	'SIGINT',
-	() => ((stopping = true), console.log('\nshutting down after current job...'))
-);
+process.on('SIGINT', () => {
+	stopping = true;
+	log.info('SIGINT received — shutting down after current job');
+});
 process.on('SIGTERM', () => (stopping = true));
 
 /** Apply pending drizzle migrations (same runner the web app uses). */
@@ -46,7 +51,7 @@ async function ensureSchema(): Promise<void> {
 		.filter((f) => f.endsWith('.sql'))
 		.map((name) => ({ name, sql: readFileSync(dir + name, 'utf8') }));
 	const ran = await applyMigrations(client, entries);
-	if (ran.length) console.log(`applied ${ran.length} migration(s): ${ran.join(', ')}`);
+	if (ran.length) log.info({ migrations: ran }, `applied ${ran.length} migration(s)`);
 }
 
 /** Atomically claim the oldest queued run; returns it or null. */
@@ -69,7 +74,10 @@ async function claimNext(): Promise<SyncRun | null> {
 		.limit(1);
 	if (live) {
 		if (!standby) {
-			console.log(`another worker (${live.workerId}) owns an active run — standing by`);
+			log.info(
+				{ activeWorkerId: live.workerId },
+				'another worker owns an active run — standing by'
+			);
 			standby = true;
 		}
 		return null;
@@ -93,7 +101,10 @@ async function claimNext(): Promise<SyncRun | null> {
 }
 
 async function runOne(run: SyncRun, publish: boolean): Promise<void> {
-	console.log(`▶ run ${run.id} mode=${run.mode} max=${run.maxPages ?? 'default'}`);
+	// Per-run child: runId + mode ride on every line the run's own modules emit too
+	// (they bind the same fields off run.*), so the whole run correlates.
+	const runLog = log.child({ runId: run.id, mode: run.mode });
+	runLog.info({ maxPages: run.maxPages ?? 'default', publish }, 'run started');
 	try {
 		if (run.mode === 'sync') await executeSync(run, { publish });
 		else if (run.mode === 'extract') await executeExtract(run);
@@ -102,14 +113,21 @@ async function runOne(run: SyncRun, publish: boolean): Promise<void> {
 		const [done] = await db.select().from(syncRun).where(eq(syncRun.id, run.id));
 		// extract/embed log their own summary (counts are stage-specific, not crawl rollups).
 		if (run.mode !== 'extract' && run.mode !== 'embed') {
-			console.log(
-				`✓ run ${run.id} ${done?.status}: ${done?.pages} pages, ${done?.documents} docs, ` +
-					`${done?.newCount} new / ${done?.changedCount} changed, ${done?.errorCount} errors`
+			runLog.info(
+				{
+					status: done?.status,
+					pages: done?.pages,
+					documents: done?.documents,
+					new: done?.newCount,
+					changed: done?.changedCount,
+					errors: done?.errorCount
+				},
+				'run finished'
 			);
 		}
 	} catch (e) {
 		const msg = e instanceof Error ? (e.stack ?? e.message) : String(e);
-		console.error(`✗ run ${run.id} failed:`, msg);
+		runLog.error({ err: e }, 'run failed');
 		await db
 			.update(syncRun)
 			.set({ status: 'failed', finishedAt: new Date(), error: msg.slice(0, 2000) })
@@ -130,7 +148,8 @@ async function reapStaleRuns(): Promise<void> {
 			)
 		)
 		.returning({ id: syncRun.id });
-	if (reaped.length) console.log(`reaped ${reaped.length} stale run(s)`);
+	if (reaped.length)
+		log.warn({ reaped: reaped.map((r) => r.id) }, `reaped ${reaped.length} stale run(s)`);
 }
 
 /** Auto-schedule: enqueue a `sync` run when enabled, idle, and one is due. */
@@ -151,13 +170,18 @@ async function maybeScheduleSync(): Promise<void> {
 	const dueAt = last ? last.at.getTime() + SYNC_SCHEDULE_MS : 0;
 	if (Date.now() < dueAt) return;
 	await db.insert(syncRun).values({ mode: 'sync', status: 'queued', requestedBy: 'scheduler' });
-	console.log('scheduled sync enqueued');
+	log.info('scheduled sync enqueued');
 }
 
 async function pollLoop(publish: boolean): Promise<void> {
-	const sched = SYNC_SCHEDULE_MS > 0 ? `; auto-sync every ${SYNC_SCHEDULE_MS / 60_000}m` : '';
-	const pub = publish ? '; publishing to R2' : '; local-only (unpublished)';
-	console.log(`sync worker ${WORKER_ID} polling (every ${POLL_INTERVAL_MS}ms${sched}${pub})`);
+	log.info(
+		{
+			pollIntervalMs: POLL_INTERVAL_MS,
+			autoSyncMinutes: SYNC_SCHEDULE_MS > 0 ? SYNC_SCHEDULE_MS / 60_000 : null,
+			publish
+		},
+		'sync worker polling'
+	);
 	let lastMaintenance = 0;
 	while (!stopping) {
 		if (Date.now() - lastMaintenance > MAINTENANCE_INTERVAL_MS) {
@@ -180,7 +204,7 @@ async function pollLoop(publish: boolean): Promise<void> {
 		} else await Bun.sleep(POLL_INTERVAL_MS);
 	}
 	await deregisterWorker(WORKER_ID);
-	console.log('stopped.');
+	log.info('stopped');
 }
 
 async function enqueueAndRunOnce(mode: string, publish: boolean, maxPages?: number): Promise<void> {

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -23,7 +23,7 @@ import { executeRun, executeSync } from './crawl';
 import { executeExtract } from './extract';
 import { executeEmbed } from './embed';
 import { deregisterWorker, sweepStaleWorkers, upsertWorker, type WorkerIdentity } from './registry';
-import { logger } from '../src/lib/server/log';
+import { workerLogger } from './log';
 
 const WORKER_HOST = process.env.HOSTNAME ?? hostname();
 const WORKER_ID = `${WORKER_HOST}-${process.pid}-${crypto.randomUUID().slice(0, 8)}`;
@@ -32,9 +32,9 @@ const POLL_INTERVAL_MS = 3000;
 const MAINTENANCE_INTERVAL_MS = 30_000;
 const ACTIVE = ['queued', 'running', 'paused'] as const;
 
-// Base logger for the poll loop, bound with this process's identity — every line
-// below (and every per-run child) self-locates by workerId/host/pid.
-const log = logger('index').child({ workerId: WORKER_ID, host: WORKER_HOST, pid: process.pid });
+// Base logger for the poll loop, bound with this process's worker id (host/pid come
+// from workerLogger) — every line below, and every per-run child, self-locates.
+const log = workerLogger('index').child({ workerId: WORKER_ID });
 
 let stopping = false;
 let standby = false;

--- a/worker/log.ts
+++ b/worker/log.ts
@@ -1,0 +1,29 @@
+// Worker-scoped helpers over the shared logger (src/lib/server/log.ts). Two things
+// every worker logger wants, factored out so no call site re-hand-rolls them:
+//   • the `worker:` namespace prefix — so worker namespaces never collide with the
+//     app's once it adopts the same logger (#52), and stay grouped in aggregation;
+//   • process identity (host/pid) bound on every line.
+// Plus a per-run helper binding the SyncRun correlation (workerId/runId/mode/phase)
+// in one place, so a run's modules don't each duplicate the same child({...}) and a
+// future correlation field is a one-line change here, not shotgun surgery.
+import { hostname } from 'node:os';
+import { logger, type Logger } from '../src/lib/server/log';
+import type { SyncRun } from '../src/lib/server/db/crawl.schema';
+
+const HOST = process.env.HOSTNAME ?? hostname();
+
+/** A namespaced worker logger — `worker:<module>`, bound with host/pid. */
+export function workerLogger(module: string): Logger {
+	return logger(`worker:${module}`).child({ host: HOST, pid: process.pid });
+}
+
+/** Per-run child of a worker logger: binds workerId/runId/mode/phase off the run so
+ *  every downstream line self-locates without passing fields per call. */
+export function runLogger(module: string, run: SyncRun, phase: string): Logger {
+	return workerLogger(module).child({
+		workerId: run.workerId ?? undefined,
+		runId: run.id,
+		mode: run.mode,
+		phase
+	});
+}

--- a/worker/registry.ts
+++ b/worker/registry.ts
@@ -6,9 +6,9 @@
 import { eq, lt } from 'drizzle-orm';
 import { db } from './db';
 import { worker } from '../src/lib/server/db/schema';
-import { logger } from '../src/lib/server/log';
+import { workerLogger } from './log';
 
-const log = logger('registry');
+const log = workerLogger('registry');
 
 export type WorkerRole = 'active' | 'standby';
 

--- a/worker/registry.ts
+++ b/worker/registry.ts
@@ -6,6 +6,9 @@
 import { eq, lt } from 'drizzle-orm';
 import { db } from './db';
 import { worker } from '../src/lib/server/db/schema';
+import { logger } from '../src/lib/server/log';
+
+const log = logger('registry');
 
 export type WorkerRole = 'active' | 'standby';
 
@@ -40,7 +43,8 @@ export async function upsertWorker(
 			})
 			.onConflictDoUpdate({ target: worker.id, set: { role, runId, phase, lastSeenAt: now } });
 	} catch (e) {
-		console.error('worker registry upsert failed:', e instanceof Error ? e.message : e);
+		// Best-effort: a registry write must never disturb an in-flight run.
+		log.warn({ err: e, workerId: identity.id, role }, 'worker registry upsert failed');
 	}
 }
 
@@ -69,7 +73,11 @@ export async function sweepStaleWorkers(olderThanMs: number): Promise<void> {
 		.delete(worker)
 		.where(lt(worker.lastSeenAt, new Date(Date.now() - olderThanMs)))
 		.returning({ id: worker.id });
-	if (swept.length) console.log(`swept ${swept.length} stale worker registration(s)`);
+	if (swept.length)
+		log.warn(
+			{ swept: swept.map((w) => w.id) },
+			`swept ${swept.length} stale worker registration(s)`
+		);
 }
 
 /** Best-effort self-removal so a graceful shutdown leaves the live set promptly

--- a/worker/sync-blobs.ts
+++ b/worker/sync-blobs.ts
@@ -17,6 +17,9 @@ import { eq, isNull } from 'drizzle-orm';
 import { db } from './db';
 import { blob } from '../src/lib/server/db/schema';
 import { makeLocalStorage, makeR2Storage, localDir, type Storage } from './storage';
+import { logger } from '../src/lib/server/log';
+
+const log = logger('sync-blobs');
 
 function human(n: number): string {
 	const u = ['B', 'KB', 'MB', 'GB', 'TB'];
@@ -54,9 +57,17 @@ async function copyMissing(
 		copied++;
 		bytes += data.byteLength;
 	}
-	console.log(
-		`${dir.name}: ${dryRun ? 'would copy' : 'copied'} ${copied} object(s), ${human(bytes)}` +
-			(missingSrc ? ` — ${missingSrc} missing at source (${dir.src.kind})` : '')
+	log.info(
+		{
+			direction: dir.name,
+			dryRun,
+			copied,
+			bytes,
+			human: human(bytes),
+			missingSrc,
+			source: dir.src.kind
+		},
+		`${dir.name}: ${dryRun ? 'would copy' : 'copied'} ${copied} object(s), ${human(bytes)}`
 	);
 	return { copied, bytes, missingSrc };
 }
@@ -97,10 +108,18 @@ async function pushHeld(local: Storage, r2: Storage, dryRun: boolean) {
 		stamped++;
 		bytes += data.byteLength;
 	}
-	console.log(
+	log.info(
+		{
+			held: held.length,
+			dryRun,
+			promoted: copied,
+			bytes,
+			human: human(bytes),
+			stamped,
+			missingSrc
+		},
 		`push (local→R2): ${held.length} held · ${dryRun ? 'would promote' : 'promoted'} ${copied} ` +
-			`object(s), ${human(bytes)}${dryRun ? '' : ` · stamped ${stamped}`}` +
-			(missingSrc ? ` — ${missingSrc} missing at source (local)` : '')
+			`object(s), ${human(bytes)}${dryRun ? '' : ` · stamped ${stamped}`}`
 	);
 	return { copied, bytes, stamped, missingSrc };
 }
@@ -115,7 +134,7 @@ const doPull =
 const local = makeLocalStorage(localDir());
 const r2 = makeR2Storage();
 if (!r2) {
-	console.error(
+	log.error(
 		'R2 is not configured — set R2_ENDPOINT / R2_BUCKET / R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY.'
 	);
 	process.exit(1);
@@ -127,7 +146,8 @@ const rows = (
 	(r) => r.key && !r.key.startsWith('local/') // ignore legacy placeholder keys
 ) as { key: string; contentType: string | null }[];
 
-console.log(
+log.info(
+	{ blobs: rows.length, local: local.label, remote: r2.label, dryRun },
 	`manifest: ${rows.length} blob(s) · local=${local.label} · remote=${r2.label}${dryRun ? ' · DRY RUN' : ''}`
 );
 

--- a/worker/sync-blobs.ts
+++ b/worker/sync-blobs.ts
@@ -17,9 +17,9 @@ import { eq, isNull } from 'drizzle-orm';
 import { db } from './db';
 import { blob } from '../src/lib/server/db/schema';
 import { makeLocalStorage, makeR2Storage, localDir, type Storage } from './storage';
-import { logger } from '../src/lib/server/log';
+import { workerLogger } from './log';
 
-const log = logger('sync-blobs');
+const log = workerLogger('sync-blobs');
 
 function human(n: number): string {
 	const u = ['B', 'KB', 'MB', 'GB', 'TB'];


### PR DESCRIPTION
Closes #16

## What

Introduces a shared, server-side **pino** logger (`src/lib/server/log.ts`) and migrates the sync worker onto it. Leveled JSON to stdout in prod; pretty-printed in dev with a **stable per-namespace color** (the `debug` npm module's hash→256-color idea). `crawl_event` is untouched.

- `src/lib/server/log.ts` — base pino logger + `logger(namespace)`; importable by BOTH worker and app (app is follow-up #52).
- `worker/log.ts` — worker-scoped helpers: `workerLogger(module)` (prefixes `worker:`, binds host/pid) and `runLogger(module, run, phase)` (binds workerId/runId/mode/phase off the `SyncRun` in one place).
- All operational worker `console.*` calls migrated to namespaced child loggers with sensible levels.
- At each error/significant `crawl_event` write, the worker now ALSO emits a matching-level log — the `crawl_event` table and its writers/consumers are unchanged.

## Acceptance criteria

- [x] **1.** Shared pino logger module exists, importable by worker AND app; prod emits JSON lines to stdout, dev pretty-prints.
- [x] **2.** `LOG_LEVEL` gates output — verified `LOG_LEVEL=warn` suppresses info/debug.
- [x] **3.** Each worker module logs under its own namespace; dev shows a stable, distinct color per namespace (observed `worker:index`→196, `worker:crawl`→41, `worker:embed`→33). Prod JSON carries `ns` as a field.
- [x] **4.** Logs carry correlation (`workerId`+`host`/`pid`; `runId`/`mode`/`phase` where applicable) via child loggers — no per-call passing.
- [x] **5.** All operational worker `console.*` replaced; no bare `console.*` in `worker/` except the eval report CLI (see note).
- [x] **6.** `crawl_event` unchanged; error/significant sites emit a matching log alongside the existing write.
- [x] **7.** `bun run check` clean (0 errors); `prettier`/`eslint` clean on tracked files; JSON verified in prod mode, colored per-namespace pretty in dev.

## Verify coverage

Ran `worker/index.ts` locally against `file:` DBs and OBSERVED output:
- **dev** (`--mode crawl/estimate --max N --once`): leveled, per-namespace-colored (`worker:index` vs `worker:crawl` distinct colors), correlation-bearing lines; same `runId` flows from `worker:index` to `worker:crawl` with no manual passing.
- **prod** (`NODE_ENV=production`): one JSON object per line with `ns`/`host`/`pid`/`workerId`/`runId`/`mode`/`phase`/`msg`.
- **gating**: `LOG_LEVEL=warn` suppressed all info lines.
- 31 worker unit tests pass; `bun run check` 0 errors; eslint/prettier clean (gitignored `project.inlang/*` warnings ignored per brief).

## Bun / pino note

pino-pretty is attached as an **in-process (single-thread) stream**, NOT via `pino.transport()` worker threads — I validated pino's worker-thread transport is the risky path under Bun, and the synchronous/single-thread destination runs cleanly. Prod uses pino's default stdout destination. No transport worker threads anywhere.

## Deliberate exception (criterion 5)

`worker/eval/run.ts` keeps its 3 `console.*` calls: it's a standalone report CLI (the eval harness, #39) whose stdout output IS the program's product (a formatted text/markdown report), not the sync worker's operational stream. Migrating it belongs with the eval harness, not this issue.

## Reviewer must-checks

- `worker/log.ts` correlation contract (the `run.workerId ?? undefined` guard and field names) — single source of truth now.
- Level choices at the mirrored `crawl_event` sites: `fetch_error`/`http_error`→`warn`, extract/embed failures→`error`, `robots_blocked`/`throttled`→`debug`.
- `base: null` in prod (log.ts) drops pino's default pid/hostname so `worker/log.ts` binds host/pid explicitly — intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)