### PR TITLE
Worker runtime seam — resumable tick() core + local driver (#27)

### DIFF
--- a/src/lib/server/db/crawl.schema.ts
+++ b/src/lib/server/db/crawl.schema.ts
@@ -58,7 +58,7 @@ export const resource = sqliteTable(
 		state: text('state').notNull().default('active'), // active | gone | error
 		// frontier scheduling: priority tier (0=core sitemap page … 3=doc) and when
 		// this URL is next due for (re)fetch. Drives the resumable, freshness-aware
-		// `sync` mode — see worker/crawl.ts executeSync.
+		// `sync` mode — see worker/crawl.ts createSyncSession.
 		priority: integer('priority').notNull().default(1),
 		nextFetchAt: integer('next_fetch_at', { mode: 'timestamp_ms' }),
 		// latest observed content fingerprint

--- a/worker/README.md
+++ b/worker/README.md
@@ -118,6 +118,80 @@ bun run worker --publish
 > Tell-tale: a `sync` run stuck in `current_phase='crawling'` with no tier-0
 > resources or unfetched frontier rows — that's an old worker.
 
+## Runtime seam: core `tick()` + drivers
+
+The execution model is split in two so the same crawl engine can run in very
+different environments (a long-lived box today; a serverless function tomorrow)
+without the engine knowing which. This is the SvelteKit-adapter idea applied to
+the worker: one portable **core**, swappable **drivers**.
+
+```
+  ┌──────────────────────────── core (env-agnostic) ────────────────────────────┐
+  │  worker/core.ts    tick(opts) -> { status: 'more' | 'idle' | 'done', … }     │
+  │  worker/crawl.ts   createCrawlSession / createSyncSession (bounded step())    │
+  │                                                                              │
+  │  One tick = claim-or-continue the active run, process ONE bounded batch      │
+  │  (capped by a max item count AND a soft wall-time budget), persist progress, │
+  │  honor control (pause/cancel/discovery), return. NO loop, NO signals, NO     │
+  │  wait-sleeps, NO process lifecycle. It does one unit and returns.            │
+  └──────────────────────────────────────────────────────────────────────────────┘
+                                     ▲  pumps
+  ┌──────────────────────────── driver (env-specific) ──────────────────────────┐
+  │  worker/driver.ts  makeLocalDriver — the long-lived `bun run worker` loop:   │
+  │    loop { maintenance-when-due; tick(); react to status } + idle sleeps +    │
+  │    SIGINT/SIGTERM graceful shutdown + registry active/standby transitions.   │
+  │  worker/index.ts   thin: build identity + budget, migrate, pick a driver.    │
+  └──────────────────────────────────────────────────────────────────────────────┘
+```
+
+**`tick()` status contract** — the whole seam:
+
+| status | meaning                                  | a driver typically…                     |
+| ------ | ---------------------------------------- | --------------------------------------- |
+| `more` | budget spent, work remains               | pumps again immediately                 |
+| `idle` | nothing to claim, or the run is paused   | waits (sleep / next cron) then re-ticks |
+| `done` | run reached a terminal state (finalized) | pumps again (claim the next run)        |
+
+Per-tick bounds are configurable — `WORKER_TICK_MAX_ITEMS` (item cap) and
+`WORKER_TICK_BUDGET_MS` (soft wall-time). The bounds only _chunk_ the work: the
+resulting rows/counts are identical to an unbounded loop, because every processed
+resource reschedules itself (`sync`) or is skipped as already-captured (`crawl`),
+and unchanged content produces no new version row (content-addressed sha compare).
+So a batch is safe to re-run — `tick()` advances **atomically and idempotently**
+(no duplicate `resource_version` rows, no double blob writes), which is also what
+keeps a future sharded/parallel driver from needing any core change.
+
+**Single-writer is unchanged.** Exactly one active run at a time via the Turso
+lease (`claimNext` + heartbeat, preserved verbatim in `core.ts`). The local driver
+keeps one warm in-process session across ticks, so the crawl BFS frontier
+(in-memory for `crawl`/`estimate`/`recrawl`) continues step to step. `sync` is the
+DB-resumable mode — the `resource` table _is_ the frontier — so it resumes across
+process restarts too.
+
+### Adding a serverless driver (future — NOT built here)
+
+The seam is shaped so a Cloudflare/Vercel driver drops in **without touching the
+core**. It composes the same primitives, but inverts the loop — the platform's
+scheduler _is_ the loop. A one-tick-per-invocation handler looks like:
+
+```ts
+// pseudo-code for a future serverless driver — do not ship yet
+export async function handler() {
+	await runMaintenance(identity, /* idle */ true); // reap/sweep/schedule
+	const r = await tick({ identity, publish, budget });
+	// 'more'  -> schedule an immediate follow-up invocation
+	// 'idle'  -> let the next cron tick handle it
+	// 'done'  -> lapse; the next queued run is picked up next invocation
+}
+```
+
+Because `sync` is DB-resumable and every processed row reschedules itself, one tick
+per invocation across fresh processes still converges on the same result — no
+shared in-process state required. `worker/driver.ts` exports the reusable
+primitives (`runMaintenance`, `reapStaleRuns`, `maybeScheduleSync`) alongside
+`makeLocalDriver`; a new driver reuses them and supplies only its own loop
+discipline and lifecycle.
+
 ## Blob storage: R2 canonical + opt-in publishing
 
 Bodies are stored content-addressed (by sha256). R2 is the **canonical durable

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -106,6 +106,26 @@ export const SYNC_BATCH = Number(process.env.CRAWLER_SYNC_BATCH ?? 200);
 export const SYNC_ERROR_BACKOFF_MS =
 	Number(process.env.CRAWLER_ERROR_BACKOFF_HOURS ?? 6) * 3_600_000;
 
+// ---------------------------------------------------------------------------
+// Tick budget (the resumable core, worker/core.ts)
+// ---------------------------------------------------------------------------
+// A single `tick()` processes ONE bounded batch of frontier work and returns —
+// bounded by BOTH a max item count AND a soft wall-time budget (whichever trips
+// first). This is what makes the core resumable and driver-agnostic: a long-lived
+// local driver pumps many ticks back-to-back; a serverless driver would run one
+// tick per invocation. The bounds only chunk the work — the resulting rows/counts
+// are identical to an unbounded loop, because each processed resource reschedules
+// itself (see executeSync's freshness scheduling), so tick boundaries never
+// double-process or drop work.
+export const TICK_MAX_ITEMS = Number(process.env.WORKER_TICK_MAX_ITEMS ?? 200);
+export const TICK_TIME_BUDGET_MS = Number(process.env.WORKER_TICK_BUDGET_MS ?? 10_000);
+
+// Local-driver loop cadence (worker/driver.ts). How long to sleep when the core
+// reports `idle` (nothing to claim), and how often to run maintenance (reap stale
+// runs, sweep the worker registry, refresh standby, auto-schedule).
+export const POLL_INTERVAL_MS = Number(process.env.WORKER_POLL_MS ?? 3000);
+export const MAINTENANCE_INTERVAL_MS = Number(process.env.WORKER_MAINTENANCE_MS ?? 30_000);
+
 // Auto-schedule: when > 0, an idle worker enqueues a `sync` run this often.
 // 0 / unset = disabled (only manual/dashboard runs). See worker/index.ts.
 export const SYNC_SCHEDULE_MS = Number(process.env.SYNC_SCHEDULE_MINUTES ?? 0) * 60_000;

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -115,7 +115,7 @@ export const SYNC_ERROR_BACKOFF_MS =
 // local driver pumps many ticks back-to-back; a serverless driver would run one
 // tick per invocation. The bounds only chunk the work — the resulting rows/counts
 // are identical to an unbounded loop, because each processed resource reschedules
-// itself (see executeSync's freshness scheduling), so tick boundaries never
+// itself (see createSyncSession's freshness scheduling), so tick boundaries never
 // double-process or drop work.
 export const TICK_MAX_ITEMS = Number(process.env.WORKER_TICK_MAX_ITEMS ?? 200);
 export const TICK_TIME_BUDGET_MS = Number(process.env.WORKER_TICK_BUDGET_MS ?? 10_000);

--- a/worker/core.test.ts
+++ b/worker/core.test.ts
@@ -1,0 +1,231 @@
+// Core seam test — drives the resumable `tick()` against a throwaway libSQL file
+// DB with a mocked (offline) site, covering issue #27's load-bearing guarantees:
+//   • driving tick() repeatedly runs a `sync` run to completion (criterion 3),
+//   • a tiny per-tick budget forces many bounded ticks — no unbounded loop
+//     (criterion 1) — and interrupting between ticks then resuming completes the
+//     run correctly (criterion 4),
+//   • re-running over unchanged content adds NO duplicate version rows — atomic &
+//     idempotent advance (criterion 6).
+import { afterAll, beforeAll, describe, it, expect, vi } from 'vitest';
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const BASE = 'https://www.town.orleans.ma.us';
+
+// In-memory fake site, shared with the ./http mock via vi.hoisted (hoisted above
+// the dynamic imports in beforeAll).
+const site = vi.hoisted(() => ({ pages: new Map<string, { ct: string; body: string }>() }));
+
+// Mock ./storage — it imports Bun's S3Client at module load, which vitest's node
+// runner can't resolve. An in-memory content-addressed writer is all the sync
+// crawl needs (it exercises dedupe/refcount in the DB, not the bytes backend).
+vi.mock('./storage', () => ({
+	makeBlobWriter: () => ({
+		publish: false,
+		label: 'test (in-memory)',
+		async putIfAbsent(sha256: string, ext: string) {
+			return { key: `blobs/${sha256}${ext}`, r2Synced: false };
+		},
+		async ensurePublished() {
+			return false;
+		}
+	}),
+	// Stubs — the extract/embed modules import these but aren't driven by this test.
+	localDir: () => '/tmp/blobs',
+	makeLocalStorage: () => ({}),
+	makeR2Storage: () => null
+}));
+
+// Mock only the NETWORK seam of ./http (politeFetch + Robots); keep every pure
+// helper (normalize/inScope/sha256Hex/parseSitemap…) real so the engine runs for
+// real, just offline.
+vi.mock('./http', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('./http')>();
+	return {
+		...actual,
+		Robots: { load: async () => ({ canFetch: () => true }) },
+		politeFetch: async (url: string) => {
+			const p = site.pages.get(url);
+			if (!p) return { resp: new Response('', { status: 404 }), throttled: false };
+			return {
+				resp: new Response(p.body, { status: 200, headers: { 'Content-Type': p.ct } }),
+				throttled: false
+			};
+		}
+	};
+});
+
+const drizzleDir = fileURLToPath(new URL('../drizzle/', import.meta.url));
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+let tmp: string;
+let db: any;
+let client: any;
+let schema: any;
+let tick: any;
+let DEFAULT_BUDGET: any;
+
+const IDENTITY = { id: 'test-worker', host: 'test', pid: 1 };
+
+function sitemap(urls: string[]): string {
+	const body = urls.map((u) => `<url><loc>${u}</loc></url>`).join('');
+	return `<?xml version="1.0"?><urlset>${body}</urlset>`;
+}
+
+function page(text: string, links: string[] = []): string {
+	const a = links.map((u) => `<a href="${u}">x</a>`).join('');
+	return `<!doctype html><html><head><title>T</title></head><body><main>${text} ${a}</main></body></html>`;
+}
+
+beforeAll(async () => {
+	// The engine runs under the Bun runtime in production; vitest's node runner has
+	// no global `Bun`. Two surfaces are reached here: `Bun.sleep` (politeDelay) and
+	// `Bun.CryptoHasher` (sha256Hex) — shim both, the latter via node's crypto.
+	const { createHash } = await import('node:crypto');
+	class CryptoHasher {
+		private h;
+		constructor(algo: string) {
+			this.h = createHash(algo);
+		}
+		update(data: Uint8Array | string) {
+			this.h.update(data);
+			return this;
+		}
+		digest(enc: string) {
+			return this.h.digest(enc as 'hex');
+		}
+	}
+	(globalThis as unknown as { Bun?: unknown }).Bun ??= {
+		sleep: () => Promise.resolve(),
+		CryptoHasher
+	};
+	tmp = mkdtempSync(join(tmpdir(), 'core-tick-'));
+	// worker/db.ts + config.ts read env at import time — set before importing.
+	process.env.DATABASE_URL = `file:${join(tmp, 'test.db')}`;
+	delete process.env.DATABASE_AUTH_TOKEN;
+	process.env.CRAWLER_RATE_LIMIT = '0'; // no polite delay in tests
+	process.env.CRAWLER_RATE_LIMIT_JITTER = '0';
+	process.env.CRAWLER_SEEDS = `${BASE}/page-a`; // single seed root
+	({ db, client } = await import('./db'));
+	schema = await import('../src/lib/server/db/schema');
+	const { applyMigrations } = await import('../src/lib/server/db/migrator');
+	({ tick, DEFAULT_BUDGET } = await import('./core'));
+	const entries = readdirSync(drizzleDir)
+		.filter((f) => f.endsWith('.sql'))
+		.map((name) => ({ name, sql: readFileSync(join(drizzleDir, name), 'utf8') }));
+	await applyMigrations(client, entries);
+
+	// A 3-page site: page-a links to b and c; the sitemap lists all three.
+	site.pages.set(`${BASE}/sitemap.xml`, {
+		ct: 'application/xml',
+		body: sitemap([`${BASE}/page-a`, `${BASE}/page-b`, `${BASE}/page-c`])
+	});
+	site.pages.set(`${BASE}/page-a`, {
+		ct: 'text/html',
+		body: page('alpha', [`${BASE}/page-b`, `${BASE}/page-c`])
+	});
+	site.pages.set(`${BASE}/page-b`, { ct: 'text/html', body: page('bravo') });
+	site.pages.set(`${BASE}/page-c`, { ct: 'text/html', body: page('charlie') });
+});
+
+afterAll(() => {
+	client?.close();
+	if (tmp) rmSync(tmp, { recursive: true, force: true });
+});
+
+async function enqueueSync(): Promise<string> {
+	const [run] = await db
+		.insert(schema.syncRun)
+		.values({ mode: 'sync', status: 'queued', requestedBy: 'test' })
+		.returning();
+	return run.id;
+}
+async function count(table: string): Promise<number> {
+	const r = await client.execute(`select count(*) n from ${table}`);
+	return Number(r.rows[0].n);
+}
+async function runStatus(id: string): Promise<string> {
+	const r = await client.execute({ sql: 'select status from sync_run where id=?', args: [id] });
+	return String(r.rows[0].status);
+}
+
+describe('tick() core', () => {
+	it('drives a sync run to completion over many bounded ticks (criteria 1 + 3)', async () => {
+		const id = await enqueueSync();
+
+		// A tiny budget (1 item/tick) forces MANY ticks — proving the core is bounded
+		// (no unbounded loop) and that pumping it repeatedly completes the run.
+		const budget = { maxItems: 1, timeBudgetMs: 60_000 };
+		const statuses: string[] = [];
+		let guard = 0;
+		for (;;) {
+			const r = await tick({ identity: IDENTITY, publish: false, budget });
+			statuses.push(r.status);
+			if (r.status === 'done') break;
+			if (r.status === 'idle' && !r.runId) break;
+			if (++guard > 200) throw new Error('tick did not converge');
+		}
+
+		expect(await runStatus(id)).toBe('completed');
+		// 3 real pages fetched + stored → 3 version rows, 3 blobs.
+		expect(await count('resource_version')).toBe(3);
+		expect(await count('blob')).toBe(3);
+		// It genuinely took multiple ticks (a `more` before the terminal `done`).
+		expect(statuses.filter((s) => s === 'more').length).toBeGreaterThan(0);
+		expect(statuses.at(-1)).toBe('done');
+
+		// A follow-up tick with nothing queued is idle (no work), runId null.
+		const idle = await tick({ identity: IDENTITY, publish: false, budget });
+		expect(idle.status).toBe('idle');
+		expect(idle.runId).toBeNull();
+	});
+
+	it('is idempotent: re-running over unchanged content adds no new version rows (criterion 6)', async () => {
+		const versionsBefore = await count('resource_version');
+
+		// Force every resource due again and re-run to completion.
+		await client.execute('update resource set next_fetch_at = null');
+		const id = await enqueueSync();
+		let guard = 0;
+		for (;;) {
+			const r = await tick({ identity: IDENTITY, publish: false, budget: DEFAULT_BUDGET });
+			if (r.status === 'done') break;
+			if (r.status === 'idle' && !r.runId) break;
+			if (++guard > 200) throw new Error('tick did not converge');
+		}
+
+		expect(await runStatus(id)).toBe('completed');
+		// Same bytes → same sha → recorded `unchanged` → NO new version rows.
+		expect(await count('resource_version')).toBe(versionsBefore);
+	});
+
+	it('resumes correctly when interrupted between ticks (criterion 4)', async () => {
+		// Change page-b's content (text only — no new links) so the resume run has
+		// exactly one real change to persist.
+		site.pages.set(`${BASE}/page-b`, { ct: 'text/html', body: page('bravo-edited') });
+		await client.execute('update resource set next_fetch_at = null');
+		const id = await enqueueSync();
+		const versionsBefore = await count('resource_version');
+
+		// Pump just TWO bounded ticks, then "interrupt" (stop calling tick).
+		const budget = { maxItems: 1, timeBudgetMs: 60_000 };
+		await tick({ identity: IDENTITY, publish: false, budget });
+		await tick({ identity: IDENTITY, publish: false, budget });
+		expect(await runStatus(id)).toBe('running'); // not finished yet — mid-run
+
+		// Resume: keep pumping the same core to completion.
+		let guard = 0;
+		for (;;) {
+			const r = await tick({ identity: IDENTITY, publish: false, budget });
+			if (r.status === 'done') break;
+			if (r.status === 'idle' && !r.runId) break;
+			if (++guard > 200) throw new Error('tick did not converge');
+		}
+
+		expect(await runStatus(id)).toBe('completed');
+		// Exactly one new version (page-b changed); a and c unchanged → no dup rows.
+		expect(await count('resource_version')).toBe(versionsBefore + 1);
+	});
+});

--- a/worker/core.ts
+++ b/worker/core.ts
@@ -1,0 +1,245 @@
+// The environment-agnostic sync-worker CORE.
+//
+// A single `tick()` is the whole contract: it claims-or-continues the one active
+// run, processes ONE bounded batch of work, persists progress to Turso, honors
+// control (pause/cancel/discovery), and returns a status — `more` (work remains),
+// `idle` (nothing to do right now), or `done` (the run reached a terminal state).
+//
+// The core deliberately contains **no unbounded loop and no process-lifecycle
+// logic**: no `while (true)`, no signal handlers, no sleeps-to-wait. It does one
+// bounded unit and returns. The *driver* (worker/driver.ts) owns the loop, the
+// idle sleeps, the OS signals, and the periodic maintenance. That split is the
+// runtime seam: the same core is pumped by a long-lived local driver today, and
+// could be pumped one-tick-per-invocation by a future serverless driver WITHOUT
+// any change here (see worker/README.md § Runtime seam).
+//
+// Single-writer semantics are unchanged — exactly one active run at a time via the
+// Turso lease (`claimNext` + heartbeat). And `tick()` advances work idempotently:
+// re-running a batch never double-processes, because every processed resource
+// reschedules itself (sync) or is skipped as already-captured (crawl), and
+// unchanged content produces no new version row (content-addressed sha compare).
+import { and, asc, eq, gt, inArray } from 'drizzle-orm';
+import { db } from './db';
+import { syncRun } from '../src/lib/server/db/schema';
+import type { SyncRun } from '../src/lib/server/db/crawl.schema';
+import { STALE_RUN_MS, TICK_MAX_ITEMS, TICK_TIME_BUDGET_MS } from './config';
+import { createCrawlSession, createSyncSession } from './crawl';
+import { executeExtract } from './extract';
+import { executeEmbed } from './embed';
+import type { WorkerIdentity } from './registry';
+import { workerLogger } from './log';
+
+// ---------------------------------------------------------------------------
+// The session seam — one resumable unit of a run.
+//
+// A `RunSession` is a claimed run's execution as a series of bounded steps. Each
+// mode (crawl/estimate/recrawl, sync, extract, embed) builds one; the core pumps
+// its `step()` and never sees mode-specific detail. A session owns its own
+// per-run state (frontier, stats, control flags) across steps.
+// ---------------------------------------------------------------------------
+
+/** Bounds on a single `step()`: stop at whichever trips first. */
+export interface StepBudget {
+	/** Max items (fetch attempts / resources) to process this step. */
+	maxItems: number;
+	/** Soft wall-time budget in ms; checked between items. */
+	timeBudgetMs: number;
+}
+
+/** What one bounded `step()` produced:
+ *  - `more`   — the budget was spent but work remains; pump again.
+ *  - `paused` — the run is paused (control=pause); yield and re-check later.
+ *  - `done`   — the run reached a terminal state (completed/canceled) and was
+ *               finalized; the session is spent. */
+export type StepResult = 'more' | 'paused' | 'done';
+
+export interface RunSession {
+	readonly run: SyncRun;
+	/** Human phase label for logs/registry (`crawling` | `sync` | …). */
+	readonly phase: string;
+	/** Process one bounded batch of this run's work. Persists its own progress. */
+	step(budget: StepBudget): Promise<StepResult>;
+}
+
+// ---------------------------------------------------------------------------
+// tick — the driver-facing contract.
+// ---------------------------------------------------------------------------
+export type TickStatus = 'more' | 'idle' | 'done';
+
+export interface TickOptions {
+	/** This pumper's identity (for the single-writer lease + registry). */
+	identity: WorkerIdentity;
+	/** Publish blobs through to R2 (--publish); otherwise local-only. */
+	publish: boolean;
+	/** Per-tick batch bounds. Defaults to config (TICK_MAX_ITEMS/TICK_TIME_BUDGET_MS). */
+	budget?: StepBudget;
+}
+
+export interface TickResult {
+	status: TickStatus;
+	/** The run this tick advanced/owns, if any (null only on a no-work `idle`). */
+	runId: string | null;
+	mode: string | null;
+	phase: string | null;
+}
+
+export const DEFAULT_BUDGET: StepBudget = {
+	maxItems: TICK_MAX_ITEMS,
+	timeBudgetMs: TICK_TIME_BUDGET_MS
+};
+
+const log = workerLogger('core');
+
+// The one run this process is currently executing, kept warm across ticks. For the
+// crawl/estimate/recrawl modes this holds the in-memory BFS frontier, so a
+// long-lived driver continues the same walk step to step. `sync` is DB-resumable
+// regardless, so a fresh process (serverless) can re-adopt it via claimNext without
+// this cache. Cleared when the run finishes or fails.
+let active: RunSession | null = null;
+
+/** Build the right session for a claimed run and run its one-time init. */
+async function createSession(run: SyncRun, publish: boolean): Promise<RunSession> {
+	switch (run.mode) {
+		case 'sync':
+			return createSyncSession(run, { publish });
+		case 'extract':
+			return oneShotSession(run, 'extracting', () => executeExtract(run));
+		case 'embed':
+			return oneShotSession(run, 'embedding', () => executeEmbed(run));
+		default:
+			// estimate / crawl / recrawl
+			return createCrawlSession(run, { publish });
+	}
+}
+
+// Adapter for the derivation stages (extract/embed). These already own a bounded
+// internal batch loop and finalize themselves, so a single `step()` runs one to
+// completion and reports `done`. They are not part of the crawl frontier core, so
+// they aren't tick-bounded here — a future refactor could make them step-native
+// without touching this seam.
+function oneShotSession(run: SyncRun, phase: string, execute: () => Promise<void>): RunSession {
+	let ran = false;
+	return {
+		run,
+		phase,
+		async step(): Promise<StepResult> {
+			if (!ran) {
+				ran = true;
+				await execute();
+			}
+			return 'done';
+		}
+	};
+}
+
+/**
+ * Claim-or-continue the active run, process ONE bounded batch, and return a
+ * status. This is the entire core contract — call it repeatedly to make progress.
+ */
+export async function tick(opts: TickOptions): Promise<TickResult> {
+	const budget = opts.budget ?? DEFAULT_BUDGET;
+
+	// Fresh claim only when we aren't already mid-run. Single-writer lease preserved.
+	if (!active) {
+		const run = await claimNext(opts.identity);
+		if (!run) return { status: 'idle', runId: null, mode: null, phase: null };
+		log
+			.child({ runId: run.id, mode: run.mode })
+			.info({ maxPages: run.maxPages ?? 'default', publish: opts.publish }, 'run started');
+		try {
+			active = await createSession(run, opts.publish);
+		} catch (e) {
+			await markFailed(run, e);
+			return { status: 'done', runId: run.id, mode: run.mode, phase: null };
+		}
+	}
+
+	const session = active;
+	const { run } = session;
+	try {
+		const result = await session.step(budget);
+		if (result === 'done') {
+			active = null;
+			return { status: 'done', runId: run.id, mode: run.mode, phase: session.phase };
+		}
+		if (result === 'paused') {
+			// Still ours, just waiting — the driver keeps us active and re-ticks later.
+			return { status: 'idle', runId: run.id, mode: run.mode, phase: session.phase };
+		}
+		return { status: 'more', runId: run.id, mode: run.mode, phase: session.phase };
+	} catch (e) {
+		active = null;
+		await markFailed(run, e);
+		return { status: 'done', runId: run.id, mode: run.mode, phase: session.phase };
+	}
+}
+
+/** Mark a run failed (mirrors the old poll loop's runOne catch). */
+async function markFailed(run: SyncRun, e: unknown): Promise<void> {
+	const msg = e instanceof Error ? (e.stack ?? e.message) : String(e);
+	log.child({ runId: run.id, mode: run.mode }).error({ err: e }, 'run failed');
+	await db
+		.update(syncRun)
+		.set({ status: 'failed', finishedAt: new Date(), error: msg.slice(0, 2000) })
+		.where(eq(syncRun.id, run.id));
+}
+
+// One-time log flag so the "standing by" notice prints once per standby episode.
+let standby = false;
+
+/**
+ * Atomically claim the oldest queued run; returns it or null.
+ *
+ * Single-writer guard. Two workers iterating the same frontier double-process
+ * every resource — duplicate version rows, double blob writes, and 2× request
+ * load on the (politely rate-limited) target site. If another worker already owns
+ * a live run (fresh heartbeat), stand down. This process becomes a warm standby:
+ * it only starts claiming once that worker dies and its run goes stale (reaped by
+ * the driver's reapStaleRuns).
+ *
+ * PRESERVED verbatim from the old worker/index.ts — the lease is the core's
+ * correctness guarantee and must not drift.
+ */
+export async function claimNext(identity: WorkerIdentity): Promise<SyncRun | null> {
+	const [live] = await db
+		.select({ id: syncRun.id, workerId: syncRun.workerId })
+		.from(syncRun)
+		.where(
+			and(
+				inArray(syncRun.status, ['running', 'paused']),
+				gt(syncRun.heartbeatAt, new Date(Date.now() - STALE_RUN_MS))
+			)
+		)
+		.limit(1);
+	if (live) {
+		if (!standby) {
+			log.info(
+				{ activeWorkerId: live.workerId },
+				'another worker owns an active run — standing by'
+			);
+			standby = true;
+		}
+		return null;
+	}
+	standby = false;
+
+	const [queued] = await db
+		.select()
+		.from(syncRun)
+		.where(eq(syncRun.status, 'queued'))
+		.orderBy(asc(syncRun.requestedAt))
+		.limit(1);
+	if (!queued) return null;
+
+	const claimed = await db
+		.update(syncRun)
+		.set({
+			status: 'running',
+			workerId: identity.id,
+			startedAt: new Date(),
+			heartbeatAt: new Date()
+		})
+		.where(and(eq(syncRun.id, queued.id), eq(syncRun.status, 'queued')))
+		.returning();
+	return claimed[0] ?? null; // null => another worker grabbed it first
+}

--- a/worker/crawl.ts
+++ b/worker/crawl.ts
@@ -261,6 +261,20 @@ function logRunSummary(log: ReturnType<typeof runLogger>, status: string, stats:
 	);
 }
 
+// Terminal step for both crawl-family and sync sessions: resolve link targets to
+// resource ids in one pass, finalize the run row, and log the rollup (except when
+// canceled). Shared so the two sessions can't drift on how a run ends.
+async function finishRun(
+	runId: string,
+	status: string,
+	log: ReturnType<typeof runLogger>,
+	stats: Stats
+): Promise<void> {
+	await backfillLinkTargets();
+	await finalizeRun(runId, status, stats);
+	if (status !== 'canceled') logRunSummary(log, status, stats);
+}
+
 // ---------------------------------------------------------------------------
 // crawl / estimate / recrawl — in-memory BFS frontier, as a resumable session.
 //
@@ -352,12 +366,7 @@ export async function createCrawlSession(
 		})
 		.where(eq(syncRun.id, runId));
 
-	async function finish(status: string): Promise<void> {
-		// Backfill link targets to resource ids in one pass, then finalize.
-		await backfillLinkTargets();
-		await finalizeRun(runId, status, stats);
-		if (status !== 'canceled') logRunSummary(log, status, stats);
-	}
+	const finish = (status: string) => finishRun(runId, status, log, stats);
 
 	return {
 		run,
@@ -574,11 +583,7 @@ export async function createSyncSession(
 
 	await refreshSeeds(runId, stats);
 
-	async function finish(status: string): Promise<void> {
-		await backfillLinkTargets();
-		await finalizeRun(runId, status, stats);
-		if (status !== 'canceled') logRunSummary(log, status, stats);
-	}
+	const finish = (status: string) => finishRun(runId, status, log, stats);
 
 	/** Fetch the next page of due resources (priority-ordered). */
 	function dueBatch() {
@@ -792,7 +797,7 @@ async function gate(
  *  NOT gated by the discovery toggle — seeds/sitemap are the *known site
  *  structure* (the backlog to drain), a separate concern from frontier discovery,
  *  which is specifically the ingest of newly-found links from fetched page bodies
- *  (see the `discoveryEnabled` gate in executeSync). Seeds run once at run start
+ *  (see the `discoveryEnabled` gate in createSyncSession). Seeds run once at run start
  *  and are bounded, so they don't cause the runaway frontier growth the toggle
  *  exists to pause. */
 async function refreshSeeds(runId: string, stats: Stats): Promise<void> {

--- a/worker/crawl.ts
+++ b/worker/crawl.ts
@@ -2,6 +2,15 @@
 // sitemap + module seeds, conditional GETs for change detection, content-
 // addressed blob storage, and full manifest/version/link bookkeeping in Turso.
 // Honors run.control (pause/cancel) and writes heartbeats for the dashboard.
+//
+// The engine is exposed as resumable *sessions* (createCrawlSession /
+// createSyncSession), NOT as a single run-to-completion loop. Each session's
+// `step(budget)` processes ONE bounded batch of frontier work and returns —
+// bounded by a max item count AND a soft wall-time budget. The env-agnostic core
+// (worker/core.ts) pumps these steps; the driver (worker/driver.ts) owns the loop.
+// Splitting the frontier walk into bounded steps is what lets the same engine run
+// under a long-lived local driver OR a future serverless one-tick-per-invocation
+// driver, without the engine knowing which. See worker/README.md § Runtime seam.
 import { and, asc, eq, isNull, lte, ne, or, sql } from 'drizzle-orm';
 import { db } from './db';
 import {
@@ -44,6 +53,7 @@ import {
 } from './http';
 import { refreshActiveWorker } from './registry';
 import { runLogger } from './log';
+import type { RunSession, StepBudget, StepResult } from './core';
 
 const HEARTBEAT_MS = 2000;
 
@@ -234,7 +244,37 @@ async function ingestResponse(resp: Response, ctx: IngestCtx): Promise<string[]>
 	return [];
 }
 
-export async function executeRun(run: SyncRun, opts: { publish?: boolean } = {}): Promise<void> {
+// A run finished its crawl: log the same rollup summary the old poll loop printed
+// from index.ts, but from the stats we already hold (no re-select). Skipped for
+// `canceled` — a canceled run's partial counts aren't a completion summary.
+function logRunSummary(log: ReturnType<typeof runLogger>, status: string, stats: Stats): void {
+	log.info(
+		{
+			status,
+			pages: stats.pages,
+			documents: stats.documents,
+			new: stats.newCount,
+			changed: stats.changedCount,
+			errors: stats.errorCount
+		},
+		'run finished'
+	);
+}
+
+// ---------------------------------------------------------------------------
+// crawl / estimate / recrawl — in-memory BFS frontier, as a resumable session.
+//
+// The BFS `queue`/`seen` live in the session closure, so successive `step()`
+// calls continue the SAME frontier (the local driver keeps the session warm
+// across ticks). Unlike `sync`, this frontier is NOT persisted, so it resumes
+// only in-process — a fresh process re-seeds from SEED_PATHS (exactly today's
+// behavior: killing a crawl restarts it; `crawl` mode then skips already-captured
+// URLs). `sync` is the DB-resumable mode a serverless driver would pump.
+// ---------------------------------------------------------------------------
+export async function createCrawlSession(
+	run: SyncRun,
+	opts: { publish?: boolean } = {}
+): Promise<RunSession> {
 	const mode = run.mode as Mode;
 	const runId = run.id;
 	const maxPages = run.maxPages ?? MAX_PAGES;
@@ -264,12 +304,15 @@ export async function executeRun(run: SyncRun, opts: { publish?: boolean } = {})
 	}
 
 	let control: string = run.control;
-	// Live frontier-discovery switch, refreshed each heartbeat (see executeSync).
+	// Live frontier-discovery switch, refreshed each heartbeat (see createSyncSession).
 	let discoveryEnabled = run.discoveryEnabled;
 	let lastBeat = 0;
 	// Forward-progress watermark for the stall marker: the last requestsMade value
 	// we recorded a progress bump for. -1 so the first beat always initializes it.
 	let lastProgress = -1;
+	// Whether we've flipped the run row to `paused` — so we flip it back to `running`
+	// exactly once on resume (see gateControl). Persists across steps.
+	let paused = false;
 	const workerId = run.workerId;
 
 	async function beat(currentUrl: string | null): Promise<void> {
@@ -285,6 +328,19 @@ export async function executeRun(run: SyncRun, opts: { publish?: boolean } = {})
 		}));
 	}
 
+	// Control gate: heartbeat, then classify. On pause it flips the run row to
+	// `paused` (once) and yields `paused` — the core never blocks, it returns and
+	// the driver re-ticks (this replaces the old in-loop `Bun.sleep` pause wait).
+	// On resume it flips back to `running`.
+	const gateControl = (url: string | null) =>
+		gate(
+			runId,
+			() => beat(url),
+			() => control,
+			() => paused,
+			(p) => (paused = p)
+		);
+
 	// Mark running. Seed progress_at so a run is never "stalled" before its first beat.
 	await db
 		.update(syncRun)
@@ -296,121 +352,137 @@ export async function executeRun(run: SyncRun, opts: { publish?: boolean } = {})
 		})
 		.where(eq(syncRun.id, runId));
 
-	while (queue.length > 0 && stats.requestsMade < maxPages) {
-		const url = queue.shift()!;
-		if (seen.has(url) || !inScope(url)) continue;
-		seen.add(url);
-
-		// Control: react to pause/cancel between requests.
-		await beat(url);
-		if (control === 'cancel') break;
-		while (control === 'pause') {
-			await db.update(syncRun).set({ status: 'paused' }).where(eq(syncRun.id, runId));
-			await Bun.sleep(1500);
-			lastBeat = 0;
-			await beat(url);
-			if (control === 'cancel') break;
-			if (control !== 'pause') {
-				await db.update(syncRun).set({ status: 'running' }).where(eq(syncRun.id, runId));
-			}
-		}
-		if (control === 'cancel') break;
-
-		if (!robots.canFetch(url)) {
-			await logEvent(runId, url, 'robots_blocked', null, null);
-			log.debug({ url }, 'robots blocked');
-			continue;
-		}
-
-		// Existing manifest row drives conditional GET + change detection.
-		const existing = await db
-			.select({
-				id: resource.id,
-				sha256: resource.sha256,
-				etag: resource.etag,
-				lastModified: resource.lastModified,
-				sizeBytes: resource.sizeBytes,
-				lastFetchedAt: resource.lastFetchedAt
-			})
-			.from(resource)
-			.where(eq(resource.url, url))
-			.limit(1);
-		const prev = existing[0];
-
-		// Plain crawl skips URLs already captured; recrawl/estimate re-check.
-		if (prev && prev.lastFetchedAt && mode === 'crawl') continue;
-
-		const headers: Record<string, string> = {};
-		if (prev && mode === 'recrawl') {
-			if (prev.etag) headers['If-None-Match'] = prev.etag;
-			if (prev.lastModified) headers['If-Modified-Since'] = prev.lastModified;
-		}
-
-		const { resp, throttled, error } = await politeFetch(url, headers);
-		stats.requestsMade++;
-		if (throttled) {
-			await logEvent(runId, url, 'throttled', null, null);
-			log.debug({ url }, 'throttled');
-		}
-
-		if (!resp) {
-			stats.errorCount++;
-			await logEvent(runId, url, 'fetch_error', null, error ?? 'no response');
-			log.warn({ url, error: error ?? 'no response' }, 'fetch error');
-			await recordFailure(runId, url, prev?.id, 0, 'error');
-			await politeDelay();
-			continue;
-		}
-		if (resp.status === 304) {
-			stats.unchangedCount++;
-			if (prev) await touchFetched(prev.id, runId);
-			resp.body?.cancel();
-			await politeDelay();
-			continue;
-		}
-		if (resp.status !== 200) {
-			resp.body?.cancel();
-			stats.errorCount++;
-			await logEvent(runId, url, 'http_error', resp.status, null);
-			log.warn({ url, status: resp.status }, 'http error');
-			if (resp.status === 404 || resp.status === 410) {
-				stats.goneCount++;
-				await recordGone(runId, url, prev?.id, resp.status);
-			} else {
-				await recordFailure(runId, url, prev?.id, resp.status, 'error');
-			}
-			await politeDelay();
-			continue;
-		}
-		stats.fetched++;
-		const targets = await ingestResponse(resp, {
-			url,
-			prevId: prev?.id,
-			prevSha: prev?.sha256 ?? null,
-			prevSize: prev?.sizeBytes ?? null,
-			mode,
-			maxDocBytes,
-			runId,
-			stats,
-			writer
-		});
-		// Frontier discovery: only enqueue newly-discovered URLs while the switch is
-		// on. Off = keep draining what's already queued without growing the frontier.
-		if (discoveryEnabled) {
-			for (const t of targets) {
-				if (!seen.has(t)) {
-					queue.push(t);
-					stats.discovered++;
-				}
-			}
-		}
-
-		await politeDelay();
+	async function finish(status: string): Promise<void> {
+		// Backfill link targets to resource ids in one pass, then finalize.
+		await backfillLinkTargets();
+		await finalizeRun(runId, status, stats);
+		if (status !== 'canceled') logRunSummary(log, status, stats);
 	}
 
-	// Backfill link targets to resource ids in one pass, then finalize.
-	await backfillLinkTargets();
-	await finalizeRun(runId, control === 'cancel' ? 'canceled' : 'completed', stats);
+	return {
+		run,
+		phase: 'crawling',
+		async step(budget: StepBudget): Promise<StepResult> {
+			const deadline = Date.now() + budget.timeBudgetMs;
+			let items = 0;
+			while (queue.length > 0 && stats.requestsMade < maxPages) {
+				// Bounded batch: yield `more` once the item cap or wall-time budget trips.
+				if (items >= budget.maxItems || Date.now() >= deadline) return 'more';
+
+				const url = queue.shift()!;
+				if (seen.has(url) || !inScope(url)) continue;
+				seen.add(url);
+
+				// Control: react to pause/cancel between requests.
+				const g = await gateControl(url);
+				if (g === 'canceled') {
+					await finish('canceled');
+					return 'done';
+				}
+				if (g === 'paused') {
+					// Un-consume this url so the next step re-processes it on resume.
+					seen.delete(url);
+					queue.unshift(url);
+					return 'paused';
+				}
+
+				if (!robots.canFetch(url)) {
+					await logEvent(runId, url, 'robots_blocked', null, null);
+					log.debug({ url }, 'robots blocked');
+					continue;
+				}
+
+				// Existing manifest row drives conditional GET + change detection.
+				const existing = await db
+					.select({
+						id: resource.id,
+						sha256: resource.sha256,
+						etag: resource.etag,
+						lastModified: resource.lastModified,
+						sizeBytes: resource.sizeBytes,
+						lastFetchedAt: resource.lastFetchedAt
+					})
+					.from(resource)
+					.where(eq(resource.url, url))
+					.limit(1);
+				const prev = existing[0];
+
+				// Plain crawl skips URLs already captured; recrawl/estimate re-check.
+				if (prev && prev.lastFetchedAt && mode === 'crawl') continue;
+
+				const headers: Record<string, string> = {};
+				if (prev && mode === 'recrawl') {
+					if (prev.etag) headers['If-None-Match'] = prev.etag;
+					if (prev.lastModified) headers['If-Modified-Since'] = prev.lastModified;
+				}
+
+				const { resp, throttled, error } = await politeFetch(url, headers);
+				stats.requestsMade++;
+				items++;
+				if (throttled) {
+					await logEvent(runId, url, 'throttled', null, null);
+					log.debug({ url }, 'throttled');
+				}
+
+				if (!resp) {
+					stats.errorCount++;
+					await logEvent(runId, url, 'fetch_error', null, error ?? 'no response');
+					log.warn({ url, error: error ?? 'no response' }, 'fetch error');
+					await recordFailure(runId, url, prev?.id, 0, 'error');
+					await politeDelay();
+					continue;
+				}
+				if (resp.status === 304) {
+					stats.unchangedCount++;
+					if (prev) await touchFetched(prev.id, runId);
+					resp.body?.cancel();
+					await politeDelay();
+					continue;
+				}
+				if (resp.status !== 200) {
+					resp.body?.cancel();
+					stats.errorCount++;
+					await logEvent(runId, url, 'http_error', resp.status, null);
+					log.warn({ url, status: resp.status }, 'http error');
+					if (resp.status === 404 || resp.status === 410) {
+						stats.goneCount++;
+						await recordGone(runId, url, prev?.id, resp.status);
+					} else {
+						await recordFailure(runId, url, prev?.id, resp.status, 'error');
+					}
+					await politeDelay();
+					continue;
+				}
+				stats.fetched++;
+				const targets = await ingestResponse(resp, {
+					url,
+					prevId: prev?.id,
+					prevSha: prev?.sha256 ?? null,
+					prevSize: prev?.sizeBytes ?? null,
+					mode,
+					maxDocBytes,
+					runId,
+					stats,
+					writer
+				});
+				// Frontier discovery: only enqueue newly-discovered URLs while the switch is
+				// on. Off = keep draining what's already queued without growing the frontier.
+				if (discoveryEnabled) {
+					for (const t of targets) {
+						if (!seen.has(t)) {
+							queue.push(t);
+							stats.discovered++;
+						}
+					}
+				}
+
+				await politeDelay();
+			}
+
+			await finish('completed');
+			return 'done';
+		}
+	};
 }
 
 // ---------------------------------------------------------------------------
@@ -422,8 +494,17 @@ export async function executeRun(run: SyncRun, opts: { publish?: boolean } = {})
 // priority order, reschedules each with a per-tier TTL, and enqueues newly
 // discovered URLs as due-now — so core pages finish before the long tail, and
 // the run picks up exactly where it left off, only fetching what's stale.
+//
+// Because the frontier is the DB and every processed resource reschedules itself
+// (nextFetchAt in the future), the session is idempotent across `step()`
+// boundaries AND across process restarts: a step that ends mid-batch re-queries
+// due rows next time — already-done rows are no longer due, so nothing is
+// double-processed, and unchanged content produces no new version row (sha match).
 // ---------------------------------------------------------------------------
-export async function executeSync(run: SyncRun, opts: { publish?: boolean } = {}): Promise<void> {
+export async function createSyncSession(
+	run: SyncRun,
+	opts: { publish?: boolean } = {}
+): Promise<RunSession> {
 	const runId = run.id;
 	const maxPages = run.maxPages ?? MAX_PAGES;
 	const params = run.params ? (JSON.parse(run.params) as { maxDocBytes?: number }) : {};
@@ -441,8 +522,9 @@ export async function executeSync(run: SyncRun, opts: { publish?: boolean } = {}
 	// still fetches/refreshes known resources but ingests no newly-discovered URLs.
 	let discoveryEnabled = run.discoveryEnabled;
 	let lastBeat = 0;
-	// Forward-progress watermark for the stall marker (see executeRun.beat).
+	// Forward-progress watermark for the stall marker (see createCrawlSession.beat).
 	let lastProgress = -1;
+	let paused = false;
 	const workerId = run.workerId;
 
 	async function beat(currentUrl: string | null): Promise<void> {
@@ -458,20 +540,16 @@ export async function executeSync(run: SyncRun, opts: { publish?: boolean } = {}
 		}));
 	}
 
-	/** Wait out a pause; returns false if the run was canceled. */
-	async function awaitResume(url: string | null): Promise<boolean> {
-		while (control === 'pause') {
-			await db.update(syncRun).set({ status: 'paused' }).where(eq(syncRun.id, runId));
-			await Bun.sleep(1500);
-			lastBeat = 0;
-			await beat(url);
-			if (control === 'cancel') return false;
-			if (control !== 'pause') {
-				await db.update(syncRun).set({ status: 'running' }).where(eq(syncRun.id, runId));
-			}
-		}
-		return control !== 'cancel';
-	}
+	// See createCrawlSession.gateControl — heartbeat + pause/cancel classification,
+	// yielding instead of blocking on pause.
+	const gateControl = (url: string | null) =>
+		gate(
+			runId,
+			() => beat(url),
+			() => control,
+			() => paused,
+			(p) => (paused = p)
+		);
 
 	const schedule = (id: string, priority: number) =>
 		db
@@ -496,139 +574,218 @@ export async function executeSync(run: SyncRun, opts: { publish?: boolean } = {}
 
 	await refreshSeeds(runId, stats);
 
-	// Drain the due frontier in priority order until nothing is due (caught up).
-	while (stats.requestsMade < maxPages) {
-		await beat(null);
-		if (control === 'cancel' || !(await awaitResume(null))) break;
+	async function finish(status: string): Promise<void> {
+		await backfillLinkTargets();
+		await finalizeRun(runId, status, stats);
+		if (status !== 'canceled') logRunSummary(log, status, stats);
+	}
 
-		const batch = await db
-			.select({
-				id: resource.id,
-				url: resource.url,
-				priority: resource.priority,
-				sha256: resource.sha256,
-				etag: resource.etag,
-				lastModified: resource.lastModified,
-				sizeBytes: resource.sizeBytes
-			})
-			.from(resource)
-			.where(
-				and(
-					or(isNull(resource.nextFetchAt), lte(resource.nextFetchAt, new Date())),
-					ne(resource.state, 'gone')
+	/** Fetch the next page of due resources (priority-ordered). */
+	function dueBatch() {
+		return (
+			db
+				.select({
+					id: resource.id,
+					url: resource.url,
+					priority: resource.priority,
+					sha256: resource.sha256,
+					etag: resource.etag,
+					lastModified: resource.lastModified,
+					sizeBytes: resource.sizeBytes
+				})
+				.from(resource)
+				.where(
+					and(
+						or(isNull(resource.nextFetchAt), lte(resource.nextFetchAt, new Date())),
+						ne(resource.state, 'gone')
+					)
 				)
-			)
-			// Completeness before freshness: fetch never-seen URLs first (in priority
-			// order), then re-verify already-have ones. So we capture new content
-			// (e.g. thousands of documents) before re-checking pages we already hold.
-			.orderBy(
-				sql`${resource.lastFetchedAt} is null desc`,
-				asc(resource.priority),
-				asc(resource.nextFetchAt)
-			)
-			.limit(SYNC_BATCH);
-		if (batch.length === 0) break; // caught up
+				// Completeness before freshness: fetch never-seen URLs first (in priority
+				// order), then re-verify already-have ones. So we capture new content
+				// (e.g. thousands of documents) before re-checking pages we already hold.
+				.orderBy(
+					sql`${resource.lastFetchedAt} is null desc`,
+					asc(resource.priority),
+					asc(resource.nextFetchAt)
+				)
+				.limit(SYNC_BATCH)
+		);
+	}
 
-		for (const r of batch) {
-			if (stats.requestsMade >= maxPages) break;
-			await beat(r.url);
-			if (control === 'cancel' || !(await awaitResume(r.url))) break;
+	/** Fetch + record one due resource (the per-item body of the old inner loop). */
+	async function processResource(r: {
+		id: string;
+		url: string;
+		priority: number;
+		sha256: string | null;
+		etag: string | null;
+		lastModified: string | null;
+		sizeBytes: number | null;
+	}): Promise<void> {
+		if (!inScope(r.url)) {
+			await schedule(r.id, r.priority);
+			return;
+		}
+		if (!robots.canFetch(r.url)) {
+			await logEvent(runId, r.url, 'robots_blocked', null, null);
+			log.debug({ url: r.url }, 'robots blocked');
+			await schedule(r.id, r.priority);
+			return;
+		}
 
-			if (!inScope(r.url)) {
-				await schedule(r.id, r.priority);
-				continue;
-			}
-			if (!robots.canFetch(r.url)) {
-				await logEvent(runId, r.url, 'robots_blocked', null, null);
-				log.debug({ url: r.url }, 'robots blocked');
-				await schedule(r.id, r.priority);
-				continue;
-			}
+		// Always conditional-GET in sync (cheap 304s for unchanged content).
+		const headers: Record<string, string> = {};
+		if (r.etag) headers['If-None-Match'] = r.etag;
+		if (r.lastModified) headers['If-Modified-Since'] = r.lastModified;
 
-			// Always conditional-GET in sync (cheap 304s for unchanged content).
-			const headers: Record<string, string> = {};
-			if (r.etag) headers['If-None-Match'] = r.etag;
-			if (r.lastModified) headers['If-Modified-Since'] = r.lastModified;
+		const { resp, throttled, error } = await politeFetch(r.url, headers);
+		stats.requestsMade++;
+		if (throttled) {
+			await logEvent(runId, r.url, 'throttled', null, null);
+			log.debug({ url: r.url }, 'throttled');
+		}
 
-			const { resp, throttled, error } = await politeFetch(r.url, headers);
-			stats.requestsMade++;
-			if (throttled) {
-				await logEvent(runId, r.url, 'throttled', null, null);
-				log.debug({ url: r.url }, 'throttled');
-			}
-
-			if (!resp) {
-				stats.errorCount++;
-				await logEvent(runId, r.url, 'fetch_error', null, error ?? 'no response');
-				log.warn({ url: r.url, error: error ?? 'no response' }, 'fetch error');
-				await recordFailure(runId, r.url, r.id, 0, 'error');
+		if (!resp) {
+			stats.errorCount++;
+			await logEvent(runId, r.url, 'fetch_error', null, error ?? 'no response');
+			log.warn({ url: r.url, error: error ?? 'no response' }, 'fetch error');
+			await recordFailure(runId, r.url, r.id, 0, 'error');
+			await db
+				.update(resource)
+				.set({ nextFetchAt: new Date(Date.now() + SYNC_ERROR_BACKOFF_MS) })
+				.where(eq(resource.id, r.id));
+			await politeDelay();
+			return;
+		}
+		if (resp.status === 304) {
+			stats.unchangedCount++;
+			await touchFetched(r.id, runId);
+			await schedule(r.id, r.priority);
+			resp.body?.cancel();
+			await politeDelay();
+			return;
+		}
+		if (resp.status !== 200) {
+			resp.body?.cancel();
+			stats.errorCount++;
+			await logEvent(runId, r.url, 'http_error', resp.status, null);
+			log.warn({ url: r.url, status: resp.status }, 'http error');
+			if (resp.status === 404 || resp.status === 410) {
+				stats.goneCount++;
+				await recordGone(runId, r.url, r.id, resp.status);
+				// Gone: park it far in the future so it isn't re-fetched.
+				await db
+					.update(resource)
+					.set({ nextFetchAt: new Date(Date.now() + 365 * 86_400_000) })
+					.where(eq(resource.id, r.id));
+			} else {
+				await recordFailure(runId, r.url, r.id, resp.status, 'error');
 				await db
 					.update(resource)
 					.set({ nextFetchAt: new Date(Date.now() + SYNC_ERROR_BACKOFF_MS) })
 					.where(eq(resource.id, r.id));
-				await politeDelay();
-				continue;
-			}
-			if (resp.status === 304) {
-				stats.unchangedCount++;
-				await touchFetched(r.id, runId);
-				await schedule(r.id, r.priority);
-				resp.body?.cancel();
-				await politeDelay();
-				continue;
-			}
-			if (resp.status !== 200) {
-				resp.body?.cancel();
-				stats.errorCount++;
-				await logEvent(runId, r.url, 'http_error', resp.status, null);
-				log.warn({ url: r.url, status: resp.status }, 'http error');
-				if (resp.status === 404 || resp.status === 410) {
-					stats.goneCount++;
-					await recordGone(runId, r.url, r.id, resp.status);
-					// Gone: park it far in the future so it isn't re-fetched.
-					await db
-						.update(resource)
-						.set({ nextFetchAt: new Date(Date.now() + 365 * 86_400_000) })
-						.where(eq(resource.id, r.id));
-				} else {
-					await recordFailure(runId, r.url, r.id, resp.status, 'error');
-					await db
-						.update(resource)
-						.set({ nextFetchAt: new Date(Date.now() + SYNC_ERROR_BACKOFF_MS) })
-						.where(eq(resource.id, r.id));
-				}
-				await politeDelay();
-				continue;
-			}
-
-			stats.fetched++;
-			const discovered = await ingestResponse(resp, {
-				url: r.url,
-				prevId: r.id,
-				prevSha: r.sha256,
-				prevSize: r.sizeBytes,
-				mode: 'sync',
-				maxDocBytes,
-				runId,
-				stats,
-				writer
-			});
-			await schedule(r.id, r.priority);
-			// Frontier discovery: enqueue newly-found in-scope URLs only while the
-			// switch is on. When off, the fetch/refresh above still runs (drain the
-			// known backlog) but no new URLs enter the frontier, so totals stop growing.
-			if (discoveryEnabled) {
-				const fresh = discovered.filter((t) => !t.endsWith('sitemap.xml'));
-				await batchAll(fresh.map((t) => enqueueResourceStmt(t, runId)));
-				stats.discovered += fresh.length;
 			}
 			await politeDelay();
+			return;
 		}
-		if (control === 'cancel') break;
+
+		stats.fetched++;
+		const discovered = await ingestResponse(resp, {
+			url: r.url,
+			prevId: r.id,
+			prevSha: r.sha256,
+			prevSize: r.sizeBytes,
+			mode: 'sync',
+			maxDocBytes,
+			runId,
+			stats,
+			writer
+		});
+		await schedule(r.id, r.priority);
+		// Frontier discovery: enqueue newly-found in-scope URLs only while the
+		// switch is on. When off, the fetch/refresh above still runs (drain the
+		// known backlog) but no new URLs enter the frontier, so totals stop growing.
+		if (discoveryEnabled) {
+			const fresh = discovered.filter((t) => !t.endsWith('sitemap.xml'));
+			await batchAll(fresh.map((t) => enqueueResourceStmt(t, runId)));
+			stats.discovered += fresh.length;
+		}
+		await politeDelay();
 	}
 
-	await backfillLinkTargets();
-	await finalizeRun(runId, control === 'cancel' ? 'canceled' : 'completed', stats);
+	return {
+		run,
+		phase: 'sync',
+		async step(budget: StepBudget): Promise<StepResult> {
+			const deadline = Date.now() + budget.timeBudgetMs;
+			let items = 0;
+			// Drain the due frontier in priority order until nothing is due (caught up)
+			// or this step's budget is spent.
+			while (stats.requestsMade < maxPages) {
+				if (items >= budget.maxItems || Date.now() >= deadline) return 'more';
+
+				const g = await gateControl(null);
+				if (g === 'canceled') {
+					await finish('canceled');
+					return 'done';
+				}
+				if (g === 'paused') return 'paused';
+
+				const batch = await dueBatch();
+				if (batch.length === 0) {
+					await finish('completed');
+					return 'done'; // caught up
+				}
+
+				for (const r of batch) {
+					if (stats.requestsMade >= maxPages) break;
+					if (items >= budget.maxItems || Date.now() >= deadline) return 'more';
+
+					const gr = await gateControl(r.url);
+					if (gr === 'canceled') {
+						await finish('canceled');
+						return 'done';
+					}
+					if (gr === 'paused') return 'paused';
+
+					await processResource(r);
+					items++;
+				}
+			}
+
+			await finish('completed'); // hit maxPages
+			return 'done';
+		}
+	};
+}
+
+// Shared control gate for the crawl/sync sessions. Heartbeats (which reads back
+// `control`), then classifies: `canceled`, `paused` (flipping the run row to
+// paused once), or `proceed` (flipping back to running on resume). Unlike the old
+// in-loop wait, pause does NOT sleep here — it returns and lets the driver decide
+// when to re-tick, so the core stays free of process-lifecycle blocking.
+async function gate(
+	runId: string,
+	beat: () => Promise<void>,
+	getControl: () => string,
+	getPaused: () => boolean,
+	setPaused: (p: boolean) => void
+): Promise<'proceed' | 'paused' | 'canceled'> {
+	await beat();
+	const control = getControl();
+	if (control === 'cancel') return 'canceled';
+	if (control === 'pause') {
+		if (!getPaused()) {
+			await db.update(syncRun).set({ status: 'paused' }).where(eq(syncRun.id, runId));
+			setPaused(true);
+		}
+		return 'paused';
+	}
+	if (getPaused()) {
+		await db.update(syncRun).set({ status: 'running' }).where(eq(syncRun.id, runId));
+		setPaused(false);
+	}
+	return 'proceed';
 }
 
 /** Seed the frontier: module roots (tier 1) + sitemap core pages (tier 0).

--- a/worker/driver.ts
+++ b/worker/driver.ts
@@ -186,20 +186,20 @@ async function runLocalDriver(ctx: DriverContext): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
-// One-shot pump — the CLI (`--mode X --once`). Drains the core to completion with
-// no loop-forever, no signals, no maintenance: just pump `tick()` until there's no
-// more work. Used after enqueueing a single run.
+// One-shot pump — the CLI (`--mode X --once`). Pumps `tick()` to drive EXACTLY
+// ONE run to completion, then returns — matching the old enqueueAndRunOnce, which
+// claimed+ran a single row and exited. No loop-forever, no signals, no
+// maintenance. It does NOT drain other queued runs (a scheduler/dashboard row is
+// left for the long-running driver).
 // ---------------------------------------------------------------------------
-export async function runToCompletion(ctx: DriverContext): Promise<void> {
+export async function runSingleJob(ctx: DriverContext): Promise<void> {
 	const { identity, publish } = ctx;
 	const budget = ctx.budget ?? DEFAULT_BUDGET;
 	for (;;) {
 		const r = await tick({ identity, publish, budget });
-		// No work left to claim → done draining.
-		if (r.status === 'idle' && !r.runId) return;
-		// A one-shot run should never be paused (nothing drives the dashboard here);
-		// if it somehow is, bail rather than hot-spin.
-		if (r.status === 'idle' && r.runId) return;
-		// 'more' / 'done' → keep pumping (each tick does real, rate-limited work).
+		// `done` = the one claimed run finished → exit (don't claim the next).
+		// `idle` = nothing claimable (e.g. another worker holds the single-writer
+		// lease) → exit rather than hot-spin. Only `more` keeps pumping.
+		if (r.status === 'done' || r.status === 'idle') return;
 	}
 }

--- a/worker/driver.ts
+++ b/worker/driver.ts
@@ -1,0 +1,205 @@
+// Worker DRIVERS — the environment-specific half of the runtime seam.
+//
+// The core (worker/core.ts) is a pure `tick()`: one bounded batch, no loop, no
+// signals, no sleeps. A *driver* supplies everything env-specific around it:
+//   • the loop that pumps `tick()` and reacts to its status,
+//   • the idle wait between polls,
+//   • OS signal handling / graceful shutdown,
+//   • the periodic maintenance (reap stale runs, sweep the worker registry,
+//     refresh this worker's standby row, auto-schedule sync runs),
+//   • the worker-registry active/standby transitions around a run.
+//
+// Only the LOCAL driver is implemented here (a long-lived process — `bun run
+// worker`). The seam is shaped so other drivers slot in WITHOUT touching the core:
+//
+//   ┌─────────────────────── the seam ───────────────────────┐
+//   │  a driver = { provide identity/publish/budget }         │
+//   │            + { loop discipline: when to tick / wait }    │
+//   │            + { lifecycle: signals, maintenance cadence } │
+//   │  calling only: tick(), runMaintenance(), the registry.   │
+//   └─────────────────────────────────────────────────────────┘
+//
+// A future SERVERLESS driver (Cloudflare/Vercel — NOT built here) would compose
+// the very same primitives, but invert the loop: the platform's scheduler is the
+// loop, so its handler does `runMaintenance()` + a single `tick()` per invocation
+// and returns — `more` schedules an immediate follow-up, `idle` waits for the next
+// cron tick, `done` lets it lapse. Because `sync` is DB-resumable (the frontier is
+// the `resource` table, and every processed row reschedules itself), one tick per
+// invocation across fresh processes still converges — no core change required.
+import { and, desc, eq, inArray, lt } from 'drizzle-orm';
+import { db } from './db';
+import { syncRun } from '../src/lib/server/db/schema';
+import {
+	MAINTENANCE_INTERVAL_MS,
+	POLL_INTERVAL_MS,
+	STALE_RUN_MS,
+	SYNC_SCHEDULE_MS
+} from './config';
+import { deregisterWorker, sweepStaleWorkers, upsertWorker, type WorkerIdentity } from './registry';
+import { DEFAULT_BUDGET, tick, type StepBudget } from './core';
+import { workerLogger } from './log';
+
+const ACTIVE = ['queued', 'running', 'paused'] as const;
+
+/** What a driver needs to pump the core. The seam's config surface. */
+export interface DriverContext {
+	identity: WorkerIdentity;
+	publish: boolean;
+	/** Per-tick batch bounds. Defaults to config. */
+	budget?: StepBudget;
+}
+
+/** A driver owns the loop that pumps the core. Local today; serverless later. */
+export interface Driver {
+	run(): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Maintenance — env-agnostic housekeeping any driver runs on a cadence. Kept here
+// (not in the core) because *when* to run it is a driver/lifecycle decision.
+// ---------------------------------------------------------------------------
+
+/** Mark crashed runs (running/paused, heartbeat gone stale) as failed, so a dead
+ *  worker doesn't leave an active row blocking claims + the schedule. */
+export async function reapStaleRuns(): Promise<void> {
+	const log = workerLogger('driver');
+	const reaped = await db
+		.update(syncRun)
+		.set({
+			status: 'failed',
+			finishedAt: new Date(),
+			error: 'worker heartbeat timed out (reaped)'
+		})
+		.where(
+			and(
+				inArray(syncRun.status, ['running', 'paused']),
+				lt(syncRun.heartbeatAt, new Date(Date.now() - STALE_RUN_MS))
+			)
+		)
+		.returning({ id: syncRun.id });
+	if (reaped.length)
+		log.warn({ reaped: reaped.map((r) => r.id) }, `reaped ${reaped.length} stale run(s)`);
+}
+
+/** Auto-schedule: enqueue a `sync` run when enabled, idle, and one is due. */
+export async function maybeScheduleSync(): Promise<void> {
+	if (SYNC_SCHEDULE_MS <= 0) return;
+	const [active] = await db
+		.select({ id: syncRun.id })
+		.from(syncRun)
+		.where(inArray(syncRun.status, [...ACTIVE]))
+		.limit(1);
+	if (active) return; // don't stack runs
+	const [last] = await db
+		.select({ at: syncRun.requestedAt })
+		.from(syncRun)
+		.where(eq(syncRun.mode, 'sync'))
+		.orderBy(desc(syncRun.requestedAt))
+		.limit(1);
+	const dueAt = last ? last.at.getTime() + SYNC_SCHEDULE_MS : 0;
+	if (Date.now() < dueAt) return;
+	await db.insert(syncRun).values({ mode: 'sync', status: 'queued', requestedBy: 'scheduler' });
+	workerLogger('driver').info('scheduled sync enqueued');
+}
+
+/** One maintenance pass. `idle` (no run in flight) also refreshes this worker's
+ *  standby registry row — skipped mid-run so it never clobbers the active role the
+ *  run's heartbeat is keeping fresh. */
+export async function runMaintenance(identity: WorkerIdentity, idle: boolean): Promise<void> {
+	await reapStaleRuns();
+	await sweepStaleWorkers(STALE_RUN_MS);
+	if (idle) await upsertWorker(identity, 'standby', null, null);
+	await maybeScheduleSync();
+}
+
+// ---------------------------------------------------------------------------
+// Local driver — the long-lived process. Behaves exactly as the old pollLoop.
+// ---------------------------------------------------------------------------
+export function makeLocalDriver(ctx: DriverContext): Driver {
+	return { run: () => runLocalDriver(ctx) };
+}
+
+async function runLocalDriver(ctx: DriverContext): Promise<void> {
+	const { identity, publish } = ctx;
+	const budget = ctx.budget ?? DEFAULT_BUDGET;
+	const log = workerLogger('driver').child({ workerId: identity.id });
+
+	let stopping = false;
+	const onSignal = (sig: string) => {
+		stopping = true;
+		log.info(`${sig} received — shutting down after current run`);
+	};
+	process.on('SIGINT', () => onSignal('SIGINT'));
+	process.on('SIGTERM', () => onSignal('SIGTERM'));
+
+	log.info(
+		{
+			pollIntervalMs: POLL_INTERVAL_MS,
+			tickBudget: budget,
+			autoSyncMinutes: SYNC_SCHEDULE_MS > 0 ? SYNC_SCHEDULE_MS / 60_000 : null,
+			publish
+		},
+		'sync worker polling'
+	);
+
+	// The run this driver is currently steering (spans many ticks), so we stamp the
+	// registry active once on claim and standby once on finish — the run's own
+	// heartbeat keeps it active in between.
+	let currentRunId: string | null = null;
+	let lastMaintenance = 0;
+
+	try {
+		for (;;) {
+			const idle = currentRunId === null;
+			if (Date.now() - lastMaintenance > MAINTENANCE_INTERVAL_MS) {
+				lastMaintenance = Date.now();
+				await runMaintenance(identity, idle);
+			}
+
+			const r = await tick({ identity, publish, budget });
+
+			// A newly-started run: flip this worker to active (its heartbeat keeps it so).
+			if (r.runId && r.runId !== currentRunId) {
+				currentRunId = r.runId;
+				await upsertWorker(identity, 'active', r.runId, r.phase);
+			}
+
+			if (r.status === 'more') continue; // keep pumping — also finishes the run under stop
+			if (r.status === 'done') {
+				currentRunId = null;
+				await upsertWorker(identity, 'standby', null, null);
+				if (stopping) break;
+				continue; // immediately try the next queued run (matches the old loop)
+			}
+			// idle: either no work, or the owned run is paused.
+			if (!r.runId && currentRunId) {
+				currentRunId = null;
+				await upsertWorker(identity, 'standby', null, null);
+			}
+			if (stopping) break; // stop now (a paused run is left to be resumed/reaped)
+			await Bun.sleep(POLL_INTERVAL_MS);
+		}
+	} finally {
+		await deregisterWorker(identity.id);
+		log.info('stopped');
+	}
+}
+
+// ---------------------------------------------------------------------------
+// One-shot pump — the CLI (`--mode X --once`). Drains the core to completion with
+// no loop-forever, no signals, no maintenance: just pump `tick()` until there's no
+// more work. Used after enqueueing a single run.
+// ---------------------------------------------------------------------------
+export async function runToCompletion(ctx: DriverContext): Promise<void> {
+	const { identity, publish } = ctx;
+	const budget = ctx.budget ?? DEFAULT_BUDGET;
+	for (;;) {
+		const r = await tick({ identity, publish, budget });
+		// No work left to claim → done draining.
+		if (r.status === 'idle' && !r.runId) return;
+		// A one-shot run should never be paused (nothing drives the dashboard here);
+		// if it somehow is, bail rather than hot-spin.
+		if (r.status === 'idle' && r.runId) return;
+		// 'more' / 'done' → keep pumping (each tick does real, rate-limited work).
+	}
+}

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,8 +1,13 @@
-// Sync worker entrypoint. Polls sync_run for queued jobs, claims one at a time
-// (atomic guard against double-claim), and runs it to completion. Also supports
-// a one-shot CLI mode for ops/testing:
+// Sync worker entrypoint — now a THIN shell over the runtime seam. It builds this
+// process's identity + tick budget, applies pending migrations, then either:
+//   • pumps the CORE (worker/core.ts) to completion for a one-shot CLI job, or
+//   • hands off to the LOCAL DRIVER (worker/driver.ts) for the long-running loop.
 //
-//   bun run worker/index.ts                       # long-running poll loop
+// The execution model (the loop, sleeps, signals, maintenance) lives in the
+// driver; the bounded batch of crawl work lives in the core. This file only wires
+// them together and parses flags. See worker/README.md § Runtime seam.
+//
+//   bun run worker/index.ts                       # long-running local driver
 //   bun run worker/index.ts --publish             # ...writing blobs through to R2
 //   bun run worker/index.ts --mode estimate --max 80 --once
 //   bun run worker/index.ts --mode crawl          # enqueue + run once, then exit
@@ -13,36 +18,19 @@
 import { hostname } from 'node:os';
 import { readdirSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { and, asc, desc, eq, gt, inArray, lt } from 'drizzle-orm';
 import { client, db } from './db';
 import { syncRun } from '../src/lib/server/db/schema';
-import type { SyncRun } from '../src/lib/server/db/crawl.schema';
 import { applyMigrations } from '../src/lib/server/db/migrator';
-import { SYNC_SCHEDULE_MS, STALE_RUN_MS } from './config';
-import { executeRun, executeSync } from './crawl';
-import { executeExtract } from './extract';
-import { executeEmbed } from './embed';
-import { deregisterWorker, sweepStaleWorkers, upsertWorker, type WorkerIdentity } from './registry';
+import { DEFAULT_BUDGET } from './core';
+import { makeLocalDriver, runToCompletion, type DriverContext } from './driver';
+import type { WorkerIdentity } from './registry';
 import { workerLogger } from './log';
 
 const WORKER_HOST = process.env.HOSTNAME ?? hostname();
 const WORKER_ID = `${WORKER_HOST}-${process.pid}-${crypto.randomUUID().slice(0, 8)}`;
 const IDENTITY: WorkerIdentity = { id: WORKER_ID, host: WORKER_HOST, pid: process.pid };
-const POLL_INTERVAL_MS = 3000;
-const MAINTENANCE_INTERVAL_MS = 30_000;
-const ACTIVE = ['queued', 'running', 'paused'] as const;
 
-// Base logger for the poll loop, bound with this process's worker id (host/pid come
-// from workerLogger) — every line below, and every per-run child, self-locates.
 const log = workerLogger('index').child({ workerId: WORKER_ID });
-
-let stopping = false;
-let standby = false;
-process.on('SIGINT', () => {
-	stopping = true;
-	log.info('SIGINT received — shutting down after current job');
-});
-process.on('SIGTERM', () => (stopping = true));
 
 /** Apply pending drizzle migrations (same runner the web app uses). */
 async function ensureSchema(): Promise<void> {
@@ -54,166 +42,16 @@ async function ensureSchema(): Promise<void> {
 	if (ran.length) log.info({ migrations: ran }, `applied ${ran.length} migration(s)`);
 }
 
-/** Atomically claim the oldest queued run; returns it or null. */
-async function claimNext(): Promise<SyncRun | null> {
-	// Single-writer guard. Two workers iterating the same frontier double-process
-	// every resource — duplicate version rows, double blob writes, and 2× request
-	// load on the (politely rate-limited) target site. If another worker already
-	// owns a live run (fresh heartbeat), stand down. This process becomes a warm
-	// standby: it only starts claiming once that worker dies and its run goes
-	// stale (reaped by reapStaleRuns).
-	const [live] = await db
-		.select({ id: syncRun.id, workerId: syncRun.workerId })
-		.from(syncRun)
-		.where(
-			and(
-				inArray(syncRun.status, ['running', 'paused']),
-				gt(syncRun.heartbeatAt, new Date(Date.now() - STALE_RUN_MS))
-			)
-		)
-		.limit(1);
-	if (live) {
-		if (!standby) {
-			log.info(
-				{ activeWorkerId: live.workerId },
-				'another worker owns an active run — standing by'
-			);
-			standby = true;
-		}
-		return null;
-	}
-	standby = false;
-
-	const [queued] = await db
-		.select()
-		.from(syncRun)
-		.where(eq(syncRun.status, 'queued'))
-		.orderBy(asc(syncRun.requestedAt))
-		.limit(1);
-	if (!queued) return null;
-
-	const claimed = await db
-		.update(syncRun)
-		.set({ status: 'running', workerId: WORKER_ID, startedAt: new Date(), heartbeatAt: new Date() })
-		.where(and(eq(syncRun.id, queued.id), eq(syncRun.status, 'queued')))
-		.returning();
-	return claimed[0] ?? null; // null => another worker grabbed it first
-}
-
-async function runOne(run: SyncRun, publish: boolean): Promise<void> {
-	// Per-run child: runId + mode ride on every line the run's own modules emit too
-	// (they bind the same fields off run.*), so the whole run correlates.
-	const runLog = log.child({ runId: run.id, mode: run.mode });
-	runLog.info({ maxPages: run.maxPages ?? 'default', publish }, 'run started');
-	try {
-		if (run.mode === 'sync') await executeSync(run, { publish });
-		else if (run.mode === 'extract') await executeExtract(run);
-		else if (run.mode === 'embed') await executeEmbed(run);
-		else await executeRun(run, { publish });
-		const [done] = await db.select().from(syncRun).where(eq(syncRun.id, run.id));
-		// extract/embed log their own summary (counts are stage-specific, not crawl rollups).
-		if (run.mode !== 'extract' && run.mode !== 'embed') {
-			runLog.info(
-				{
-					status: done?.status,
-					pages: done?.pages,
-					documents: done?.documents,
-					new: done?.newCount,
-					changed: done?.changedCount,
-					errors: done?.errorCount
-				},
-				'run finished'
-			);
-		}
-	} catch (e) {
-		const msg = e instanceof Error ? (e.stack ?? e.message) : String(e);
-		runLog.error({ err: e }, 'run failed');
-		await db
-			.update(syncRun)
-			.set({ status: 'failed', finishedAt: new Date(), error: msg.slice(0, 2000) })
-			.where(eq(syncRun.id, run.id));
-	}
-}
-
-/** Mark crashed runs (running/paused, heartbeat gone stale) as failed, so a dead
- *  worker doesn't leave an active row blocking claims + the schedule. */
-async function reapStaleRuns(): Promise<void> {
-	const reaped = await db
-		.update(syncRun)
-		.set({ status: 'failed', finishedAt: new Date(), error: 'worker heartbeat timed out (reaped)' })
-		.where(
-			and(
-				inArray(syncRun.status, ['running', 'paused']),
-				lt(syncRun.heartbeatAt, new Date(Date.now() - STALE_RUN_MS))
-			)
-		)
-		.returning({ id: syncRun.id });
-	if (reaped.length)
-		log.warn({ reaped: reaped.map((r) => r.id) }, `reaped ${reaped.length} stale run(s)`);
-}
-
-/** Auto-schedule: enqueue a `sync` run when enabled, idle, and one is due. */
-async function maybeScheduleSync(): Promise<void> {
-	if (SYNC_SCHEDULE_MS <= 0) return;
-	const [active] = await db
-		.select({ id: syncRun.id })
-		.from(syncRun)
-		.where(inArray(syncRun.status, [...ACTIVE]))
-		.limit(1);
-	if (active) return; // don't stack runs
-	const [last] = await db
-		.select({ at: syncRun.requestedAt })
-		.from(syncRun)
-		.where(eq(syncRun.mode, 'sync'))
-		.orderBy(desc(syncRun.requestedAt))
-		.limit(1);
-	const dueAt = last ? last.at.getTime() + SYNC_SCHEDULE_MS : 0;
-	if (Date.now() < dueAt) return;
-	await db.insert(syncRun).values({ mode: 'sync', status: 'queued', requestedBy: 'scheduler' });
-	log.info('scheduled sync enqueued');
-}
-
-async function pollLoop(publish: boolean): Promise<void> {
-	log.info(
-		{
-			pollIntervalMs: POLL_INTERVAL_MS,
-			autoSyncMinutes: SYNC_SCHEDULE_MS > 0 ? SYNC_SCHEDULE_MS / 60_000 : null,
-			publish
-		},
-		'sync worker polling'
-	);
-	let lastMaintenance = 0;
-	while (!stopping) {
-		if (Date.now() - lastMaintenance > MAINTENANCE_INTERVAL_MS) {
-			lastMaintenance = Date.now();
-			await reapStaleRuns();
-			await sweepStaleWorkers(STALE_RUN_MS);
-			// Refresh this process's registry row. Between jobs a worker is a standby
-			// (idle or standing down behind the single-writer guard); the active role is
-			// stamped on claim + each heartbeat, so this refresh is always standby.
-			await upsertWorker(IDENTITY, 'standby', null, null);
-			await maybeScheduleSync();
-		}
-		const run = await claimNext();
-		if (run) {
-			// Flip to active immediately (the heartbeat keeps it fresh mid-run),
-			// then back to standby when the run returns.
-			await upsertWorker(IDENTITY, 'active', run.id, run.currentPhase ?? null);
-			await runOne(run, publish);
-			await upsertWorker(IDENTITY, 'standby', null, null);
-		} else await Bun.sleep(POLL_INTERVAL_MS);
-	}
-	await deregisterWorker(WORKER_ID);
-	log.info('stopped');
-}
-
-async function enqueueAndRunOnce(mode: string, publish: boolean, maxPages?: number): Promise<void> {
-	const [run] = await db
+/** Enqueue a single run and pump the core to completion (one-shot CLI). */
+async function enqueueAndRunOnce(
+	ctx: DriverContext,
+	mode: string,
+	maxPages?: number
+): Promise<void> {
+	await db
 		.insert(syncRun)
-		.values({ mode, maxPages: maxPages ?? null, status: 'queued', requestedBy: 'cli' })
-		.returning();
-	const claimed = await claimNext(); // claims the row we just made
-	await runOne(claimed ?? run, publish);
+		.values({ mode, maxPages: maxPages ?? null, status: 'queued', requestedBy: 'cli' });
+	await runToCompletion(ctx);
 }
 
 function parseArgs(argv: string[]): {
@@ -236,11 +74,13 @@ function parseArgs(argv: string[]): {
 }
 
 const args = parseArgs(process.argv.slice(2));
+const ctx: DriverContext = { identity: IDENTITY, publish: args.publish, budget: DEFAULT_BUDGET };
+
 await ensureSchema();
 if (args.mode || args.once) {
-	await enqueueAndRunOnce(args.mode ?? 'estimate', args.publish, args.max);
+	await enqueueAndRunOnce(ctx, args.mode ?? 'estimate', args.max);
 	process.exit(0);
 } else {
-	await pollLoop(args.publish);
+	await makeLocalDriver(ctx).run();
 	process.exit(0);
 }

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -22,7 +22,7 @@ import { client, db } from './db';
 import { syncRun } from '../src/lib/server/db/schema';
 import { applyMigrations } from '../src/lib/server/db/migrator';
 import { DEFAULT_BUDGET } from './core';
-import { makeLocalDriver, runToCompletion, type DriverContext } from './driver';
+import { makeLocalDriver, runSingleJob, type DriverContext } from './driver';
 import type { WorkerIdentity } from './registry';
 import { workerLogger } from './log';
 
@@ -51,7 +51,7 @@ async function enqueueAndRunOnce(
 	await db
 		.insert(syncRun)
 		.values({ mode, maxPages: maxPages ?? null, status: 'queued', requestedBy: 'cli' });
-	await runToCompletion(ctx);
+	await runSingleJob(ctx);
 }
 
 function parseArgs(argv: string[]): {


### PR DESCRIPTION
Closes #27

Refactors the sync worker's execution model into an environment-agnostic resumable **core** (`tick()`) plus a **local driver** that pumps it, replacing the hard-wired `pollLoop`. Behavior-preserving; only the local driver is built (no Cloudflare/Vercel).

## What changed
- **`worker/core.ts`** (new) — `tick(opts)`: claims-or-continues the one active run, processes ONE bounded batch (max item count **and** soft wall-time budget), persists progress, honors control (pause/cancel/discovery), returns `more`/`idle`/`done`. No `while(true)`, no signal handlers, no wait-sleeps, no lifecycle. Holds the single-writer lease (`claimNext`, preserved verbatim) and a warm in-process session across ticks.
- **`worker/crawl.ts`** — `executeRun`/`executeSync` → `createCrawlSession`/`createSyncSession` exposing a bounded `step(budget)`. Per-item fetch/ingest/schedule logic is unchanged. Pause now **yields** (returns) instead of blocking on `Bun.sleep`; the polite rate-limit delay stays (work-pacing, not lifecycle). Shared `finishRun()` for the terminal step.
- **`worker/driver.ts`** (new) — the driver seam (`Driver`/`DriverContext`) + local driver: the long loop, idle sleeps, SIGINT/SIGTERM graceful shutdown (finishes the in-flight run), periodic maintenance (reap stale runs, sweep registry, standby refresh, auto-schedule), and registry active/standby transitions. Exports reusable primitives (`runMaintenance`, `reapStaleRuns`, `maybeScheduleSync`) for a future serverless driver.
- **`worker/index.ts`** — thin: build identity + budget, migrate, pick a driver. One-shot `--once` (`runSingleJob`) drives exactly one run to completion then exits.
- **`worker/config.ts`** — `WORKER_TICK_MAX_ITEMS` / `WORKER_TICK_BUDGET_MS` bounds + driver cadence knobs.
- **`worker/core.test.ts`** (new) — drives `tick()` to completion, resumability across interrupted ticks, and idempotency (re-run adds no duplicate version rows), all offline.
- **`worker/README.md`** — new **§ Runtime seam** documenting the core/driver split and how a serverless one-tick-per-invocation driver slots in without touching the core.

## Acceptance criteria
- [x] **1** — core exposes a resumable `tick()` processing a bounded batch (count + time budget), returns `more`/`idle`/`done`, no unbounded loop / lifecycle inside.
- [x] **2** — `bun run worker` (local driver) behaves as today: verified end-to-end — claims a queued run, crawls to completion (heartbeats, registry active→standby), graceful SIGINT shutdown + deregister.
- [x] **3** — driving `tick()` repeatedly completes a run identically: `crawl --max 12` yields identical rows/counts vs pre-refactor baseline (resource=11, resource_version=11, blob=11, pages=11, new=11, requests=12).
- [x] **4** — interrupt-between-ticks + resume continues correctly (covered by `core.test.ts` "resumes correctly when interrupted between ticks").
- [x] **5** — driver seam documented (worker/README.md § Runtime seam + driver.ts header); no CF/Vercel driver built.
- [x] **6** — `tick()` advances atomically & idempotently: `core.test.ts` re-runs over unchanged content → zero new version rows; a live `recrawl` over the same 11 URLs added no versions for the 10 unchanged pages (content-addressed sha compare).
- [x] **7** — `bun run check` + `bun run lint` clean; behavior verified on real local crawls (crawl/estimate/sync/recrawl).

## Verify coverage
- **Behavior parity (before vs after):** `crawl --max 12` — identical row counts and rollups.
- **Long-running local driver:** claimed a seeded queued run, ran to completion, worker registry row transitioned active→standby, SIGINT → graceful "stopped" + worker deregistered.
- **Multi-tick + resumability:** `sync --max 8` with `WORKER_TICK_MAX_ITEMS=2` / `WORKER_TICK_BUDGET_MS=500` (many bounded ticks) completed correctly; unit test interrupts and resumes.
- **Idempotency:** `recrawl` over unchanged content → no new version rows; unit test asserts re-run adds none.
- **Tests:** all 34 worker server tests pass (31 existing + 3 new); full server project 60 pass.

## Reviewer must-checks / known deltas
- **extract/embed are not tick-bounded.** They run to completion in a single `step()` (they own internal batch loops and finalize themselves); the bounded-batch requirement targets the crawl frontier. Documented in `core.ts` (`oneShotSession`). A future refactor could make them step-native without touching the seam.
- **One-shot lease behavior (intentional):** old `--once` ran its enqueued row even when another worker held a live lease (lease-bypass). New `--once` goes through the lease-gated `tick()`, so it no-ops if a live run exists — more correct, but a behavior change on that CLI edge. Never triggers for the normal isolated-DB one-shot.
- **Maintenance now runs between ticks of a long run** (not only between runs). All passes are no-ops for a healthy active run (fresh heartbeat; `maybeScheduleSync` skips when a run is active; standby refresh is gated to idle so it never clobbers the active role). Confirmed safe.
- **Cosmetic:** the `sync` "run finished" summary line now carries `phase:"crawling"` (the crawl session's logger binding) — matches the pre-existing logger phase for sync; non-load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)