### PR TITLE
feat(embed): filter nav/boilerplate chunks by content density (#59)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,3 +82,5 @@ R2_SECRET_ACCESS_KEY=""
 # EMBED_CHUNK_CHARS=1200      # target chunk size in characters
 # EMBED_CHUNK_OVERLAP=200     # overlap between neighbouring chunks
 # EMBED_BATCH=32              # chunks per embedding request
+# EMBED_MIN_STOPWORD_RATIO=0.2  # content-density floor: chunks below it (nav/menu/
+#                               # form chrome) are kept out of the index; 0 disables

--- a/worker/README.md
+++ b/worker/README.md
@@ -85,6 +85,19 @@ column width. A model with a different dimensionality needs a new migration
 (vector columns are fixed-width) — see `EMBED_DIM` in
 [`crawl.schema.ts`](../src/lib/server/db/crawl.schema.ts).
 
+**Boilerplate filter (#59).** Nav-heavy CivicPlus landing/index pages leak menu,
+link-list, form, and contact-footer chrome through extraction. Before embedding,
+each chunk is scored for **content density** — its function-word (stopword) ratio,
+see [`worker/boilerplate.ts`](boilerplate.ts) — and chunks below
+`EMBED_MIN_STOPWORD_RATIO` (default `0.2`) are dropped so those near-duplicate
+low-signal snippets never enter the `chunk` index or dilute retrieval. Genuine
+prose (FAQ answers, policy text, news) sits well above the floor; nav/label chrome
+sits near zero. Set the knob to `0` to disable. Filtering happens at chunk time, so
+the raw `resource_text` is untouched. A page whose chunks are _all_ boilerplate (a
+pure index page) yields zero chunks; it stays selectable by the freshness
+predicate, so a re-run re-chunks + re-filters it cheaply (no embedding calls, no
+writes) rather than being a strict no-op — content resources settle normally.
+
 **Document size limit.** In `crawl`/`recrawl`, HTML is always downloaded but large
 binaries can be skipped: `CRAWLER_MAX_DOC_BYTES` (env default) or per-run
 `params.maxDocBytes` (the dashboard's "Max file size, MB"). Docs over the limit are

--- a/worker/boilerplate.test.ts
+++ b/worker/boilerplate.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { stopwordRatio, isBoilerplateChunk } from './boilerplate';
+
+// Real low-signal chunks captured verbatim from a live Orleans crawl — the
+// nav/menu/index/form/footer chrome #59 must keep out of the vector index. Each
+// leaks through readability off a nav-heavy landing/index page.
+const HOW_DO_I_INDEX =
+	'Government Community Business Visiting Orleans How Do I... HomeHow Do I... A A ' +
+	'Click the button to sign up for emergency alerts. Click the button to sign up for ' +
+	'website notifications. 9 2 2 3 Employment Opportunities Beach and OSV Stickers ' +
+	'Passports Building Permits Senior Tax Work-Off Program Universal Pre-K Program ' +
+	'Rental Registration Departments & Staff Police Department Select Board Flood Map ' +
+	'Information Channel 1072 Live Stream CivicReady Emergency Alerts NotifyMe Website ' +
+	'Notifications EyeOnWater Voting Recreation Activities Video Archive Requests Online ' +
+	'Payments Parking Ticket Payments (In Person) Parking Ticket Payments (Mail)';
+const AGENDA_CENTER_INDEX =
+	'HomeAgenda Center View current agendas and minutes for all boards and commissions. ' +
+	'Search Agendas by: Time Period Enter Search Terms Select a Category Search 141 ' +
+	'Portanimicut Road Task Force 2021 2020 Building Code of Appeals 2022 Community Center ' +
+	'Feasibility Task Force 2022 2021 Fire-Rescue Building Committee 2026 2025 Governor ' +
+	'Prence Planning Committee 2022 2021 Long Range Capital Planning Committee 2024 2023';
+const CONTACT_FOOTER =
+	'Contact Us 19 School RoadOrleans, MA 02653Phone: 508-240-3700Fax: 508-240-3388' +
+	'Town Hall Hours M - F 8:30 AM to 4:30 PMPassport Hours T - T 8:30 AM to 12PM, 1PM to 4PM';
+const DIRECTORY_FORM = 'Category: First Name: Last Name: Search';
+
+// Genuine content (FAQ answer / policy prose) from the same crawl — must be kept.
+const FAQ_ANSWER =
+	'An abatement is a reduction in your property’s assessment that you can apply for ' +
+	'if you believe that assessment does not accurately reflect the property’s market value. ' +
+	'You should seek an abatement if you believe one of the following applies to your property.';
+const POLICY_TEXT =
+	'The Town of Orleans remains in a significant drought and has implemented mandatory ' +
+	'water use restrictions. Outdoor watering is permitted between 5:00 PM and 9:00 AM using ' +
+	'hand-held hoses, watering cans, or drip irrigation. Limited exceptions are in place.';
+
+describe('stopwordRatio (content density)', () => {
+	it('is below the default floor for nav/index/form/footer chrome', () => {
+		// All measured well under 0.2 on the real corpus (0.0–0.19).
+		expect(stopwordRatio(HOW_DO_I_INDEX)).toBeLessThan(0.2);
+		expect(stopwordRatio(AGENDA_CENTER_INDEX)).toBeLessThan(0.2);
+		expect(stopwordRatio(CONTACT_FOOTER)).toBeLessThan(0.2);
+		expect(stopwordRatio(DIRECTORY_FORM)).toBeLessThan(0.2);
+	});
+
+	it('is well above the floor for genuine prose', () => {
+		expect(stopwordRatio(FAQ_ANSWER)).toBeGreaterThan(0.3);
+		expect(stopwordRatio(POLICY_TEXT)).toBeGreaterThan(0.3);
+	});
+
+	it('scores empty / word-free text as 0', () => {
+		expect(stopwordRatio('')).toBe(0);
+		expect(stopwordRatio('   \n\n ')).toBe(0);
+		expect(stopwordRatio('!!! —— 123 456')).toBe(0);
+	});
+});
+
+describe('isBoilerplateChunk', () => {
+	it('flags nav/index/form/footer chrome as boilerplate', () => {
+		expect(isBoilerplateChunk(HOW_DO_I_INDEX)).toBe(true);
+		expect(isBoilerplateChunk(AGENDA_CENTER_INDEX)).toBe(true);
+		expect(isBoilerplateChunk(CONTACT_FOOTER)).toBe(true);
+		expect(isBoilerplateChunk(DIRECTORY_FORM)).toBe(true);
+	});
+
+	it('keeps genuine FAQ / policy content', () => {
+		expect(isBoilerplateChunk(FAQ_ANSWER)).toBe(false);
+		expect(isBoilerplateChunk(POLICY_TEXT)).toBe(false);
+	});
+
+	it('honors an explicit threshold (tunable knob)', () => {
+		// A stricter floor drops borderline prose; a looser one keeps chrome.
+		expect(isBoilerplateChunk(FAQ_ANSWER, 0.9)).toBe(true);
+		expect(isBoilerplateChunk(HOW_DO_I_INDEX, 0.05)).toBe(false);
+	});
+
+	it('is disabled when the threshold is 0 (or negative)', () => {
+		expect(isBoilerplateChunk(HOW_DO_I_INDEX, 0)).toBe(false);
+		expect(isBoilerplateChunk(DIRECTORY_FORM, 0)).toBe(false);
+		expect(isBoilerplateChunk('', 0)).toBe(false);
+	});
+});

--- a/worker/boilerplate.ts
+++ b/worker/boilerplate.ts
@@ -1,0 +1,74 @@
+// Boilerplate / low-signal chunk filter (#59). Nav-heavy CivicPlus landing and
+// index pages leak menu/chrome through readability extraction — e.g. the menu
+// strip "Government Community Business Visiting Orleans How Do I…", contact-info
+// footers, calendar grids, and link lists. Chunked and embedded, those near-
+// identical low-signal snippets recur across many resources and pollute the
+// vector index (they match everything and mean nothing).
+//
+// The discriminator is CONTENT DENSITY, measured as function-word (stopword)
+// ratio: the fraction of word tokens that are common English function words
+// (the/of/to/and/is/…). Genuine prose — FAQ answers, policy text, news — is
+// always rich in function words (~0.25–0.50 on the real Orleans corpus). Nav
+// menus, label lists, form fields, and number grids are noun/label salads with
+// almost none (~0.00–0.18). A single tunable floor cleanly separates the two.
+//
+// Filtering happens at chunk time (worker/embed.ts), BEFORE chunks are embedded
+// and written to `chunk`, so the raw `resource_text` stays intact — the filter
+// only decides which chunks reach the index, never mutates the extracted text.
+import { CHUNK_MIN_STOPWORD_RATIO } from './config';
+
+// A compact, standard English function-word list. Function words carry grammar,
+// not topic, so real sentences are dense with them while nav/label chrome is not
+// — which is exactly what makes their density a robust content signal. Lowercase;
+// matched against alphanumeric word tokens.
+// prettier-ignore
+export const STOPWORDS: ReadonlySet<string> = new Set([
+	'a', 'about', 'above', 'after', 'again', 'against', 'all', 'am', 'an', 'and',
+	'any', 'are', 'as', 'at', 'be', 'because', 'been', 'before', 'being', 'below',
+	'between', 'both', 'but', 'by', 'can', 'could', 'did', 'do', 'does', 'doing',
+	'down', 'during', 'each', 'few', 'for', 'from', 'further', 'had', 'has', 'have',
+	'having', 'he', 'her', 'here', 'hers', 'herself', 'him', 'himself', 'his', 'how',
+	'i', 'if', 'in', 'into', 'is', 'it', 'its', 'itself', 'just', 'me', 'might',
+	'more', 'most', 'must', 'my', 'myself', 'no', 'nor', 'not', 'now', 'of', 'off',
+	'on', 'once', 'only', 'or', 'other', 'our', 'ours', 'out', 'over', 'own', 'said',
+	'same', 'shall', 'she', 'should', 'so', 'some', 'such', 'than', 'that', 'the',
+	'their', 'theirs', 'them', 'themselves', 'then', 'there', 'these', 'they', 'this',
+	'those', 'through', 'to', 'too', 'under', 'until', 'up', 'upon', 'us', 'very',
+	'was', 'we', 'were', 'what', 'when', 'where', 'which', 'while', 'who', 'whom',
+	'why', 'will', 'with', 'would', 'you', 'your', 'yours', 'yourself'
+]);
+
+/** Word tokens (alphanumeric runs, Unicode-aware) used to measure density. */
+function words(text: string): string[] {
+	return text.toLowerCase().match(/[\p{L}\p{N}]+/gu) ?? [];
+}
+
+/**
+ * Content density of a chunk: the fraction of its word tokens that are English
+ * function words, in [0, 1]. High for prose, near-zero for nav/label/link/number
+ * chrome. Empty / word-free text scores 0 (treated as no content).
+ */
+export function stopwordRatio(text: string): number {
+	const toks = words(text);
+	if (toks.length === 0) return 0;
+	let stop = 0;
+	for (const t of toks) if (STOPWORDS.has(t)) stop++;
+	return stop / toks.length;
+}
+
+/**
+ * True when a chunk is low-signal boilerplate (nav/menu/link-list/form/number
+ * chrome) and should be kept OUT of the vector index. A chunk qualifies when its
+ * content density (stopword ratio) is below `minRatio`.
+ *
+ * `minRatio` defaults to the configured CHUNK_MIN_STOPWORD_RATIO. A value of 0
+ * disables the filter (nothing is boilerplate) — the escape hatch for turning it
+ * off entirely via config.
+ */
+export function isBoilerplateChunk(
+	text: string,
+	minRatio: number = CHUNK_MIN_STOPWORD_RATIO
+): boolean {
+	if (minRatio <= 0) return false; // filter disabled
+	return stopwordRatio(text) < minRatio;
+}

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -154,6 +154,14 @@ export const CHUNK_MAX_CHARS = Number(process.env.EMBED_CHUNK_CHARS ?? 1200);
 export const CHUNK_OVERLAP_CHARS = Number(process.env.EMBED_CHUNK_OVERLAP ?? 200);
 // How many chunks to send to the embedding model per request (batching).
 export const EMBED_BATCH = Number(process.env.EMBED_BATCH ?? 32);
+// Boilerplate/low-signal chunk filter (#59). A chunk whose content density —
+// measured as its function-word (stopword) ratio, see worker/boilerplate.ts — is
+// below this floor is treated as nav/menu/link-list/form chrome and kept OUT of
+// the `chunk` index, so those near-duplicate low-signal snippets don't pollute
+// retrieval. Genuine prose (FAQ answers, policy text, news) sits well above it
+// (~0.25–0.50 on the real Orleans corpus) while nav/label chrome sits near zero,
+// so 0.2 separates them with margin. Set to 0 to disable the filter entirely.
+export const CHUNK_MIN_STOPWORD_RATIO = Number(process.env.EMBED_MIN_STOPWORD_RATIO ?? 0.2);
 // Which embedding provider to use: 'cloudflare' | 'openai' | 'fake'. Unset =
 // auto-detect from available credentials, falling back to the deterministic
 // 'fake' embedder (so the pipeline runs offline / in CI). See selectEmbedder().

--- a/worker/embed.pipeline.test.ts
+++ b/worker/embed.pipeline.test.ts
@@ -137,4 +137,31 @@ describe('executeEmbed pipeline', () => {
 		expect(await chunkCount('r1')).toBe(0); // orphans cleared
 		expect(await chunkCount('r2')).toBe(r2Count); // unrelated resource intact
 	});
+
+	it('keeps nav/boilerplate chunks out of the index but retains content (#59)', async () => {
+		// A pure nav/index page (real How-Do-I index chunk): menu strip + link labels,
+		// no prose. Every chunk is low-signal, so none should reach `chunk`.
+		const NAV =
+			'Government Community Business Visiting Orleans How Do I... HomeHow Do I... A A ' +
+			'Employment Opportunities Beach and OSV Stickers Passports Building Permits ' +
+			'Senior Tax Work-Off Program Universal Pre-K Program Rental Registration ' +
+			'Departments & Staff Police Department Select Board Flood Map Information ' +
+			'Channel 1072 Live Stream CivicReady Emergency Alerts NotifyMe Website ' +
+			'Notifications EyeOnWater Voting Recreation Activities Video Archive Requests';
+		await seedResource('r3', 'https://x/how-do-i', 'How Do I');
+		await seedText('r3', 'shaC', 'ok', NAV);
+		// A genuine FAQ answer alongside it — must be retained.
+		await seedResource('r4', 'https://x/faq', 'FAQ');
+		await seedText(
+			'r4',
+			'shaD',
+			'ok',
+			'An abatement is a reduction in your property assessment that you can apply for if ' +
+				'you believe that assessment does not accurately reflect the market value of your home.'
+		);
+		await embedRun();
+
+		expect(await chunkCount('r3')).toBe(0); // all nav chunks filtered out
+		expect(await chunkCount('r4')).toBeGreaterThan(0); // real content retained
+	});
 });

--- a/worker/embed.ts
+++ b/worker/embed.ts
@@ -16,6 +16,7 @@ import { chunk, crawlEvent, resource, resourceText, syncRun } from '../src/lib/s
 import type { SyncRun } from '../src/lib/server/db/crawl.schema';
 import { EMBED_BATCH } from './config';
 import { chunkText } from './chunk';
+import { isBoilerplateChunk } from './boilerplate';
 import { selectEmbedder, type Embedder } from './embeddings';
 import { refreshActiveWorker } from './registry';
 import { runLogger } from './log';
@@ -29,15 +30,26 @@ interface EmbedStats {
 	rebuilt: number; // resources chunked + embedded
 	cleared: number; // resources whose (now non-ok) chunks were removed
 	chunks: number; // chunk rows written
+	filtered: number; // low-signal/boilerplate chunks dropped before embedding (#59)
 	errors: number;
 }
 
 function zero(): EmbedStats {
-	return { processed: 0, rebuilt: 0, cleared: 0, chunks: 0, errors: 0 };
+	return { processed: 0, rebuilt: 0, cleared: 0, chunks: 0, filtered: 0, errors: 0 };
 }
 
 /** Rebuild one resource's chunks: delete existing, then chunk + embed + insert.
- *  Returns the number of chunk rows written. */
+ *  Returns the number of chunk rows written and the number of low-signal chunks
+ *  dropped by the boilerplate filter (#59). Boilerplate chunks are removed BEFORE
+ *  embedding, so nav/menu chrome never reaches the model or the `chunk` index and
+ *  the raw `resource_text` it came from stays untouched.
+ *
+ *  A resource whose chunks are ALL boilerplate (e.g. a pure nav/index page)
+ *  yields zero surviving chunks: any prior chunks are cleared and nothing is
+ *  inserted. Such a resource stays selectable by the freshness predicate (which
+ *  keys off chunk existence), so a re-run re-chunks + re-filters it — cheap, no
+ *  embedding calls, no writes — rather than being a strict no-op. Genuine content
+ *  resources (with surviving chunks) settle normally and are never reprocessed. */
 async function rebuildResource(
 	row: {
 		resourceId: string;
@@ -48,8 +60,11 @@ async function rebuildResource(
 		kind: string;
 	},
 	embedder: Embedder
-): Promise<number> {
-	const pieces = chunkText(row.text);
+): Promise<{ written: number; filtered: number }> {
+	const all = chunkText(row.text);
+	// Drop low-signal boilerplate (nav/menu/link-list/form chrome) before embedding.
+	const pieces = all.filter((p) => !isBoilerplateChunk(p.text));
+	const filtered = all.length - pieces.length;
 
 	const now = new Date();
 	// Embed OUTSIDE the transaction — it's the slow, network-bound part, and we
@@ -86,7 +101,7 @@ async function rebuildResource(
 			await tx.insert(chunk).values(pending.slice(i, i + INSERT_CHUNK_ROWS));
 		}
 	});
-	return pending.length;
+	return { written: pending.length, filtered };
 }
 
 export async function executeEmbed(
@@ -184,7 +199,7 @@ export async function executeEmbed(
 
 			try {
 				if (r.status === 'ok') {
-					const n = await rebuildResource(
+					const { written, filtered } = await rebuildResource(
 						{
 							resourceId: r.resourceId,
 							sha256: r.sha256,
@@ -196,7 +211,8 @@ export async function executeEmbed(
 						embedder
 					);
 					stats.rebuilt++;
-					stats.chunks += n;
+					stats.chunks += written;
+					stats.filtered += filtered;
 				} else {
 					// content no longer extractable — drop its now-orphan chunks.
 					await db.delete(chunk).where(eq(chunk.resourceId, r.resourceId));
@@ -240,6 +256,7 @@ export async function executeEmbed(
 			processed: stats.processed,
 			rebuilt: stats.rebuilt,
 			chunks: stats.chunks,
+			filtered: stats.filtered,
 			cleared: stats.cleared,
 			errors: stats.errors
 		},


### PR DESCRIPTION
Closes #59

## What & why

Nav-heavy CivicPlus landing/index pages leak menu, link-list, form, and contact-footer chrome through `@mozilla/readability` extraction. Chunked and embedded, those near-identical low-signal snippets (e.g. the `Government Community Business Visiting Orleans How Do I…` menu strip) recur across many resources and pollute the vector index — they match everything and mean nothing.

This adds a **content-density filter** at chunk time. Each chunk is scored by its **function-word (stopword) ratio** — genuine prose is dense with function words (the/of/to/and/is…); nav/label/form/number chrome is a noun-salad with almost none. Chunks below a tunable floor are dropped **before embedding**, so nav chrome never reaches the model or the `chunk` index and the raw `resource_text` stays intact.

## Approach

- `worker/boilerplate.ts` — `stopwordRatio(text)` (content density) + `isBoilerplateChunk(text, minRatio)`. Pure, unit-tested, no DB.
- `worker/config.ts` — `CHUNK_MIN_STOPWORD_RATIO` (env `EMBED_MIN_STOPWORD_RATIO`), **default `0.2`**; set `0` to disable.
- `worker/embed.ts` — `rebuildResource` filters chunks after `chunkText`, before embed/insert; adds a `filtered` stat to the run log.
- Docs: `worker/README.md`, `.env.example`.

Chosen over cross-page dup detection because a single per-chunk density signal cleanly separates the two classes on real data (below) with no extra state or cross-resource bookkeeping.

## Verified against a REAL crawl

`--mode crawl --max 15` of `town.orleans.ma.us` → extract → embed (`EMBEDDING_PROVIDER=fake`), then measured the `chunk` table before/after the filter:

| | chunks | `Government Community Business Visiting Orleans` chunks | FAQ content chunks |
|---|---|---|---|
| **before** | 124 | 3 | 79 |
| **after** | 115 | 2 | 79 |

**9 boilerplate chunks removed, 0 genuine content lost.** Dropped chunks (all stopword-ratio 0.00–0.19, well below the 0.20 floor; lowest *retained* content chunk = 0.231 — clean margin):

- `/Directory.aspx` (0.00 — `Category: First Name: Last Name: Search`)
- `/AgendaCenter` (0.09 — search UI + committee/year list)
- `/27/Government`, `/DocumentCenter` (0.17 — duplicated `Contact Us / 19 School Road / hours` footer)
- `/Archive.aspx` ×2 (0.12, 0.18 — archive category lists)
- `/Calendar.aspx` ×2 (0.19, 0.17 — calendar grid + `More Details` list)
- `/9/How-Do-I` (0.19 — full menu/link index)

All 79 FAQ answer chunks and all news/policy prose retained.

## Acceptance criteria

- [x] **1. Nav/boilerplate chunks no longer enter `chunk`.** All pure nav/index/form/footer chunks dropped (9/9). *Residual:* on the two thin index pages (`/31/Community`, `/101/Visiting-Orleans`) readability interleaves the menu strip with real body text into one chunk; that chunk's density is high (~0.37) so it is **retained as content** — dropping it would violate criterion 2. Hence the menu string goes 3→2, not →0. Whole-chunk drop only (never mutates chunk text, so char offsets still reproduce the source verbatim).
- [x] **2. Genuine content retained.** 0 FAQ/policy/news chunks lost; lowest retained content sits at 0.231 vs the 0.189 top of the dropped set.
- [x] **3. Threshold configurable with a sensible default.** `CHUNK_MIN_STOPWORD_RATIO` default 0.2; `0` disables.
- [x] **4. Verified against a real crawl.** Table above (124→115; nav 3→2; FAQ 79→79).
- [x] **5. `bun run check` + lint clean.** `check` 0 errors; `eslint .` exit 0; prettier clean on changed files (only pre-existing gitignored `project.inlang/*` warnings remain).

No schema/migration change.

## Reviewer must-checks / known limitations

- **Idempotency edge (documented in code + README).** 7 of 14 resources here are pure index pages whose chunks are *all* boilerplate → 0 surviving chunks. Because the freshness predicate keys off chunk existence, such a resource stays selectable and a re-run re-chunks + re-filters it — **cheap: no embedding calls, no writes** (confirmed: 2nd embed run reported `processed:7, chunks:0, filtered:9`). Genuine-content resources settle normally and are never reprocessed. A per-resource "embedded" marker would make it a strict no-op but needs a schema column, which the brief scoped out; noted as possible follow-up.
- **Density filters drop low-density *content* too** — e.g. a duplicated `Town Hall hours / phone / address` footer is dropped (stopword-ratio 0.17). In this crawl that block only appeared as recurring index-page chrome, but on a dedicated contact page the same block would be its genuine content. Inherent to the sanctioned content-density approach; mitigated by the tunable/disablable knob.

## Tests

- `worker/boilerplate.test.ts` — density scoring + boilerplate classification on real captured nav/FAQ strings; threshold tunability; disable-at-0.
- `worker/embed.pipeline.test.ts` — new end-to-end case: a pure-nav resource yields 0 chunks while a genuine FAQ resource is retained.
- Full worker server suite: 42 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)