### PR TITLE
feat(worker): --publish writes blobs to R2 only, never local

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -109,23 +109,25 @@ This is the cheapest way to archive the text/HTML while deferring multi-MB PDFs.
 ## 5. Blob storage: R2 canonical + opt-in publishing
 
 Bodies are content-addressed: `blobs/<ab>/<cd>/<sha256><ext>`. There are two
-backends, but they are **not** interchangeable targets picked by a switch —
-they're layered:
+backends, picked by the publish flag (never both in one run):
 
 - **local** — a filesystem dir (`.cache/blobs`, or `BLOB_DIR`). The dev/staging
-  store. Every crawl writes new bytes here first.
+  store. An unpublished crawl writes new bytes here only.
 - **r2** — Cloudflare R2 (S3-compatible), the **canonical durable archive**.
 
-**Publishing to R2 is opt-in.** The crawler always writes new blobs to the local
-backend; it only writes **through** to R2 when the worker runs with `--publish`
-(prod runs pass it). A default (unpublished) run therefore never touches R2, so a
-dev/experimental crawl can't pollute the canonical archive. This is a write-path
-policy, not a read cache — nothing in the app reads blob bytes on the hot path, so
-there is no prod read-through cache.
+**Publishing to R2 is opt-in.** Without `--publish` the crawler writes new blobs
+to the local backend **only** (`r2_synced_at` null, promotable later via
+`blobs:push`). With `--publish` (prod runs pass it) new blobs go to R2 **only** —
+no local copy is written — and are stamped `r2_synced_at`. A default (unpublished)
+run therefore never touches R2, so a dev/experimental crawl can't pollute the
+canonical archive; and a publishing run writes no local files, so it needs no
+filesystem and runs on a no-fs host without accumulating dead disk copies that
+nothing reads. This is a write-path policy, not a read cache — nothing in the app
+reads blob bytes on the hot path, so there is no prod read-through cache.
 
 `blob.r2_synced_at` (nullable timestamp) is the publish marker: **null until the
 object is confirmed present in R2**, then stamped. It's set on a successful
-`--publish` write-through and on a `blobs:push` promotion. Because it doubles as
+`--publish` R2 write and on a `blobs:push` promotion. Because it doubles as
 the "held / pending publish" queue, `r2_synced_at IS NULL` is exactly the set of
 blobs that exist only locally. The read model `getUnpublishedBlobCount()`
 (`src/lib/server/sync.ts`) exposes that backlog.
@@ -211,8 +213,8 @@ Default seeded login (local/mock DB): `admin@example.com` / `password`.
    the dashboard can presign archived copies (§5). Tables auto-create on first request.
 2. Blob store → create an R2 bucket + token, set `R2_*` (see below).
 3. Worker → run `bun run worker --publish` on an always-on host with the same
-   `DATABASE_URL`/`DATABASE_AUTH_TOKEN` + `R2_*`. `--publish` writes blobs through
-   to R2 (the canonical archive); without it the worker holds blobs local-only.
+   `DATABASE_URL`/`DATABASE_AUTH_TOKEN` + `R2_*`. `--publish` writes blobs to R2
+   only (the canonical archive); without it the worker holds blobs local-only.
    Drive it from `/dashboard`.
 
 ---
@@ -221,22 +223,22 @@ Default seeded login (local/mock DB): `admin@example.com` / `password`.
 
 Full list in [`.env.example`](../.env.example).
 
-| Var                                                                       | Used by      | Notes                                                                                                                |
-| ------------------------------------------------------------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------- |
-| `DATABASE_URL`                                                            | app + worker | Turso `libsql://…` (or `file:` locally)                                                                              |
-| `DATABASE_AUTH_TOKEN`                                                     | app + worker | Required for remote Turso                                                                                            |
-| `ORIGIN`, `BETTER_AUTH_SECRET`                                            | app          | Auth                                                                                                                 |
-| `--publish` (CLI flag, not env)                                           | worker       | Write blobs through to R2 (canonical archive) + stamp `r2_synced_at`. Default off = local-only (§5). Prod passes it. |
-| `BLOB_DIR`                                                                | worker       | Local cache dir (default `.cache/blobs`)                                                                             |
-| `R2_ENDPOINT` / `R2_BUCKET` / `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` | worker + app | Cloudflare R2 (S3 API). Worker for crawl/recrawl + `blobs:*`; the app presigns them to view archived copies (§5).    |
-| `CRAWLER_USER_AGENT`                                                      | worker       | How the crawler identifies itself (see §13).                                                                         |
-| `CRAWLER_RATE_LIMIT` / `CRAWLER_RATE_LIMIT_JITTER`                        | worker       | Base seconds between requests + random extra 0..N (non-periodic).                                                    |
-| `CRAWLER_MAX_PAGES`                                                       | worker       | Hard safety cap per run.                                                                                             |
-| `CRAWLER_MAX_DOC_BYTES`                                                   | worker       | Skip downloading docs over N bytes (0 = pages-only). See §4.                                                         |
-| `CRAWLER_SEEDS`                                                           | worker       | Comma-separated paths/URLs to override the default seeds.                                                            |
-| `CRAWLER_TTL_{CORE,PAGE,AGENDA,DOC}_DAYS`                                 | worker       | `sync` per-tier freshness TTLs (default 7/7/30/180). See §11.                                                        |
-| `CRAWLER_SYNC_BATCH` / `CRAWLER_ERROR_BACKOFF_HOURS`                      | worker       | `sync` claim batch size / failed-URL re-schedule delay.                                                              |
-| `SYNC_SCHEDULE_MINUTES` / `WORKER_STALE_MINUTES`                          | worker       | Auto-enqueue `sync` this often (0=off); reap crashed runs. §11.                                                      |
+| Var                                                                       | Used by      | Notes                                                                                                                            |
+| ------------------------------------------------------------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `DATABASE_URL`                                                            | app + worker | Turso `libsql://…` (or `file:` locally)                                                                                          |
+| `DATABASE_AUTH_TOKEN`                                                     | app + worker | Required for remote Turso                                                                                                        |
+| `ORIGIN`, `BETTER_AUTH_SECRET`                                            | app          | Auth                                                                                                                             |
+| `--publish` (CLI flag, not env)                                           | worker       | Write blobs to R2 only (canonical archive) + stamp `r2_synced_at`; no local copy. Default off = local-only (§5). Prod passes it. |
+| `BLOB_DIR`                                                                | worker       | Local cache dir (default `.cache/blobs`)                                                                                         |
+| `R2_ENDPOINT` / `R2_BUCKET` / `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` | worker + app | Cloudflare R2 (S3 API). Worker for crawl/recrawl + `blobs:*`; the app presigns them to view archived copies (§5).                |
+| `CRAWLER_USER_AGENT`                                                      | worker       | How the crawler identifies itself (see §13).                                                                                     |
+| `CRAWLER_RATE_LIMIT` / `CRAWLER_RATE_LIMIT_JITTER`                        | worker       | Base seconds between requests + random extra 0..N (non-periodic).                                                                |
+| `CRAWLER_MAX_PAGES`                                                       | worker       | Hard safety cap per run.                                                                                                         |
+| `CRAWLER_MAX_DOC_BYTES`                                                   | worker       | Skip downloading docs over N bytes (0 = pages-only). See §4.                                                                     |
+| `CRAWLER_SEEDS`                                                           | worker       | Comma-separated paths/URLs to override the default seeds.                                                                        |
+| `CRAWLER_TTL_{CORE,PAGE,AGENDA,DOC}_DAYS`                                 | worker       | `sync` per-tier freshness TTLs (default 7/7/30/180). See §11.                                                                    |
+| `CRAWLER_SYNC_BATCH` / `CRAWLER_ERROR_BACKOFF_HOURS`                      | worker       | `sync` claim batch size / failed-URL re-schedule delay.                                                                          |
+| `SYNC_SCHEDULE_MINUTES` / `WORKER_STALE_MINUTES`                          | worker       | Auto-enqueue `sync` this often (0=off); reap crashed runs. §11.                                                                  |
 
 ---
 

--- a/worker/README.md
+++ b/worker/README.md
@@ -123,14 +123,15 @@ bun run worker --publish
 Bodies are stored content-addressed (by sha256). R2 is the **canonical durable
 archive**, but publishing to it is **opt-in**:
 
-- **local** — `.cache/blobs` (or `BLOB_DIR`). The dev/staging store. Every crawl
-  writes new bytes here first.
-- **r2** — Cloudflare R2. Written **through** only when the worker runs with
-  `--publish` (prod passes it). A default run holds blobs local-only, so a
-  dev/experimental crawl can't pollute the archive.
+- **local** — `.cache/blobs` (or `BLOB_DIR`). The dev/staging store. An
+  unpublished crawl writes new bytes here only.
+- **r2** — Cloudflare R2. Written **only** (no local copy) when the worker runs
+  with `--publish` (prod passes it). A default run holds blobs local-only, so a
+  dev/experimental crawl can't pollute the archive; a publishing run writes no
+  local files, so it needs no filesystem (runs on a no-fs host).
 
 `blob.r2_synced_at` is the publish marker — null until an object is confirmed in
-R2, then stamped (on a `--publish` write-through or a `blobs:push` promotion). It
+R2, then stamped (on a `--publish` R2 write or a `blobs:push` promotion). It
 doubles as the held/pending-publish queue (`r2_synced_at IS NULL`).
 
 Because keys are immutable, promoting/reconciling is a plain copy-what's-missing —

--- a/worker/crawl.ts
+++ b/worker/crawl.ts
@@ -246,7 +246,7 @@ export async function executeRun(run: SyncRun, opts: { publish?: boolean } = {})
 	// undefined = download all documents; 0 = skip all (pages-only).
 	const params = run.params ? (JSON.parse(run.params) as { maxDocBytes?: number }) : {};
 	const maxDocBytes = typeof params.maxDocBytes === 'number' ? params.maxDocBytes : MAX_DOC_BYTES;
-	// Blobs always land in the local backend; R2 write-through is opt-in (--publish).
+	// Publishing (--publish) writes blobs to R2 only; otherwise local-only.
 	// Only crawl/recrawl write bodies; estimate never touches storage.
 	const writer = makeBlobWriter({ publish: opts.publish ?? false });
 	if (mode !== 'estimate') log.info({ blobStore: writer.label }, 'blob store');
@@ -430,7 +430,7 @@ export async function executeSync(run: SyncRun, opts: { publish?: boolean } = {}
 	const maxDocBytes = typeof params.maxDocBytes === 'number' ? params.maxDocBytes : MAX_DOC_BYTES;
 	// workerId/runId/mode/phase ride on every line (see worker/log.ts).
 	const log = runLogger('crawl', run, 'crawling');
-	// Blobs always land in the local backend; R2 write-through is opt-in (--publish).
+	// Publishing (--publish) writes blobs to R2 only; otherwise local-only.
 	const writer = makeBlobWriter({ publish: opts.publish ?? false });
 	log.info({ blobStore: writer.label }, 'blob store');
 

--- a/worker/storage.ts
+++ b/worker/storage.ts
@@ -158,20 +158,18 @@ export function makeBlobWriter(opts: { publish: boolean }): BlobWriter {
 			'--publish requires R2_* env vars (R2_ENDPOINT / R2_BUCKET / R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY).'
 		);
 	}
-	// Local backend is never touched in publish mode (no fs dependency there).
-	const local = r2 ? null : makeLocalStorage(localDir());
+	// Exactly one backend for this run: R2 when publishing, else local. The local
+	// backend is never even constructed in publish mode (no fs dependency there).
+	const backend: Storage = r2 ?? makeLocalStorage(localDir());
 	return {
 		publish: opts.publish,
 		label: r2
 			? `R2-only → ${r2.label} (publishing; no local copy)`
-			: `${local!.label} — local-only (unpublished; pass --publish to write to R2)`,
+			: `${backend.label} — local-only (unpublished; pass --publish to write to R2)`,
 		async putIfAbsent(sha256, ext, bytes, contentType) {
-			if (r2) {
-				const key = await r2.putIfAbsent(sha256, ext, bytes, contentType);
-				return { key, r2Synced: true };
-			}
-			const key = await local!.putIfAbsent(sha256, ext, bytes, contentType);
-			return { key, r2Synced: false };
+			const key = await backend.putIfAbsent(sha256, ext, bytes, contentType);
+			// r2Synced iff the (sole) backend is R2 and the write succeeded.
+			return { key, r2Synced: r2 !== null };
 		},
 		async ensurePublished(key, bytes, contentType) {
 			if (!r2) return false;

--- a/worker/storage.ts
+++ b/worker/storage.ts
@@ -3,12 +3,12 @@
 //   • local  — a filesystem directory (the dev/staging store; no egress cost)
 //   • r2     — Cloudflare R2 (S3-compatible; the canonical durable archive)
 //
-// They are not interchangeable targets picked by a switch. New bytes always land
-// in local; R2 is written *through* only when publishing is enabled (see
-// makeBlobWriter + the --publish flag). Objects are keyed by sha256, so content
-// is immutable and identical bytes dedupe to one object — and because keys never
-// change meaning, promoting/reconciling is a plain copy-what's-missing (see
-// sync-blobs.ts).
+// They are not interchangeable targets picked by a switch. Without publishing,
+// new bytes land in local only; when publishing is enabled they go to R2 only
+// (no local copy — see makeBlobWriter + the --publish flag). Objects are keyed by
+// sha256, so content is immutable and identical bytes dedupe to one object — and
+// because keys never change meaning, promoting/reconciling is a plain
+// copy-what's-missing (see sync-blobs.ts).
 import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import { S3Client } from 'bun';
@@ -122,17 +122,19 @@ export function localDir(): string {
 // ---------------------------------------------------------------------------
 // Blob write path (the crawler's view of storage)
 // ---------------------------------------------------------------------------
-// R2 is the canonical durable archive, but publishing to it is *opt-in*. The
-// crawler ALWAYS writes new bytes to the local backend (the dev/staging cache);
-// only when publishing is enabled does it ALSO write-through to R2 and report
-// the object as synced (which stamps `blob.r2_synced_at`). A default run never
-// touches R2, so a dev/experimental crawl can't pollute the canonical archive.
+// R2 is the canonical durable archive, but publishing to it is *opt-in*. Without
+// publishing the crawler writes new bytes to the local backend only (the
+// dev/staging cache, `r2_synced_at` null, promotable later via blobs:push). When
+// publishing is enabled it writes new bytes to R2 ONLY — no local copy — and
+// reports the object as synced (which stamps `blob.r2_synced_at`). A default run
+// never touches R2, so a dev/experimental crawl can't pollute the canonical
+// archive; a publishing run needs no filesystem, so it runs on a no-fs host.
 export interface BlobWriter {
 	/** True when this run writes through to R2 (prod / `--publish`). */
 	readonly publish: boolean;
 	readonly label: string;
-	/** Store bytes under the content-addressed key. Always writes to the local
-	 *  backend; when publishing, also writes-through to R2. Returns the key and
+	/** Store bytes under the content-addressed key. When publishing, writes to R2
+	 *  only; otherwise writes to the local backend only. Returns the key and
 	 *  whether the object is confirmed present in R2 (drives `blob.r2_synced_at`). */
 	putIfAbsent(
 		sha256: string,
@@ -146,26 +148,30 @@ export interface BlobWriter {
 	ensurePublished(key: string, bytes: Uint8Array, contentType?: string): Promise<boolean>;
 }
 
-/** Build the crawler's blob write path. `publish` gates the R2 write-through
- *  ONLY — the local backend is always written. Publishing requires R2 env. */
+/** Build the crawler's blob write path. `publish` selects the backend: publishing
+ *  writes to R2 ONLY (no local copy), otherwise the local backend ONLY. Publishing
+ *  requires R2 env. */
 export function makeBlobWriter(opts: { publish: boolean }): BlobWriter {
-	const local = makeLocalStorage(localDir());
 	const r2 = opts.publish ? makeR2Storage() : null;
 	if (opts.publish && !r2) {
 		throw new Error(
 			'--publish requires R2_* env vars (R2_ENDPOINT / R2_BUCKET / R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY).'
 		);
 	}
+	// Local backend is never touched in publish mode (no fs dependency there).
+	const local = r2 ? null : makeLocalStorage(localDir());
 	return {
 		publish: opts.publish,
 		label: r2
-			? `${local.label} + write-through to ${r2.label}`
-			: `${local.label} — local-only (unpublished; pass --publish to write through to R2)`,
+			? `R2-only → ${r2.label} (publishing; no local copy)`
+			: `${local!.label} — local-only (unpublished; pass --publish to write to R2)`,
 		async putIfAbsent(sha256, ext, bytes, contentType) {
-			const key = await local.putIfAbsent(sha256, ext, bytes, contentType);
-			if (!r2) return { key, r2Synced: false };
-			await r2.putIfAbsent(sha256, ext, bytes, contentType);
-			return { key, r2Synced: true };
+			if (r2) {
+				const key = await r2.putIfAbsent(sha256, ext, bytes, contentType);
+				return { key, r2Synced: true };
+			}
+			const key = await local!.putIfAbsent(sha256, ext, bytes, contentType);
+			return { key, r2Synced: false };
 		},
 		async ensurePublished(key, bytes, contentType) {
 			if (!r2) return false;


### PR DESCRIPTION
Closes #30

## What

In publish mode, `makeBlobWriter` now writes each new blob to **R2 only** and stamps `r2_synced_at` — no local copy. Previously (from #26) a publishing run wrote the local backend **and** wrote through to R2, leaving a local disk copy that nothing reads (dead weight + disk pressure) and requiring a filesystem a no-fs host can't provide.

The run's backend is now modeled as one always-present `Storage` (`r2 ?? local`): R2 when publishing, local otherwise. The local backend is never constructed in publish mode, so a publishing worker has no `node:fs` dependency.

## Acceptance criteria

- [x] `--publish` writes each blob to R2 only (no local file created) and sets `r2_synced_at`
- [x] Non-publish runs unchanged (local-only, `r2_synced_at` null, `blobs:push` still promotes)
- [x] No local blob files are produced by a publish run
- [x] `bun run check` + lint clean (only pre-existing `project.inlang/*` generated-file warnings remain, gitignored)
- [x] `docs/ARCHITECTURE.md` (§5 storage) updated to state publish = R2-only (also `worker/README.md` + env table)

Out of scope (untouched): `r2_synced_at` marker mechanics, `blobs:*` reconcile, the non-publish path, `getUnpublishedBlobCount()`, dashboard, schema.

## Verify coverage

Exercised the real `makeBlobWriter` end-to-end (`DATABASE_URL=file:local.db`) against a **fake local S3 server** (Bun.serve, since no real R2 was reachable — stubbed, stated here):

- **Non-publish:** 1 local file written, `r2Synced=false`, key correct — unchanged.
- **Publish:** 0 local files in `BLOB_DIR`, exactly 1 R2 PUT (`/bucket/blobs/aa/aa/…​.html`), `r2Synced=true`.
- **Gate:** `--publish` without R2 creds throws.

The R2 write path (Bun `S3Client` → HEAD/PUT over HTTP) is genuinely exercised, just against a local stub endpoint rather than real Cloudflare R2. `ensurePublished` (crawl.ts else-branch) is unchanged and R2-only.

## Reviewer must-check

- Real R2 was **not** reachable; the R2 write was validated against a fake S3 stub. Worth a sanity check against real R2 creds before prod rely-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)