### PR TITLE
feat(app): structured server request + error logging via hooks (#52)

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -8,8 +8,10 @@ declare global {
 			user?: User;
 			session?: Session;
 			/** Per-request correlation id, set in hooks.server.ts and bound onto the
-			 *  request logger; available to downstream loads/actions for correlation. */
-			requestId: string;
+			 *  request logger; available to downstream loads/actions for correlation.
+			 *  Optional: handleError may fire for a failure that precedes the request
+			 *  hook, so downstream readers must tolerate it being unset. */
+			requestId?: string;
 		}
 
 		// interface Error {}

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -7,6 +7,9 @@ declare global {
 		interface Locals {
 			user?: User;
 			session?: Session;
+			/** Per-request correlation id, set in hooks.server.ts and bound onto the
+			 *  request logger; available to downstream loads/actions for correlation. */
+			requestId: string;
 		}
 
 		// interface Error {}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -3,9 +3,42 @@ import { building } from '$app/env';
 import { auth } from '$lib/server/auth';
 import { ensureDb } from '$lib/server/db';
 import { svelteKitHandler } from 'better-auth/svelte-kit';
-import type { Handle } from '@sveltejs/kit';
+import type { Handle, HandleServerError } from '@sveltejs/kit';
 import { getTextDirection } from '$lib/paraglide/runtime';
 import { paraglideMiddleware } from '$lib/paraglide/server';
+import { logger } from '$lib/server/log';
+
+// One request logger for the whole app. Per-request correlation (the request id)
+// is bound as a `.child(...)` inside the hook, mirroring how the worker binds its
+// per-run correlation (see worker/log.ts) rather than passing fields per call.
+const requestLog = logger('app:request');
+
+// Outermost hook: tag every request with an id, then log it exactly once when the
+// response is ready — method/path/status/duration, at a level chosen by status
+// class. Sits first in the sequence so it wraps the full handling (auth, i18n,
+// route) and reports the real final status and total duration.
+const handleRequestLogging: Handle = async ({ event, resolve }) => {
+	const requestId = crypto.randomUUID();
+	event.locals.requestId = requestId;
+
+	const start = performance.now();
+	const response = await resolve(event);
+	const duration = Math.round(performance.now() - start);
+
+	const method = event.request.method;
+	const path = event.url.pathname;
+	const status = response.status;
+	const log = requestLog.child({ requestId });
+	const fields = { method, path, status, duration };
+	const msg = `${method} ${path} ${status} ${duration}ms`;
+
+	// Level by status class: 5xx → error, 4xx → warn, otherwise info.
+	if (status >= 500) log.error(fields, msg);
+	else if (status >= 400) log.warn(fields, msg);
+	else log.info(fields, msg);
+
+	return response;
+};
 
 const handleParaglide: Handle = ({ event, resolve }) =>
 	paraglideMiddleware(event.request, ({ request, locale }) => {
@@ -33,4 +66,19 @@ const handleBetterAuth: Handle = async ({ event, resolve }) => {
 	return svelteKitHandler({ event, resolve, auth, building });
 };
 
-export const handle: Handle = sequence(handleParaglide, handleBetterAuth);
+export const handle: Handle = sequence(handleRequestLogging, handleParaglide, handleBetterAuth);
+
+// Unexpected server errors (thrown, not `error(...)` responses) land here. Log them
+// at error with the request id (so they correlate to the request line above) and
+// the stack — pino's default `err` serializer captures the stack. Returning nothing
+// keeps SvelteKit's default error response.
+//
+// SvelteKit also routes plain 404s through this hook; those aren't server faults and
+// the request hook already records them at warn, so we skip them (< 500) to keep the
+// error stream to genuine, actionable faults.
+export const handleError: HandleServerError = ({ error, event, status, message }) => {
+	if (status < 500) return;
+	logger('app:error')
+		.child({ requestId: event.locals.requestId })
+		.error({ err: error, status, method: event.request.method, path: event.url.pathname }, message);
+};

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -6,17 +6,14 @@ import { svelteKitHandler } from 'better-auth/svelte-kit';
 import type { Handle, HandleServerError } from '@sveltejs/kit';
 import { getTextDirection } from '$lib/paraglide/runtime';
 import { paraglideMiddleware } from '$lib/paraglide/server';
-import { logger } from '$lib/server/log';
-
-// One request logger for the whole app. Per-request correlation (the request id)
-// is bound as a `.child(...)` inside the hook, mirroring how the worker binds its
-// per-run correlation (see worker/log.ts) rather than passing fields per call.
-const requestLog = logger('app:request');
+import { appLogger } from '$lib/server/app-log';
 
 // Outermost hook: tag every request with an id, then log it exactly once when the
 // response is ready — method/path/status/duration, at a level chosen by status
 // class. Sits first in the sequence so it wraps the full handling (auth, i18n,
-// route) and reports the real final status and total duration.
+// route) and reports the real final status and total duration. Per-request
+// correlation (the request id) is bound via appLogger, mirroring how the worker
+// binds its per-run correlation (see worker/log.ts) rather than passing it per call.
 const handleRequestLogging: Handle = async ({ event, resolve }) => {
 	const requestId = crypto.randomUUID();
 	event.locals.requestId = requestId;
@@ -28,7 +25,7 @@ const handleRequestLogging: Handle = async ({ event, resolve }) => {
 	const method = event.request.method;
 	const path = event.url.pathname;
 	const status = response.status;
-	const log = requestLog.child({ requestId });
+	const log = appLogger('request', requestId);
 	const fields = { method, path, status, duration };
 	const msg = `${method} ${path} ${status} ${duration}ms`;
 
@@ -78,7 +75,8 @@ export const handle: Handle = sequence(handleRequestLogging, handleParaglide, ha
 // error stream to genuine, actionable faults.
 export const handleError: HandleServerError = ({ error, event, status, message }) => {
 	if (status < 500) return;
-	logger('app:error')
-		.child({ requestId: event.locals.requestId })
-		.error({ err: error, status, method: event.request.method, path: event.url.pathname }, message);
+	appLogger('error', event.locals.requestId).error(
+		{ err: error, status, method: event.request.method, path: event.url.pathname },
+		message
+	);
 };

--- a/src/lib/server/app-log.ts
+++ b/src/lib/server/app-log.ts
@@ -1,0 +1,19 @@
+// App-scoped helpers over the shared logger (./log.ts), mirroring worker/log.ts so
+// the SvelteKit app and the sync worker use the logger the same way:
+//   • the `app:` namespace prefix — so app namespaces stay grouped in aggregation and
+//     never collide with the worker's `worker:` ones;
+//   • process identity (host/pid) bound on every line;
+//   • optional per-request correlation bound in ONE place, so a future correlation
+//     field is a one-line change here, not shotgun surgery across call sites (the same
+//     rationale worker/log.ts gives for runLogger).
+import { hostname } from 'node:os';
+import { logger, type Logger } from './log';
+
+const HOST = process.env.HOSTNAME ?? hostname();
+
+/** A namespaced app logger — `app:<module>`, bound with host/pid and, when a request
+ *  id is supplied, correlated to that request. */
+export function appLogger(module: string, requestId?: string): Logger {
+	const log = logger(`app:${module}`).child({ host: HOST, pid: process.pid });
+	return requestId == null ? log : log.child({ requestId });
+}

--- a/src/routes/ask/+page.server.ts
+++ b/src/routes/ask/+page.server.ts
@@ -2,7 +2,7 @@ import { fail, redirect } from '@sveltejs/kit';
 import type { Actions, PageServerLoad } from './$types';
 import { answer } from '$lib/server/rag/answer';
 import type { AskResult } from '$lib/chat';
-import { logger } from '$lib/server/log';
+import { appLogger } from '$lib/server/app-log';
 
 // Gate /ask behind an authenticated session — same guard the dashboard uses
 // (src/routes/dashboard/+layout.server.ts). Unauthenticated visitors are bounced
@@ -20,7 +20,7 @@ export const actions: Actions = {
 	// a streaming variant (a +server.ts endpoint) can be added later without
 	// changing the UI's turn model.
 	ask: async ({ request, locals }) => {
-		const log = logger('app:ask').child({ requestId: locals.requestId });
+		const log = appLogger('ask', locals.requestId);
 		if (!locals.user) return fail(401, { error: 'Not authenticated' });
 
 		const data = await request.formData();

--- a/src/routes/ask/+page.server.ts
+++ b/src/routes/ask/+page.server.ts
@@ -2,6 +2,7 @@ import { fail, redirect } from '@sveltejs/kit';
 import type { Actions, PageServerLoad } from './$types';
 import { answer } from '$lib/server/rag/answer';
 import type { AskResult } from '$lib/chat';
+import { logger } from '$lib/server/log';
 
 // Gate /ask behind an authenticated session — same guard the dashboard uses
 // (src/routes/dashboard/+layout.server.ts). Unauthenticated visitors are bounced
@@ -19,6 +20,7 @@ export const actions: Actions = {
 	// a streaming variant (a +server.ts endpoint) can be added later without
 	// changing the UI's turn model.
 	ask: async ({ request, locals }) => {
+		const log = logger('app:ask').child({ requestId: locals.requestId });
 		if (!locals.user) return fail(401, { error: 'Not authenticated' });
 
 		const data = await request.formData();
@@ -37,7 +39,7 @@ export const actions: Actions = {
 		} catch (err) {
 			// The most common failure is a missing ANTHROPIC_API_KEY (selectLlm throws).
 			// Surface a friendly message and echo the question back so the user can retry.
-			console.error('ask action failed:', err);
+			log.error({ err }, 'ask action failed');
 			return fail(503, {
 				error: 'The answering service is unavailable right now. Please try again in a moment.',
 				question


### PR DESCRIPTION
Closes #52

Adopts the shared pino logger (`src/lib/server/log.ts`) on the SvelteKit app's server side: per-request logging via the `handle` hook, error logging via `handleError`, and replacement of the one app-side server `console.*`.

## What changed
- **`src/hooks.server.ts`** — new `handleRequestLogging` handle, added to the existing `sequence(...)` **as the outermost hook** so it wraps auth + i18n and reports the real final status/duration. better-auth's and paraglide's handles are untouched. Logs each request **once** under `app:request` with `method/path/status/duration` + a per-request id (`crypto.randomUUID`), leveled by status class (5xx→error, 4xx→warn, else info). New `handleError` logs unexpected server errors under `app:error` at `error` with the request id + stack (pino's `err` serializer); it **skips `<500`** because SvelteKit routes plain 404s here too and those are already recorded at warn by the request hook (justified deliberate exception).
- **`src/lib/server/app-log.ts`** (new) — `appLogger(module, requestId?)`, mirroring `worker/log.ts`'s `workerLogger`: `app:` namespace prefix, host/pid on every line, optional per-request correlation bound in one place.
- **`src/app.d.ts`** — `requestId?: string` on `Locals` (optional: `handleError` can fire before the request hook).
- **`src/routes/ask/+page.server.ts`** — replaced the lone `console.error` with `appLogger('ask', locals.requestId)`, correlated to the request.

## Acceptance criteria
- [x] 1. Each HTTP request logged once (`app:request`) with method/path/status/duration + per-request id
- [x] 2. Unexpected server errors logged via `handleError` at `error` with request id + stack
- [x] 3. Request id on `event.locals`, typed in `app.d.ts`
- [x] 4. No bare app-side server `console.*` (only 404-skip in `handleError` is a justified exception)
- [x] 5. Honors `LOG_LEVEL`; inherits prod-JSON / dev-pretty from the shared logger
- [x] 6. `bun run check` + lint clean (app files; pre-existing `project.inlang/*` prettier warnings are gitignored generated output)

## Verify coverage
Ran the dev server and observed, on real requests: a single `app:request` line per request (INFO `GET /login 200`, WARN `GET /nope 404`), with matching per-request id; a thrown route error produced an `app:error` ERROR line with the id + full stack **and** the same id on the request line; `LOG_LEVEL=warn` dropped the 200 info lines while keeping 404 warns (INFO count 0); confirmed prod-JSON output carries `ns/host/pid/requestId` + fields + serialized `err.stack`; auth still works (better-auth handle uninvolved). Temporary throwing routes used only during verify were removed.

## Review
`/code-review` run (Standards + Spec). No hard violations. Addressed both real findings: factored the duplicated child-binding into `appLogger` (matching the worker's documented ergonomics), and made `requestId` optional for type honesty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)