### PR TITLE
AI Search adapter — R2 cleaned-text exporter + search() provider + eval switch (#63)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,3 +84,17 @@ R2_SECRET_ACCESS_KEY=""
 # EMBED_BATCH=32              # chunks per embedding request
 # EMBED_MIN_STOPWORD_RATIO=0.2  # content-density floor: chunks below it (nav/menu/
 #                               # form chrome) are kept out of the index; 0 disables
+
+# ---------------------------------------------------------------------------
+# RAG retrieval provider (#63). Selects which retriever the answerer + eval use:
+#   vectorize (default) — custom libSQL vector_top_k over our own `chunk` index.
+#   ai-search           — Cloudflare AI Search's managed retrieval endpoint,
+#                         indexing the cleaned-text export (`bun run worker:index-export`
+#                         publishes each `ok` resource's text to the R2 `index/` prefix
+#                         with x-amz-meta-source-url/title/kind). Requires R2_* above
+#                         for the export, and the three vars below for retrieval.
+# ---------------------------------------------------------------------------
+# RETRIEVAL_PROVIDER=vectorize      # vectorize | ai-search (default vectorize)
+# CF_ACCOUNT_ID=""                  # Cloudflare account id
+# AI_SEARCH_INSTANCE=""             # AI Search instance name
+# AI_SEARCH_TOKEN=""                # API token with AI Search:Run (Bearer)

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"worker:estimate": "bun run worker/index.ts --mode estimate --once",
 		"worker:extract": "bun run worker/index.ts --mode extract --once",
 		"worker:embed": "bun run worker/index.ts --mode embed --once",
+		"worker:index-export": "bun run worker/index.ts --mode index-export --once",
 		"eval": "bun run worker/eval/run.ts",
 		"blobs:sync": "bun run worker/sync-blobs.ts --both",
 		"blobs:push": "bun run worker/sync-blobs.ts --push",

--- a/src/lib/server/rag/answer.ts
+++ b/src/lib/server/rag/answer.ts
@@ -25,11 +25,8 @@
 //     records" label, whether or not the model remembered to add it.
 //   • Mode is validated to the three-value enum; anything else degrades to
 //     `abstained` (the safe default — never assert an unsupported specific).
-import {
-	retrieve as defaultRetrieve,
-	type RetrievalResult,
-	type RetrieveOptions
-} from './retrieve';
+import { type RetrievalResult, type RetrieveOptions } from './retrieve';
+import { selectRetriever } from './provider';
 import {
 	selectLlm,
 	defaultAnswerModel,
@@ -56,7 +53,8 @@ export interface AnswerOptions {
 	model?: string;
 	/** Output cap passed to the model. Defaults to `DEFAULT_MAX_TOKENS`. */
 	maxTokens?: number;
-	/** Inject a retrieval fn (tests / seeded corpus). Defaults to #36's `retrieve()`. */
+	/** Inject a retrieval fn (tests / seeded corpus). Defaults to the provider
+	 *  selected by `RETRIEVAL_PROVIDER` (vectorize `retrieve()` or ai-search). */
 	retrieve?: (question: string, opts?: RetrieveOptions) => Promise<RetrievalResult>;
 	/** Options forwarded to the retrieval fn (topK, injected client/embedder, …). */
 	retrieveOptions?: RetrieveOptions;
@@ -75,7 +73,7 @@ export async function answer(question: string, opts: AnswerOptions = {}): Promis
 	// spend an embed + vector query on retrieval we'd then throw away.
 	const llm = selectLlm(opts.llm);
 
-	const retrieveFn = opts.retrieve ?? defaultRetrieve;
+	const retrieveFn = opts.retrieve ?? selectRetriever();
 	const retrieval = await retrieveFn(question, opts.retrieveOptions);
 	const retrievedUrls = retrieval.sources.map((s) => s.url);
 

--- a/src/lib/server/rag/provider.test.ts
+++ b/src/lib/server/rag/provider.test.ts
@@ -1,0 +1,44 @@
+// Retrieval-provider switch test (#63). Proves RETRIEVAL_PROVIDER cleanly selects
+// the custom vectorize retriever (default) vs the AI Search provider, and that an
+// unset/unknown value keeps today's default — no behaviour change unless opted in.
+import { afterEach, describe, it, expect } from 'vitest';
+import { resolveProvider, selectRetriever, DEFAULT_RETRIEVAL_PROVIDER } from './provider';
+import { retrieve } from './retrieve';
+import { search } from './search';
+
+const original = process.env.RETRIEVAL_PROVIDER;
+afterEach(() => {
+	if (original === undefined) delete process.env.RETRIEVAL_PROVIDER;
+	else process.env.RETRIEVAL_PROVIDER = original;
+});
+
+describe('retrieval provider switch', () => {
+	it('defaults to vectorize when unset', () => {
+		delete process.env.RETRIEVAL_PROVIDER;
+		expect(DEFAULT_RETRIEVAL_PROVIDER).toBe('vectorize');
+		expect(resolveProvider()).toBe('vectorize');
+		expect(selectRetriever()).toBe(retrieve);
+	});
+
+	it('selects ai-search when RETRIEVAL_PROVIDER=ai-search', () => {
+		process.env.RETRIEVAL_PROVIDER = 'ai-search';
+		expect(resolveProvider()).toBe('ai-search');
+		expect(selectRetriever()).toBe(search);
+	});
+
+	it('is case-insensitive and trims', () => {
+		expect(resolveProvider('  AI-Search ')).toBe('ai-search');
+		expect(selectRetriever('  AI-Search ')).toBe(search);
+	});
+
+	it('falls back to the default on an unknown value (never silently disables)', () => {
+		process.env.RETRIEVAL_PROVIDER = 'pinecone';
+		expect(resolveProvider()).toBe('vectorize');
+		expect(selectRetriever()).toBe(retrieve);
+	});
+
+	it('an explicit argument overrides the env var', () => {
+		process.env.RETRIEVAL_PROVIDER = 'vectorize';
+		expect(selectRetriever('ai-search')).toBe(search);
+	});
+});

--- a/src/lib/server/rag/provider.ts
+++ b/src/lib/server/rag/provider.ts
@@ -1,0 +1,33 @@
+// Retrieval-provider switch (#63). One env var, `RETRIEVAL_PROVIDER`, selects which
+// implementation of the `retrieve()` contract the pipeline uses:
+//
+//   • vectorize (default) — our custom pipeline: embed the query + libSQL
+//     `vector_top_k` over the `chunk` index (rag/retrieve.ts).
+//   • ai-search           — Cloudflare AI Search's managed retrieval endpoint
+//     (rag/search.ts), indexing the cleaned-text export (worker/index-export.ts).
+//
+// Both conform to the SAME signature and `{ passages, sources, context }` return,
+// so everything downstream (answer.ts, the #39 eval) is provider-agnostic — the
+// choice is config, not code. Default is `vectorize`, so unset/unknown values keep
+// today's behaviour exactly.
+import { retrieve, type RetrievalResult, type RetrieveOptions } from './retrieve';
+import { search } from './search';
+
+/** The shared retrieval contract both providers implement. */
+export type Retriever = (question: string, opts?: RetrieveOptions) => Promise<RetrievalResult>;
+
+export type RetrievalProvider = 'vectorize' | 'ai-search';
+
+export const DEFAULT_RETRIEVAL_PROVIDER: RetrievalProvider = 'vectorize';
+
+/** Normalize a provider name; anything unrecognised falls back to the default so a
+ *  typo can never silently disable retrieval. */
+export function resolveProvider(name?: string): RetrievalProvider {
+	const v = (name ?? process.env.RETRIEVAL_PROVIDER ?? '').trim().toLowerCase();
+	return v === 'ai-search' ? 'ai-search' : DEFAULT_RETRIEVAL_PROVIDER;
+}
+
+/** Pick the retrieval function for the given (or configured) provider. */
+export function selectRetriever(provider?: string): Retriever {
+	return resolveProvider(provider) === 'ai-search' ? search : retrieve;
+}

--- a/src/lib/server/rag/retrieve.ts
+++ b/src/lib/server/rag/retrieve.ts
@@ -168,8 +168,10 @@ export async function retrieve(
 	return { passages, sources, context };
 }
 
-/** Distinct source documents, in order of first (i.e. best-scoring) appearance. */
-function dedupeSources(passages: Passage[]): Source[] {
+/** Distinct source documents, in order of first (i.e. best-scoring) appearance.
+ *  Exported so an alternate retrieval provider (see rag/search.ts) assembles its
+ *  `sources`/`context` IDENTICALLY — the two must be drop-in interchangeable. */
+export function dedupeSources(passages: Passage[]): Source[] {
 	const seen = new Set<string>();
 	const sources: Source[] = [];
 	for (const p of passages) {
@@ -181,8 +183,9 @@ function dedupeSources(passages: Passage[]): Source[] {
 }
 
 /** Number each passage with its source's citation `[n]`, then list the sources —
- *  a compact, grounded block the answerer can quote and cite from. */
-function assembleContext(passages: Passage[], sources: Source[]): string {
+ *  a compact, grounded block the answerer can quote and cite from. Exported so an
+ *  alternate retrieval provider (rag/search.ts) produces a byte-identical context. */
+export function assembleContext(passages: Passage[], sources: Source[]): string {
 	if (passages.length === 0) return '';
 	const citation = new Map(sources.map((s, i) => [s.url, i + 1]));
 	const body = passages.map((p) => `[${citation.get(p.url)}] ${p.text}`).join('\n\n');

--- a/src/lib/server/rag/retrieve.ts
+++ b/src/lib/server/rag/retrieve.ts
@@ -69,8 +69,10 @@ export interface RetrieveOptions {
 	client?: Client;
 }
 
-const DEFAULT_TOP_K = 8;
-const DEFAULT_MAX_PER_RESOURCE = 3;
+/** Default passage count + per-source cap. Exported so an alternate provider
+ *  (rag/search.ts) trims to the SAME defaults and the two can't drift apart. */
+export const DEFAULT_TOP_K = 8;
+export const DEFAULT_MAX_PER_RESOURCE = 3;
 const CANDIDATE_MULTIPLIER = 5;
 
 interface CandidateRow {

--- a/src/lib/server/rag/search.test.ts
+++ b/src/lib/server/rag/search.test.ts
@@ -1,0 +1,174 @@
+// AI Search retrieval-provider test (#63). Drives search() with a fake `fetch` that
+// returns canned AI Search JSON, and proves the mapping: content/score → passages,
+// custom `source-url`/`title`/`kind` metadata → real source attribution, sources
+// deduped, and a numbered grounded context assembled just like retrieve(). Also
+// proves the request shape (endpoint, bearer auth, query/max_num_results body) and
+// the per-source cap. Fully offline — no network, no creds.
+import { describe, it, expect } from 'vitest';
+import { search, type FetchLike } from './search';
+
+/** A fake fetch that records the request and returns a scripted AI Search body. */
+function fakeFetch(
+	body: unknown,
+	capture?: (url: string, init?: Parameters<FetchLike>[1]) => void
+): FetchLike {
+	return async (url, init) => {
+		capture?.(url, init);
+		return {
+			ok: true,
+			status: 200,
+			json: async () => body,
+			text: async () => JSON.stringify(body)
+		};
+	};
+}
+
+const CFG = { accountId: 'acct-123', instance: 'orleans', token: 'tok-abc' };
+
+const CANNED = {
+	result: {
+		data: [
+			{
+				file_id: 'res-beach',
+				filename: 'res-beach.md',
+				score: 0.91,
+				content: [{ type: 'text', text: 'Nauset Beach resident parking stickers.' }],
+				attributes: {
+					'source-url': 'https://www.town.orleans.ma.us/beach',
+					title: 'Beach Stickers',
+					kind: 'page'
+				}
+			},
+			{
+				file_id: 'res-meeting',
+				filename: 'res-meeting.md',
+				score: 0.72,
+				content: [{ type: 'text', text: 'The Annual Town Meeting is held each spring.' }],
+				attributes: {
+					'source-url': 'https://www.town.orleans.ma.us/town-meeting',
+					title: 'Annual Town Meeting',
+					kind: 'page'
+				}
+			}
+		]
+	},
+	success: true
+};
+
+describe('search (AI Search retrieval provider)', () => {
+	it('maps content/score + custom metadata into passages with real source URLs', async () => {
+		const { passages } = await search('beach stickers', { ...CFG, fetch: fakeFetch(CANNED) });
+
+		expect(passages).toHaveLength(2);
+		const top = passages[0];
+		expect(top.text).toBe('Nauset Beach resident parking stickers.');
+		expect(top.score).toBe(0.91);
+		expect(top.url).toBe('https://www.town.orleans.ma.us/beach'); // from x-amz-meta-source-url
+		expect(top.title).toBe('Beach Stickers');
+		expect(top.kind).toBe('page');
+		expect(top.resourceId).toBe('res-beach');
+	});
+
+	it('assembles deduped sources + a numbered grounded context (drop-in with retrieve)', async () => {
+		const { sources, context } = await search('beach stickers', {
+			...CFG,
+			fetch: fakeFetch(CANNED)
+		});
+
+		expect(sources.map((s) => s.url)).toEqual([
+			'https://www.town.orleans.ma.us/beach',
+			'https://www.town.orleans.ma.us/town-meeting'
+		]);
+		expect(context).toContain('[1] Nauset Beach');
+		expect(context).toContain('[2] The Annual Town Meeting');
+		expect(context).toContain('Sources:');
+		expect(context).toContain('Beach Stickers — https://www.town.orleans.ma.us/beach');
+	});
+
+	it('calls the retrieval-only REST endpoint with bearer auth + query body', async () => {
+		let seenUrl = '';
+		let seenInit: Parameters<FetchLike>[1];
+		await search('dogs at kents point', {
+			...CFG,
+			topK: 5,
+			fetch: fakeFetch(CANNED, (url, init) => {
+				seenUrl = url;
+				seenInit = init;
+			})
+		});
+
+		// retrieval-only `/search`, NOT the generative `/ai-search`.
+		expect(seenUrl).toBe(
+			'https://api.cloudflare.com/client/v4/accounts/acct-123/ai-search/instances/orleans/search'
+		);
+		expect(seenInit?.method).toBe('POST');
+		expect(seenInit?.headers?.authorization).toBe('Bearer tok-abc');
+		const body = JSON.parse(seenInit?.body ?? '{}');
+		expect(body.query).toBe('dogs at kents point');
+		expect(body.max_num_results).toBe(5);
+	});
+
+	it('reads the alternate chunks[]/text + item.metadata wire shape too', async () => {
+		const alt = {
+			result: {
+				chunks: [
+					{
+						id: 'res-x',
+						score: 0.5,
+						text: 'flat text form',
+						item: {
+							key: 'res-x.md',
+							metadata: { 'source-url': 'https://x/y', title: 'X', kind: 'document' }
+						}
+					}
+				]
+			}
+		};
+		const { passages } = await search('q', { ...CFG, fetch: fakeFetch(alt) });
+		expect(passages).toHaveLength(1);
+		expect(passages[0].text).toBe('flat text form');
+		expect(passages[0].url).toBe('https://x/y');
+		expect(passages[0].kind).toBe('document');
+	});
+
+	it('caps passages per source document', async () => {
+		const dupey = {
+			result: {
+				data: [0, 1, 2].map((i) => ({
+					file_id: 'res-same',
+					score: 1 - i * 0.1,
+					content: [{ type: 'text', text: `chunk ${i}` }],
+					attributes: { 'source-url': 'https://x/same', title: 'Same', kind: 'page' }
+				}))
+			}
+		};
+		const { passages } = await search('q', { ...CFG, maxPerResource: 2, fetch: fakeFetch(dupey) });
+		expect(passages).toHaveLength(2); // 3 candidates from one source, capped to 2
+	});
+
+	it('returns empty for a blank question without calling fetch', async () => {
+		let called = false;
+		const result = await search('   ', {
+			...CFG,
+			fetch: fakeFetch(CANNED, () => {
+				called = true;
+			})
+		});
+		expect(called).toBe(false);
+		expect(result).toEqual({ passages: [], sources: [], context: '' });
+	});
+
+	it('throws a pointed error when config is missing', async () => {
+		await expect(search('q', { fetch: fakeFetch(CANNED) })).rejects.toThrow(/CF_ACCOUNT_ID/);
+	});
+
+	it('surfaces a non-ok response as an error', async () => {
+		const failing: FetchLike = async () => ({
+			ok: false,
+			status: 403,
+			json: async () => ({}),
+			text: async () => 'forbidden'
+		});
+		await expect(search('q', { ...CFG, fetch: failing })).rejects.toThrow(/403/);
+	});
+});

--- a/src/lib/server/rag/search.ts
+++ b/src/lib/server/rag/search.ts
@@ -26,18 +26,19 @@
 import {
 	assembleContext,
 	dedupeSources,
+	DEFAULT_MAX_PER_RESOURCE,
+	DEFAULT_TOP_K,
 	type Passage,
 	type RetrievalResult,
 	type RetrieveOptions,
 	type Source
 } from './retrieve';
 
+// DEFAULT_TOP_K / DEFAULT_MAX_PER_RESOURCE are imported from retrieve.ts (not
+// re-declared) so both providers trim to the same defaults and can't drift apart.
+
 /** Cloudflare REST API base. Overridable for tests (point at a fake server). */
 const CF_API_BASE = 'https://api.cloudflare.com/client/v4';
-const DEFAULT_TOP_K = 8;
-/** Cap passages per source document so one long page can't dominate — mirrors
- *  retrieve.ts's DEFAULT_MAX_PER_RESOURCE so the two providers behave alike. */
-const DEFAULT_MAX_PER_RESOURCE = 3;
 
 /** The injectable `fetch` seam — Node/Bun/Workers all expose this global shape. */
 export type FetchLike = (
@@ -133,7 +134,7 @@ function itemMeta(item: AiSearchResultItem): Record<string, unknown> {
 }
 
 /** Read one metadata key, tolerating the `x-amz-meta-` prefix and `-`/`_` spelling. */
-function metaValue(meta: Record<string, unknown>, key: string): string | undefined {
+function readMeta(meta: Record<string, unknown>, key: string): string | undefined {
 	for (const candidate of [
 		key,
 		`x-amz-meta-${key}`,
@@ -196,10 +197,10 @@ export async function search(question: string, opts: SearchOptions = {}): Promis
 		// Prefer the real source URL from custom metadata; fall back to the object's
 		// own identity so a mis-indexed object still yields a stable (if opaque) key.
 		const objectId = item.file_id ?? item.filename ?? item.id ?? item.item?.key ?? '';
-		const url = metaValue(meta, 'source-url') ?? metaValue(meta, 'url') ?? objectId;
-		if (!url) continue;
+		const sourceUrl = readMeta(meta, 'source-url') ?? readMeta(meta, 'url') ?? objectId;
+		if (!sourceUrl) continue;
 
-		const resourceId = objectId || url;
+		const resourceId = objectId || sourceUrl;
 		const seen = perResource.get(resourceId) ?? 0;
 		if (seen >= maxPerResource) continue;
 		perResource.set(resourceId, seen + 1);
@@ -207,9 +208,9 @@ export async function search(question: string, opts: SearchOptions = {}): Promis
 		passages.push({
 			text,
 			score: typeof item.score === 'number' ? item.score : 0,
-			url,
-			title: metaValue(meta, 'title') ?? null,
-			kind: metaValue(meta, 'kind') ?? 'page',
+			url: sourceUrl,
+			title: readMeta(meta, 'title') ?? null,
+			kind: readMeta(meta, 'kind') ?? 'page',
 			resourceId,
 			chunkIndex: seen
 		});

--- a/src/lib/server/rag/search.ts
+++ b/src/lib/server/rag/search.ts
@@ -1,0 +1,221 @@
+// AI Search retrieval provider (#63) — an ALTERNATE to the custom vectorize
+// pipeline in retrieve.ts, behind the exact same `retrieve()` contract so the two
+// are drop-in interchangeable (see rag/provider.ts + #39's eval switch).
+//
+// Where retrieve.ts embeds the question and runs libSQL `vector_top_k` over our
+// own `chunk` index, this provider delegates retrieval to Cloudflare AI Search
+// (the product formerly called AutoRAG): it POSTs the question to the managed
+// *retrieval-only* endpoint and maps the returned chunks back into the same
+// `{ passages, sources, context }` shape. The index it searches is populated by
+// the R2 exporter (worker/index-export.ts), which writes each `ok` resource's
+// CLEANED text plus `x-amz-meta-source-url` / `title` / `kind` custom metadata —
+// so a hit here carries a real Orleans source URL for citation, not an opaque
+// content-hash blob key.
+//
+// RETRIEVAL-ONLY, on purpose. We hit `…/ai-search/instances/{instance}/search`
+// (returns ranked chunks) and NOT `…/ai-search` (which also runs the model's own
+// generation). Generation stays ours — answer.ts (#37) keeps the Claude grounding
+// policy on top of whatever provider retrieved the passages.
+//
+// Endpoint confirmed from the Cloudflare AI Search REST docs
+// (developers.cloudflare.com/ai-search/usage/rest-api/): the older
+// `…/autorag/rags/{name}/search` path is deprecated in favour of the
+// `ai-search/instances` path used here. The response is read defensively (both the
+// `data[]`/`content[]` and `chunks[]`/`text` shapes the docs describe) since the
+// wire format is still settling and this can only be verified live with creds (#62).
+import {
+	assembleContext,
+	dedupeSources,
+	type Passage,
+	type RetrievalResult,
+	type RetrieveOptions,
+	type Source
+} from './retrieve';
+
+/** Cloudflare REST API base. Overridable for tests (point at a fake server). */
+const CF_API_BASE = 'https://api.cloudflare.com/client/v4';
+const DEFAULT_TOP_K = 8;
+/** Cap passages per source document so one long page can't dominate — mirrors
+ *  retrieve.ts's DEFAULT_MAX_PER_RESOURCE so the two providers behave alike. */
+const DEFAULT_MAX_PER_RESOURCE = 3;
+
+/** The injectable `fetch` seam — Node/Bun/Workers all expose this global shape. */
+export type FetchLike = (
+	input: string,
+	init?: {
+		method?: string;
+		headers?: Record<string, string>;
+		body?: string;
+	}
+) => Promise<{
+	ok: boolean;
+	status: number;
+	json: () => Promise<unknown>;
+	text: () => Promise<string>;
+}>;
+
+/** AI Search-specific knobs. Extends RetrieveOptions so the provider switch can
+ *  hand either provider the SAME `RetrieveOptions` (topK is honored; the extra
+ *  fields default from env / a real `fetch`). */
+export interface SearchOptions extends RetrieveOptions {
+	/** Cloudflare account id. Defaults to `CF_ACCOUNT_ID`. */
+	accountId?: string;
+	/** AI Search instance name. Defaults to `AI_SEARCH_INSTANCE`. */
+	instance?: string;
+	/** Bearer token (AI Search:Run). Defaults to `AI_SEARCH_TOKEN`. */
+	token?: string;
+	/** Injected fetch (tests / non-standard runtime). Defaults to global `fetch`. */
+	fetch?: FetchLike;
+	/** Override the REST API base (tests). Defaults to the Cloudflare base. */
+	apiBase?: string;
+}
+
+// ---------------------------------------------------------------------------
+// The AI Search retrieval response, modelled loosely so both documented shapes
+// map cleanly. Every field is optional because we never trust the wire fully.
+// ---------------------------------------------------------------------------
+interface AiSearchContentPart {
+	type?: string;
+	text?: string;
+}
+interface AiSearchResultItem {
+	// AutoRAG-era identity fields
+	file_id?: string;
+	filename?: string;
+	id?: string;
+	score?: number;
+	// text: an array of content parts (AutoRAG) OR a flat string (chunks[] shape)
+	content?: AiSearchContentPart[] | string;
+	text?: string;
+	// custom metadata surfaces here (attributes) or nested under item.metadata
+	attributes?: Record<string, unknown>;
+	metadata?: Record<string, unknown>;
+	item?: { key?: string; metadata?: Record<string, unknown> };
+}
+interface AiSearchResponse {
+	result?: {
+		data?: AiSearchResultItem[];
+		chunks?: AiSearchResultItem[];
+	};
+	// some shapes return data/chunks at the top level
+	data?: AiSearchResultItem[];
+	chunks?: AiSearchResultItem[];
+	success?: boolean;
+	errors?: unknown;
+}
+
+/** Read a config value from opts, else env, else throw a pointed error. */
+function required(value: string | undefined, envName: string, label: string): string {
+	const v = value ?? process.env[envName];
+	if (!v) {
+		throw new Error(
+			`AI Search retrieval needs ${label} — set ${envName} or pass it via SearchOptions.`
+		);
+	}
+	return v;
+}
+
+/** Flatten an item's text: content parts joined, or the flat `text`, trimmed. */
+function itemText(item: AiSearchResultItem): string {
+	if (typeof item.content === 'string') return item.content.trim();
+	if (Array.isArray(item.content)) {
+		return item.content
+			.map((p) => p.text ?? '')
+			.join('')
+			.trim();
+	}
+	return (item.text ?? '').trim();
+}
+
+/** The metadata bag for an item, wherever the wire put it. */
+function itemMeta(item: AiSearchResultItem): Record<string, unknown> {
+	return { ...(item.item?.metadata ?? {}), ...(item.metadata ?? {}), ...(item.attributes ?? {}) };
+}
+
+/** Read one metadata key, tolerating the `x-amz-meta-` prefix and `-`/`_` spelling. */
+function metaValue(meta: Record<string, unknown>, key: string): string | undefined {
+	for (const candidate of [
+		key,
+		`x-amz-meta-${key}`,
+		key.replace(/-/g, '_'),
+		`x-amz-meta-${key.replace(/-/g, '_')}`
+	]) {
+		const v = meta[candidate];
+		if (typeof v === 'string' && v.trim()) return v.trim();
+	}
+	return undefined;
+}
+
+/**
+ * Retrieve via Cloudflare AI Search. Same signature/return as retrieve() so it's a
+ * drop-in provider: embeds nothing locally, POSTs the question to the managed
+ * retrieval endpoint, and maps each result's text/score + `source-url`/`title`/`kind`
+ * custom metadata into passages with real source attribution.
+ *
+ * Returns empty passages/sources/context for a blank question or an empty result —
+ * callers treat "nothing retrieved" uniformly across providers.
+ */
+export async function search(question: string, opts: SearchOptions = {}): Promise<RetrievalResult> {
+	if (!question.trim()) return { passages: [], sources: [], context: '' };
+
+	const topK = Math.max(1, Math.floor(opts.topK ?? DEFAULT_TOP_K));
+	const maxPerResource = Math.max(1, Math.floor(opts.maxPerResource ?? DEFAULT_MAX_PER_RESOURCE));
+	const accountId = required(opts.accountId, 'CF_ACCOUNT_ID', 'a Cloudflare account id');
+	const instance = required(opts.instance, 'AI_SEARCH_INSTANCE', 'an AI Search instance name');
+	const token = required(opts.token, 'AI_SEARCH_TOKEN', 'an API token');
+	const doFetch = opts.fetch ?? (globalThis.fetch as unknown as FetchLike);
+	const base = (opts.apiBase ?? CF_API_BASE).replace(/\/$/, '');
+
+	const url = `${base}/accounts/${accountId}/ai-search/instances/${encodeURIComponent(instance)}/search`;
+	const res = await doFetch(url, {
+		method: 'POST',
+		headers: {
+			authorization: `Bearer ${token}`,
+			'content-type': 'application/json'
+		},
+		body: JSON.stringify({ query: question, max_num_results: topK })
+	});
+	if (!res.ok) {
+		const detail = await res.text().catch(() => '');
+		throw new Error(`AI Search retrieval failed (${res.status})${detail ? `: ${detail}` : ''}`);
+	}
+
+	const payload = (await res.json()) as AiSearchResponse;
+	const items =
+		payload.result?.data ?? payload.result?.chunks ?? payload.data ?? payload.chunks ?? [];
+
+	// Rank order is the provider's; cap per source, then take top-k — same trimming
+	// discipline as retrieve.ts so one long page can't crowd out other sources.
+	const perResource = new Map<string, number>();
+	const passages: Passage[] = [];
+	for (const item of items) {
+		if (passages.length >= topK) break;
+		const text = itemText(item);
+		if (!text) continue;
+		const meta = itemMeta(item);
+		// Prefer the real source URL from custom metadata; fall back to the object's
+		// own identity so a mis-indexed object still yields a stable (if opaque) key.
+		const objectId = item.file_id ?? item.filename ?? item.id ?? item.item?.key ?? '';
+		const url = metaValue(meta, 'source-url') ?? metaValue(meta, 'url') ?? objectId;
+		if (!url) continue;
+
+		const resourceId = objectId || url;
+		const seen = perResource.get(resourceId) ?? 0;
+		if (seen >= maxPerResource) continue;
+		perResource.set(resourceId, seen + 1);
+
+		passages.push({
+			text,
+			score: typeof item.score === 'number' ? item.score : 0,
+			url,
+			title: metaValue(meta, 'title') ?? null,
+			kind: metaValue(meta, 'kind') ?? 'page',
+			resourceId,
+			chunkIndex: seen
+		});
+	}
+
+	const sources: Source[] = dedupeSources(passages);
+	const context = assembleContext(passages, sources);
+	return { passages, sources, context };
+}

--- a/worker/README.md
+++ b/worker/README.md
@@ -103,6 +103,27 @@ binaries can be skipped: `CRAWLER_MAX_DOC_BYTES` (env default) or per-run
 `params.maxDocBytes` (the dashboard's "Max file size, MB"). Docs over the limit are
 recorded as `probed` (size/etag, no blob); `0` = skip all documents (pages-only).
 
+## AI Search export (`index-export`)
+
+An alternate to embedding: publish the **cleaned** text layer to R2 for Cloudflare
+AI Search to index, so retrieval can be swapped to a managed provider (see
+[`rag/search.ts`](../src/lib/server/rag/search.ts) + `RETRIEVAL_PROVIDER`).
+
+```bash
+bun run worker:index-export   # resource_text (status ok) → R2 index/<resourceId>.md
+```
+
+Each `ok` resource's `resource_text` is written as one object under the `index/`
+prefix with custom metadata `x-amz-meta-source-url` / `title` / `kind` (url/title
+truncated to AI Search's 500-char limit) — so a hit maps back to a **real Orleans
+URL** for citation, unlike the raw sha256-keyed `blobs/`. Non-`ok` resources and any
+object over 4 MB are skipped (logged, never errored). Needs `R2_*` env.
+
+Custom metadata is set via **aws4fetch** (a signed PUT), not the Bun `S3Client` in
+[`storage.ts`](storage.ts): Bun's `S3Options` expose `acl`/`type`/`storageClass`/
+`contentDisposition` but have **no field for `x-amz-meta-*`** metadata, which this
+index depends on.
+
 ## Running
 
 ```bash

--- a/worker/core.ts
+++ b/worker/core.ts
@@ -26,6 +26,7 @@ import { STALE_RUN_MS, TICK_MAX_ITEMS, TICK_TIME_BUDGET_MS } from './config';
 import { createCrawlSession, createSyncSession } from './crawl';
 import { executeExtract } from './extract';
 import { executeEmbed } from './embed';
+import { executeIndexExport } from './index-export';
 import type { WorkerIdentity } from './registry';
 import { workerLogger } from './log';
 
@@ -106,6 +107,8 @@ async function createSession(run: SyncRun, publish: boolean): Promise<RunSession
 			return oneShotSession(run, 'extracting', () => executeExtract(run));
 		case 'embed':
 			return oneShotSession(run, 'embedding', () => executeEmbed(run));
+		case 'index-export':
+			return oneShotSession(run, 'indexing', () => executeIndexExport(run));
 		default:
 			// estimate / crawl / recrawl
 			return createCrawlSession(run, { publish });

--- a/worker/eval/README.md
+++ b/worker/eval/README.md
@@ -12,6 +12,24 @@ bun run eval --markdown # markdown report   ·   --strict (nonzero exit on any m
 
 `--real` is implied when `ANTHROPIC_API_KEY` is set; `--offline` forces fakes.
 
+## Retrieval provider (`RETRIEVAL_PROVIDER`)
+
+The eval honors `RETRIEVAL_PROVIDER`, so custom-vs-AI-Search is one switch:
+
+```sh
+bun run eval                              # vectorize (default): our libSQL vector search
+RETRIEVAL_PROVIDER=ai-search bun run eval # Cloudflare AI Search retrieval
+```
+
+- **`vectorize`** (default) — embed the query + `vector_top_k` over our `chunk` index.
+- **`ai-search`** — Cloudflare AI Search's managed retrieval endpoint
+  (`rag/search.ts`), indexing the cleaned-text export (`worker:index-export`). A
+  **real** run needs `CF_ACCOUNT_ID` / `AI_SEARCH_INSTANCE` / `AI_SEARCH_TOKEN`; an
+  **offline** run uses a deterministic fake AI Search endpoint built from the same
+  fixture corpus (no network), so the switch is exercisable in CI. The comparison is
+  drop-in — both providers return the same `{ passages, sources, context }`, so
+  hit-rate / citation-validity are measured identically.
+
 ## Offline vs. real
 
 - **Offline** (default) runs against a built-in fixture corpus with a deterministic
@@ -52,14 +70,16 @@ ANTHROPIC_API_KEY=… EMBEDDING_PROVIDER=<same> DATABASE_URL="<turso-url>" \
 
 ### Relevant env
 
-| var                                              | purpose                            | default                                                |
-| ------------------------------------------------ | ---------------------------------- | ------------------------------------------------------ |
-| `EMBEDDING_PROVIDER`                             | `cloudflare` \| `openai` \| `fake` | auto (fake if no creds)                                |
-| `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_API_TOKEN` | Workers AI embeddings              | —                                                      |
-| `OPENAI_API_KEY`                                 | OpenAI embeddings                  | —                                                      |
-| `ANTHROPIC_API_KEY`                              | answer LLM (enables `--real`)      | —                                                      |
-| `RAG_ANSWER_MODEL`                               | answer model override              | `claude-haiku-4-5`                                     |
-| `CLOUDFLARE_EMBED_MODEL` / `OPENAI_EMBED_MODEL`  | embed model override               | `@cf/baai/bge-base-en-v1.5` / `text-embedding-3-small` |
+| var                                                        | purpose                            | default                                                |
+| ---------------------------------------------------------- | ---------------------------------- | ------------------------------------------------------ |
+| `EMBEDDING_PROVIDER`                                       | `cloudflare` \| `openai` \| `fake` | auto (fake if no creds)                                |
+| `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_API_TOKEN`           | Workers AI embeddings              | —                                                      |
+| `OPENAI_API_KEY`                                           | OpenAI embeddings                  | —                                                      |
+| `ANTHROPIC_API_KEY`                                        | answer LLM (enables `--real`)      | —                                                      |
+| `RAG_ANSWER_MODEL`                                         | answer model override              | `claude-haiku-4-5`                                     |
+| `CLOUDFLARE_EMBED_MODEL` / `OPENAI_EMBED_MODEL`            | embed model override               | `@cf/baai/bge-base-en-v1.5` / `text-embedding-3-small` |
+| `RETRIEVAL_PROVIDER`                                       | `vectorize` \| `ai-search`         | `vectorize`                                            |
+| `CF_ACCOUNT_ID` / `AI_SEARCH_INSTANCE` / `AI_SEARCH_TOKEN` | AI Search retrieval (real)         | —                                                      |
 
 ## The question set
 

--- a/worker/eval/corpus.ts
+++ b/worker/eval/corpus.ts
@@ -330,3 +330,69 @@ function firstSentence(text: string): string {
 	const s = dot > 0 ? trimmed.slice(0, dot + 1) : trimmed;
 	return s.charAt(0).toLowerCase() + s.slice(1);
 }
+
+// ---------------------------------------------------------------------------
+// Deterministic fake AI Search endpoint.
+//
+// So `RETRIEVAL_PROVIDER=ai-search bun run eval` (and the search() unit path) can
+// run fully offline: a `fetch` stand-in that answers the AI Search retrieval REST
+// call from the SAME fixture corpus, ranking docs by the same lexical coverage the
+// grounding fake uses. Each returned item mirrors the real wire shape — `content`
+// parts, a `score`, and the `x-amz-meta-source-url` / `title` / `kind` custom
+// metadata the exporter writes — so search.ts's mapping produces real source URLs
+// and the eval can compare ai-search vs vectorize head-to-head with no network.
+// ---------------------------------------------------------------------------
+
+/** A minimal `fetch`-shaped response the search() provider can read. */
+interface FakeResponse {
+	ok: boolean;
+	status: number;
+	json: () => Promise<unknown>;
+	text: () => Promise<string>;
+}
+
+/**
+ * Build a fake AI Search `fetch`. It parses the request body's `query` +
+ * `max_num_results`, scores each live fixture doc by content-word coverage, and
+ * returns the top matches as AI Search `result.data[]` items with source-url/title/
+ * kind metadata. Only `active` docs are eligible (the index never holds dead pages).
+ */
+export function makeFakeAiSearchFetch(docs: FixtureDoc[] = fixtureDocs) {
+	const live = docs.filter((d) => d.state !== 'gone' && d.state !== 'error');
+	return async (
+		_url: string,
+		init?: { method?: string; headers?: Record<string, string>; body?: string }
+	): Promise<FakeResponse> => {
+		const body = init?.body
+			? (JSON.parse(init.body) as { query?: string; max_num_results?: number })
+			: {};
+		const query = body.query ?? '';
+		const limit = Math.max(1, body.max_num_results ?? 8);
+		const qWords = contentWords(query);
+
+		const ranked = live
+			.map((d) => ({ d, score: coverage(qWords, d.text) }))
+			.filter((r) => r.score > 0)
+			.sort((a, b) => b.score - a.score)
+			.slice(0, limit);
+
+		const data = ranked.map((r) => ({
+			file_id: r.d.id,
+			filename: `${r.d.id}.md`,
+			score: r.score,
+			content: [{ type: 'text', text: r.d.text }],
+			attributes: {
+				'source-url': r.d.url,
+				title: r.d.title,
+				kind: 'page'
+			}
+		}));
+
+		return {
+			ok: true,
+			status: 200,
+			json: async () => ({ result: { data }, success: true }),
+			text: async () => JSON.stringify({ result: { data }, success: true })
+		};
+	};
+}

--- a/worker/eval/run.ts
+++ b/worker/eval/run.ts
@@ -15,9 +15,11 @@
 //                        Off by default — the report is informational unless asked.
 import { selectEmbedder } from '../embeddings';
 import { retrieve } from '../../src/lib/server/rag/retrieve';
+import { search, type SearchOptions } from '../../src/lib/server/rag/search';
+import { resolveProvider, type RetrievalProvider } from '../../src/lib/server/rag/provider';
 import { answer } from '../../src/lib/server/rag/answer';
 import { questions } from './questions';
-import { createFixtureDb, makeGroundingFakeLlm } from './corpus';
+import { createFixtureDb, makeFakeAiSearchFetch, makeGroundingFakeLlm } from './corpus';
 import { runEval, formatReport, formatMarkdown, type RunEvalDeps } from './harness';
 
 interface CliOptions {
@@ -39,8 +41,34 @@ function parseArgs(argv: string[]): CliOptions {
 	};
 }
 
-/** Offline deps: throwaway DB + fixtures + fakes. Returns deps and a cleanup fn. */
-async function offlineDeps(topK: number): Promise<{ deps: RunEvalDeps; cleanup: () => void }> {
+/** Offline deps: throwaway DB + fixtures + fakes. Returns deps and a cleanup fn.
+ *  The retrieval provider is selected by RETRIEVAL_PROVIDER so the offline eval can
+ *  compare vectorize vs ai-search with no network — ai-search runs against a
+ *  deterministic fake AI Search endpoint built from the same fixture corpus. */
+async function offlineDeps(
+	topK: number,
+	provider: RetrievalProvider
+): Promise<{ deps: RunEvalDeps; cleanup: () => void }> {
+	if (provider === 'ai-search') {
+		// Options are typed SearchOptions (a superset of RetrieveOptions) so the extra
+		// AI Search knobs survive assignment into RunEvalDeps.retrieveOptions.
+		const retrieveOptions: SearchOptions = {
+			topK,
+			fetch: makeFakeAiSearchFetch(),
+			accountId: 'offline',
+			instance: 'offline',
+			token: 'offline'
+		};
+		return {
+			deps: {
+				retrieve: search,
+				answer,
+				retrieveOptions,
+				answerOptions: { llm: makeGroundingFakeLlm() }
+			},
+			cleanup: () => {}
+		};
+	}
 	const { client, embedder, cleanup } = await createFixtureDb();
 	return {
 		deps: {
@@ -53,8 +81,19 @@ async function offlineDeps(topK: number): Promise<{ deps: RunEvalDeps; cleanup: 
 	};
 }
 
-/** Real deps: the worker's own libSQL client (DATABASE_URL) + configured models. */
-async function realDeps(topK: number): Promise<{ deps: RunEvalDeps; cleanup: () => void }> {
+/** Real deps: the worker's own libSQL client (DATABASE_URL) + configured models.
+ *  With RETRIEVAL_PROVIDER=ai-search, retrieval goes to the live AI Search endpoint
+ *  (CF_ACCOUNT_ID / AI_SEARCH_INSTANCE / AI_SEARCH_TOKEN via env) instead. */
+async function realDeps(
+	topK: number,
+	provider: RetrievalProvider
+): Promise<{ deps: RunEvalDeps; cleanup: () => void }> {
+	if (provider === 'ai-search') {
+		return {
+			deps: { retrieve: search, answer, retrieveOptions: { topK } },
+			cleanup: () => {}
+		};
+	}
 	// Import lazily so the offline path never needs DATABASE_URL.
 	const { client } = await import('../db');
 	const embedder = selectEmbedder();
@@ -67,8 +106,12 @@ async function realDeps(topK: number): Promise<{ deps: RunEvalDeps; cleanup: () 
 
 async function main(): Promise<void> {
 	const opts = parseArgs(process.argv.slice(2));
-	const { deps, cleanup } = opts.real ? await realDeps(opts.topK) : await offlineDeps(opts.topK);
-	const title = opts.real ? 'RAG eval (real models + live archive)' : 'RAG eval (offline fakes)';
+	const provider = resolveProvider(); // RETRIEVAL_PROVIDER: vectorize (default) | ai-search
+	const { deps, cleanup } = opts.real
+		? await realDeps(opts.topK, provider)
+		: await offlineDeps(opts.topK, provider);
+	const base = opts.real ? 'RAG eval (real models + live archive)' : 'RAG eval (offline fakes)';
+	const title = `${base} · retrieval: ${provider}`;
 
 	try {
 		const report = await runEval(questions, deps);

--- a/worker/index-export.test.ts
+++ b/worker/index-export.test.ts
@@ -1,0 +1,260 @@
+// Cleaned-text R2 exporter test (#63). Three layers, all offline:
+//   1. buildIndexObject / metaValue — the pure selection + skip + truncation rules
+//      (non-ok skipped, oversize skipped, url/title metadata capped at 500 chars).
+//   2. makeR2IndexWriter against a STUB S3 server (node http) — proves the real
+//      aws4fetch-signed PUT carries the object body + x-amz-meta-source-url/title/
+//      kind custom headers (the metadata Bun's S3Client can't set). Mirrors the
+//      #30 storage test's "stub S3 server" approach.
+//   3. executeIndexExport against a seeded libSQL DB + an injected capturing writer
+//      — proves the run exports only `ok` resources with correct keys + metadata and
+//      finalizes the sync_run.
+import { afterAll, beforeAll, describe, it, expect } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+	buildIndexObject,
+	metaValue,
+	makeR2IndexWriter,
+	MAX_OBJECT_BYTES,
+	META_VALUE_MAX,
+	type IndexObjectMeta,
+	type IndexWriter
+} from './index-export';
+
+const okRow = {
+	resourceId: 'res-1',
+	url: 'https://www.town.orleans.ma.us/beach',
+	title: 'Beach Stickers',
+	kind: 'page',
+	status: 'ok',
+	text: 'Nauset Beach resident parking stickers and beach permits.'
+};
+
+describe('buildIndexObject', () => {
+	it('builds an index/<resourceId>.md object with source-url/title/kind metadata', () => {
+		const obj = buildIndexObject(okRow);
+		if ('skip' in obj) throw new Error(`unexpected skip: ${obj.skip}`);
+		expect(obj.key).toBe('index/res-1.md');
+		expect(obj.contentType).toBe('text/markdown; charset=utf-8');
+		expect(new TextDecoder().decode(obj.bytes)).toBe(okRow.text);
+		expect(obj.meta).toEqual({
+			sourceUrl: 'https://www.town.orleans.ma.us/beach',
+			title: 'Beach Stickers',
+			kind: 'page'
+		});
+	});
+
+	it('skips non-ok resources', () => {
+		for (const status of ['empty', 'scanned', 'unsupported']) {
+			expect(buildIndexObject({ ...okRow, status })).toEqual({ skip: `status ${status} (not ok)` });
+		}
+	});
+
+	it('skips a resource with blank text', () => {
+		expect(buildIndexObject({ ...okRow, text: '   ' })).toEqual({ skip: 'empty text' });
+		expect(buildIndexObject({ ...okRow, text: null })).toEqual({ skip: 'empty text' });
+	});
+
+	it('skips an object over the 4 MB ceiling', () => {
+		const big = 'x'.repeat(MAX_OBJECT_BYTES + 1);
+		const obj = buildIndexObject({ ...okRow, text: big });
+		expect('skip' in obj && obj.skip).toMatch(/oversize/);
+	});
+
+	it('accepts an object exactly at the ceiling', () => {
+		const exact = 'x'.repeat(MAX_OBJECT_BYTES);
+		expect('skip' in buildIndexObject({ ...okRow, text: exact })).toBe(false);
+	});
+
+	it('truncates url/title metadata to the AI Search 500-char limit', () => {
+		const longUrl = 'https://x/' + 'a'.repeat(600);
+		const obj = buildIndexObject({ ...okRow, url: longUrl, title: 'b'.repeat(600) });
+		if ('skip' in obj) throw new Error('unexpected skip');
+		expect(obj.meta.sourceUrl).toHaveLength(META_VALUE_MAX);
+		expect(obj.meta.title).toHaveLength(META_VALUE_MAX);
+	});
+});
+
+describe('metaValue', () => {
+	it('strips non-ASCII and control chars to a valid header value', () => {
+		expect(metaValue('Beach — Stickers\n\t(été)')).toBe('Beach  Stickers (t)');
+	});
+	it('defaults null/undefined to empty', () => {
+		expect(metaValue(null)).toBe('');
+		expect(metaValue(undefined)).toBe('');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// makeR2IndexWriter against a stub S3 server.
+// ---------------------------------------------------------------------------
+interface CapturedPut {
+	method: string;
+	path: string;
+	headers: Record<string, string | string[] | undefined>;
+	body: string;
+}
+
+describe('makeR2IndexWriter (aws4fetch → stub S3)', () => {
+	let server: Server;
+	let base: string;
+	const puts: CapturedPut[] = [];
+
+	beforeAll(async () => {
+		server = createServer((req, res) => {
+			const chunks: Buffer[] = [];
+			req.on('data', (c) => chunks.push(c));
+			req.on('end', () => {
+				puts.push({
+					method: req.method ?? '',
+					path: req.url ?? '',
+					headers: req.headers,
+					body: Buffer.concat(chunks).toString('utf8')
+				});
+				res.writeHead(200).end();
+			});
+		});
+		await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+		const addr = server.address();
+		if (!addr || typeof addr === 'string') throw new Error('no server address');
+		base = `http://127.0.0.1:${addr.port}`;
+	});
+
+	afterAll(() => {
+		server?.close();
+	});
+
+	it('signs a PUT carrying the body + x-amz-meta-* custom metadata', async () => {
+		const writer = makeR2IndexWriter({
+			endpoint: base,
+			bucket: 'test-bucket',
+			accessKeyId: 'AKIA_TEST',
+			secretAccessKey: 'secret'
+		});
+		expect(writer).not.toBeNull();
+
+		const meta: IndexObjectMeta = {
+			sourceUrl: 'https://www.town.orleans.ma.us/beach',
+			title: 'Beach Stickers',
+			kind: 'page'
+		};
+		await writer!.put(
+			'index/res-1.md',
+			new TextEncoder().encode('hello clean text'),
+			'text/markdown; charset=utf-8',
+			meta
+		);
+
+		expect(puts).toHaveLength(1);
+		const put = puts[0];
+		expect(put.method).toBe('PUT');
+		expect(put.path).toBe('/test-bucket/index/res-1.md');
+		expect(put.body).toBe('hello clean text');
+		expect(put.headers['x-amz-meta-source-url']).toBe('https://www.town.orleans.ma.us/beach');
+		expect(put.headers['x-amz-meta-title']).toBe('Beach Stickers');
+		expect(put.headers['x-amz-meta-kind']).toBe('page');
+		expect(String(put.headers['content-type'])).toContain('text/markdown');
+		// aws4fetch signs the request — so the metadata is part of the signature.
+		expect(String(put.headers['authorization'])).toMatch(/^AWS4-HMAC-SHA256/);
+	});
+
+	it('returns null when R2 config is incomplete', () => {
+		expect(makeR2IndexWriter({ endpoint: base })).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// executeIndexExport against a seeded DB + injected capturing writer.
+// ---------------------------------------------------------------------------
+const drizzleDir = fileURLToPath(new URL('../drizzle/', import.meta.url));
+
+describe('executeIndexExport', () => {
+	let tmp: string;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	let db: any;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	let schema: any;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	let client: any;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	let executeIndexExport: any;
+
+	beforeAll(async () => {
+		(globalThis as unknown as { Bun?: unknown }).Bun ??= { sleep: () => Promise.resolve() };
+		tmp = mkdtempSync(join(tmpdir(), 'index-export-'));
+		process.env.DATABASE_URL = `file:${join(tmp, 'test.db')}`;
+		delete process.env.DATABASE_AUTH_TOKEN;
+		({ db, client } = await import('./db'));
+		schema = await import('../src/lib/server/db/schema');
+		const { applyMigrations } = await import('../src/lib/server/db/migrator');
+		({ executeIndexExport } = await import('./index-export'));
+		const entries = readdirSync(drizzleDir)
+			.filter((f) => f.endsWith('.sql'))
+			.map((name) => ({ name, sql: readFileSync(join(drizzleDir, name), 'utf8') }));
+		await applyMigrations(client, entries);
+
+		// Two `ok` resources (should export) + one `empty` (should not).
+		const rows = [
+			{ id: 'r-ok-1', url: 'https://x/one', title: 'One', status: 'ok', text: 'clean text one' },
+			{ id: 'r-ok-2', url: 'https://x/two', title: 'Two', status: 'ok', text: 'clean text two' },
+			{ id: 'r-empty', url: 'https://x/none', title: 'None', status: 'empty', text: null }
+		];
+		for (const r of rows) {
+			await db.insert(schema.resource).values({
+				id: r.id,
+				url: r.url,
+				urlHash: `h-${r.id}`,
+				host: 'x',
+				path: new URL(r.url).pathname,
+				kind: 'page',
+				title: r.title,
+				state: 'active',
+				sha256: `sha-${r.id}`
+			});
+			await db.insert(schema.resourceText).values({
+				resourceId: r.id,
+				sha256: `sha-${r.id}`,
+				contentType: 'text/html',
+				status: r.status,
+				text: r.text,
+				charCount: r.text?.length ?? 0,
+				extractor: 'test'
+			});
+		}
+	});
+
+	afterAll(() => {
+		client?.close();
+		if (tmp) rmSync(tmp, { recursive: true, force: true });
+	});
+
+	it('exports only ok resources with correct keys + metadata, and finalizes the run', async () => {
+		const written: { key: string; meta: IndexObjectMeta; text: string }[] = [];
+		const writer: IndexWriter = {
+			label: 'capture',
+			async put(key, bytes, _ct, meta) {
+				written.push({ key, meta, text: new TextDecoder().decode(bytes) });
+			}
+		};
+
+		const [run] = await db
+			.insert(schema.syncRun)
+			.values({ mode: 'index-export', status: 'queued', requestedBy: 'test' })
+			.returning();
+
+		await executeIndexExport(run, { writer });
+
+		expect(written.map((w) => w.key).sort()).toEqual(['index/r-ok-1.md', 'index/r-ok-2.md']);
+		// the empty resource was never written
+		expect(written.some((w) => w.key.includes('r-empty'))).toBe(false);
+		const one = written.find((w) => w.key === 'index/r-ok-1.md');
+		expect(one?.text).toBe('clean text one');
+		expect(one?.meta).toEqual({ sourceUrl: 'https://x/one', title: 'One', kind: 'page' });
+
+		const [finished] = await db.select().from(schema.syncRun).limit(1);
+		expect(finished.status).toBe('completed');
+	});
+});

--- a/worker/index-export.test.ts
+++ b/worker/index-export.test.ts
@@ -1,5 +1,5 @@
 // Cleaned-text R2 exporter test (#63). Three layers, all offline:
-//   1. buildIndexObject / metaValue — the pure selection + skip + truncation rules
+//   1. buildIndexObject / sanitizeMetaValue — the pure selection + skip + truncation rules
 //      (non-ok skipped, oversize skipped, url/title metadata capped at 500 chars).
 //   2. makeR2IndexWriter against a STUB S3 server (node http) — proves the real
 //      aws4fetch-signed PUT carries the object body + x-amz-meta-source-url/title/
@@ -16,7 +16,7 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
 	buildIndexObject,
-	metaValue,
+	sanitizeMetaValue,
 	makeR2IndexWriter,
 	MAX_OBJECT_BYTES,
 	META_VALUE_MAX,
@@ -78,13 +78,13 @@ describe('buildIndexObject', () => {
 	});
 });
 
-describe('metaValue', () => {
+describe('sanitizeMetaValue', () => {
 	it('strips non-ASCII and control chars to a valid header value', () => {
-		expect(metaValue('Beach — Stickers\n\t(été)')).toBe('Beach  Stickers (t)');
+		expect(sanitizeMetaValue('Beach — Stickers\n\t(été)')).toBe('Beach  Stickers (t)');
 	});
 	it('defaults null/undefined to empty', () => {
-		expect(metaValue(null)).toBe('');
-		expect(metaValue(undefined)).toBe('');
+		expect(sanitizeMetaValue(null)).toBe('');
+		expect(sanitizeMetaValue(undefined)).toBe('');
 	});
 });
 

--- a/worker/index-export.ts
+++ b/worker/index-export.ts
@@ -1,0 +1,313 @@
+// Cleaned-text R2 exporter (#63) — the INDEXING side of the AI Search adapter.
+//
+// AI Search (rag/search.ts) can only cite what it indexes, and the content-addressed
+// `blob`s in R2 are the RAW scrape: nav-heavy, sha256-keyed, and carrying NO
+// source-URL metadata — the wrong layer to feed a retrieval index. This mode writes
+// the CLEAN layer instead: for every resource whose extraction landed `ok` (#34),
+// it publishes the cleaned `resource_text` as one object under a dedicated R2
+// prefix (`index/`), tagged with custom metadata so a hit maps back to a real
+// Orleans URL:
+//
+//   index/<resourceId>.md   (text/markdown)
+//     x-amz-meta-source-url : the resource's URL   (≤500 chars, AI Search's limit)
+//     x-amz-meta-title      : the resource's title (≤500 chars)
+//     x-amz-meta-kind       : page | document | …
+//
+// WHY NOT worker/storage.ts's Bun S3Client: Bun's native `S3Client.write()` options
+// (S3Options) expose acl/type/storageClass/contentDisposition but have NO field for
+// custom `x-amz-meta-*` metadata (confirmed against bun-types s3.d.ts / the Bun S3
+// docs). So the metadata this index depends on can't be set through that path. We
+// use aws4fetch instead — already a dependency, already the app's R2 signer
+// (src/lib/server/blob.ts) — which signs a plain PUT with arbitrary headers.
+//
+// Skips: non-`ok` resources (nothing clean to index) and any object over 4 MB — both
+// logged via the structured logger, never errored.
+import { and, asc, eq, gt } from 'drizzle-orm';
+import { AwsClient } from 'aws4fetch';
+import { crawlEvent, resource, resourceText, syncRun } from '../src/lib/server/db/schema';
+import type { SyncRun } from '../src/lib/server/db/crawl.schema';
+import { runLogger } from './log';
+
+// `db` + `registry` are imported LAZILY inside executeIndexExport (below) so the
+// pure/writer helpers here — buildIndexObject / makeR2IndexWriter — stay import-safe
+// without a configured DATABASE_URL (tests exercise them directly). Mirrors the same
+// lazy-db seam in rag/retrieve.ts.
+
+/** R2 prefix the export lands under (kept separate from `blobs/`). */
+export const INDEX_PREFIX = 'index/';
+/** Objects larger than this are skipped — AI Search's per-file ceiling. */
+export const MAX_OBJECT_BYTES = 4 * 1024 * 1024;
+/** AI Search truncates custom metadata values at 500 chars; we do it up front. */
+export const META_VALUE_MAX = 500;
+
+const HEARTBEAT_MS = 2000;
+const BATCH = 200; // resources per DB round-trip
+
+/** Custom metadata attached to each exported object (→ `x-amz-meta-*`). */
+export interface IndexObjectMeta {
+	sourceUrl: string;
+	title: string;
+	kind: string;
+}
+
+/** A ready-to-write index object, or a reason it was skipped. */
+export type IndexObject =
+	{ key: string; bytes: Uint8Array; contentType: string; meta: IndexObjectMeta } | { skip: string };
+
+/** One resource's extraction row, as selected for export. */
+export interface ExportRow {
+	resourceId: string;
+	url: string;
+	title: string | null;
+	kind: string;
+	status: string;
+	text: string | null;
+}
+
+/** Strip a value to a valid, single-line ASCII HTTP-header ByteString and truncate
+ *  to AI Search's 500-char metadata limit. Non-ASCII (e.g. a title's em-dash) is
+ *  dropped rather than encoded — attribution rides on the ASCII source URL, and a
+ *  header can't carry raw Unicode. */
+export function metaValue(raw: string | null | undefined): string {
+	return (raw ?? '')
+		.replace(/[\r\n\t]+/g, ' ')
+		.replace(/[^\x20-\x7E]/g, '')
+		.trim()
+		.slice(0, META_VALUE_MAX);
+}
+
+/**
+ * Decide what (if anything) to export for one resource. Pure + injectable so the
+ * selection/skip/truncation rules are unit-testable without a DB or R2:
+ *   • non-`ok` status or blank text → skip (nothing clean to index),
+ *   • text over `maxBytes` → skip (too big for AI Search),
+ *   • otherwise a `index/<resourceId>.md` object + source-url/title/kind metadata.
+ */
+export function buildIndexObject(row: ExportRow, maxBytes = MAX_OBJECT_BYTES): IndexObject {
+	if (row.status !== 'ok') return { skip: `status ${row.status} (not ok)` };
+	const text = row.text ?? '';
+	if (!text.trim()) return { skip: 'empty text' };
+
+	const bytes = new TextEncoder().encode(text);
+	if (bytes.length > maxBytes) {
+		return { skip: `oversize (${bytes.length} bytes > ${maxBytes})` };
+	}
+
+	return {
+		key: `${INDEX_PREFIX}${row.resourceId}.md`,
+		bytes,
+		contentType: 'text/markdown; charset=utf-8',
+		meta: {
+			sourceUrl: metaValue(row.url),
+			title: metaValue(row.title),
+			kind: metaValue(row.kind) || 'page'
+		}
+	};
+}
+
+// ---------------------------------------------------------------------------
+// The index writer — a plain PUT to R2 with custom metadata headers, signed by
+// aws4fetch. Injectable so the exporter can be driven against a stub S3 server.
+// ---------------------------------------------------------------------------
+export interface IndexWriter {
+	readonly label: string;
+	put(key: string, bytes: Uint8Array, contentType: string, meta: IndexObjectMeta): Promise<void>;
+}
+
+export interface R2WriterConfig {
+	endpoint: string;
+	bucket: string;
+	accessKeyId: string;
+	secretAccessKey: string;
+}
+
+/** Build the R2 index writer from config (defaults to R2_* env). Returns null when
+ *  R2 isn't configured — the run then fails fast with a clear message. */
+export function makeR2IndexWriter(cfg: Partial<R2WriterConfig> = {}): IndexWriter | null {
+	const endpoint = cfg.endpoint ?? process.env.R2_ENDPOINT;
+	const bucket = cfg.bucket ?? process.env.R2_BUCKET;
+	const accessKeyId = cfg.accessKeyId ?? process.env.R2_ACCESS_KEY_ID;
+	const secretAccessKey = cfg.secretAccessKey ?? process.env.R2_SECRET_ACCESS_KEY;
+	if (!endpoint || !bucket || !accessKeyId || !secretAccessKey) return null;
+
+	const client = new AwsClient({ accessKeyId, secretAccessKey, service: 's3', region: 'auto' });
+	const base = endpoint.replace(/\/$/, '');
+	return {
+		label: `R2 index writer (${bucket}/${INDEX_PREFIX})`,
+		async put(key, bytes, contentType, meta) {
+			const url = `${base}/${bucket}/${key}`;
+			const res = await client.fetch(url, {
+				method: 'PUT',
+				// aws4fetch signs x-amz-* headers, so this metadata is part of the request.
+				headers: {
+					'content-type': contentType,
+					'x-amz-meta-source-url': meta.sourceUrl,
+					'x-amz-meta-title': meta.title,
+					'x-amz-meta-kind': meta.kind
+				},
+				body: bytes
+			});
+			if (!res.ok) {
+				const detail = await res.text().catch(() => '');
+				throw new Error(`R2 PUT ${key} failed (${res.status})${detail ? `: ${detail}` : ''}`);
+			}
+		}
+	};
+}
+
+// ---------------------------------------------------------------------------
+// The export run.
+// ---------------------------------------------------------------------------
+interface ExportStats {
+	processed: number; // resources we looked at this run
+	written: number; // objects written to the index prefix
+	skipped: number; // non-ok / oversize
+	errors: number;
+}
+
+function zero(): ExportStats {
+	return { processed: 0, written: 0, skipped: 0, errors: 0 };
+}
+
+/**
+ * Export cleaned text for every `ok` resource to the R2 `index/` prefix with
+ * source-URL/title/kind metadata. Mirrors extract/embed's run scaffolding
+ * (heartbeat, pause/cancel, syncRun lifecycle); the writer is injectable so tests
+ * point it at a stub S3 server.
+ */
+export async function executeIndexExport(
+	run: SyncRun,
+	opts: { writer?: IndexWriter } = {}
+): Promise<void> {
+	const runId = run.id;
+	const maxPages = run.maxPages ?? Infinity; // --max caps processed count (testing)
+	const log = runLogger('index-export', run, 'indexing');
+	// Lazy so the module stays import-safe without DATABASE_URL (see note up top).
+	const { db } = await import('./db');
+	const { refreshActiveWorker } = await import('./registry');
+	const writer = opts.writer ?? makeR2IndexWriter();
+	if (!writer) {
+		throw new Error(
+			'index-export requires R2_* env vars (R2_ENDPOINT / R2_BUCKET / R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY).'
+		);
+	}
+	const stats = zero();
+	let control: string = run.control;
+	let lastBeat = 0;
+
+	async function beat(currentUrl: string | null): Promise<void> {
+		const nowMs = Date.now();
+		if (nowMs - lastBeat < HEARTBEAT_MS) return;
+		lastBeat = nowMs;
+		await refreshActiveWorker(run.workerId, runId, 'indexing');
+		const [row] = await db
+			.update(syncRun)
+			.set({ heartbeatAt: new Date(), currentUrl })
+			.where(eq(syncRun.id, runId))
+			.returning({ control: syncRun.control });
+		control = row?.control ?? 'none';
+	}
+
+	await db
+		.update(syncRun)
+		.set({ status: 'running', startedAt: new Date(), currentPhase: 'indexing' })
+		.where(eq(syncRun.id, runId));
+
+	log.info({ writer: writer.label }, 'index export started');
+
+	// Walk every `ok` resource_text (only `ok` carries clean text) joined to its
+	// resource for the source URL / title / kind attribution.
+	let cursor = '';
+	while (stats.processed < maxPages) {
+		await beat(null);
+		if (control === 'cancel') break;
+		while (control === 'pause') {
+			await db.update(syncRun).set({ status: 'paused' }).where(eq(syncRun.id, runId));
+			await Bun.sleep(1500);
+			lastBeat = 0;
+			await beat(null);
+			if (control === 'cancel') break;
+			if (control !== 'pause') {
+				await db.update(syncRun).set({ status: 'running' }).where(eq(syncRun.id, runId));
+			}
+		}
+		if (control === 'cancel') break;
+
+		const batch = await db
+			.select({
+				rtId: resourceText.id,
+				resourceId: resourceText.resourceId,
+				status: resourceText.status,
+				text: resourceText.text,
+				url: resource.url,
+				title: resource.title,
+				kind: resource.kind
+			})
+			.from(resourceText)
+			.innerJoin(resource, eq(resource.id, resourceText.resourceId))
+			.where(and(gt(resourceText.id, cursor), eq(resourceText.status, 'ok')))
+			.orderBy(asc(resourceText.id))
+			.limit(BATCH);
+		if (batch.length === 0) break; // caught up
+
+		for (const r of batch) {
+			if (stats.processed >= maxPages) break;
+			cursor = r.rtId;
+			await beat(r.url);
+			if (control === 'cancel') break;
+
+			try {
+				const obj = buildIndexObject({
+					resourceId: r.resourceId,
+					url: r.url,
+					title: r.title,
+					kind: r.kind,
+					status: r.status,
+					text: r.text
+				});
+				stats.processed++;
+				if ('skip' in obj) {
+					stats.skipped++;
+					log.info({ url: r.url, resourceId: r.resourceId, reason: obj.skip }, 'index export skip');
+					continue;
+				}
+				await writer.put(obj.key, obj.bytes, obj.contentType, obj.meta);
+				stats.written++;
+			} catch (e) {
+				stats.errors++;
+				const msg = e instanceof Error ? e.message : String(e);
+				await db.insert(crawlEvent).values({
+					runId,
+					resourceId: r.resourceId,
+					url: r.url,
+					kind: 'index_export_error',
+					message: `index export failed: ${msg}`.slice(0, 500)
+				});
+				log.error({ err: e, url: r.url, resourceId: r.resourceId }, 'index export failed');
+			}
+		}
+	}
+
+	const status = control === 'cancel' ? 'canceled' : 'completed';
+	await db
+		.update(syncRun)
+		.set({
+			status,
+			finishedAt: new Date(),
+			currentUrl: null,
+			currentPhase: null,
+			heartbeatAt: new Date()
+		})
+		.where(eq(syncRun.id, runId));
+
+	log.info(
+		{
+			status,
+			processed: stats.processed,
+			written: stats.written,
+			skipped: stats.skipped,
+			errors: stats.errors
+		},
+		'index export finished'
+	);
+}

--- a/worker/index-export.ts
+++ b/worker/index-export.ts
@@ -68,7 +68,7 @@ export interface ExportRow {
  *  to AI Search's 500-char metadata limit. Non-ASCII (e.g. a title's em-dash) is
  *  dropped rather than encoded — attribution rides on the ASCII source URL, and a
  *  header can't carry raw Unicode. */
-export function metaValue(raw: string | null | undefined): string {
+export function sanitizeMetaValue(raw: string | null | undefined): string {
 	return (raw ?? '')
 		.replace(/[\r\n\t]+/g, ' ')
 		.replace(/[^\x20-\x7E]/g, '')
@@ -98,9 +98,9 @@ export function buildIndexObject(row: ExportRow, maxBytes = MAX_OBJECT_BYTES): I
 		bytes,
 		contentType: 'text/markdown; charset=utf-8',
 		meta: {
-			sourceUrl: metaValue(row.url),
-			title: metaValue(row.title),
-			kind: metaValue(row.kind) || 'page'
+			sourceUrl: sanitizeMetaValue(row.url),
+			title: sanitizeMetaValue(row.title),
+			kind: sanitizeMetaValue(row.kind) || 'page'
 		}
 	};
 }

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -11,6 +11,7 @@
 //   bun run worker/index.ts --publish             # ...writing blobs through to R2
 //   bun run worker/index.ts --mode estimate --max 80 --once
 //   bun run worker/index.ts --mode crawl          # enqueue + run once, then exit
+//   bun run worker/index.ts --mode index-export --once   # publish cleaned text to R2 index/
 //
 // Publishing is opt-in: without --publish the worker holds blobs in the LOCAL
 // backend only (r2_synced_at null); with --publish it writes through to R2 (the


### PR DESCRIPTION
Closes #63

Adds an alternate retrieval path behind the existing `retrieve()` contract so the custom vectorize pipeline can be compared head-to-head with Cloudflare AI Search. All three pieces are injectable and offline-tested; **no live AI Search call is needed** — the live comparison/tuning remains #62.

## What's here

1. **R2 cleaned-text exporter** — `--mode index-export` (+ `worker:index-export` script → `worker/index-export.ts`). Writes each `ok` `resource_text` to the R2 `index/` prefix as one `index/<resourceId>.md` object with custom metadata `x-amz-meta-source-url` / `title` / `kind` (url/title truncated to ≤500 chars). Non-`ok` and objects >4 MB are skipped and logged via the structured logger.
2. **`search()` provider** (`src/lib/server/rag/search.ts`) — calls the AI Search **retrieval-only** REST endpoint via an injectable `fetch` + bearer token, mapping each result's content/score + `source-url`/`title` metadata into the same `{ passages, sources, context }` shape (reusing retrieve.ts's `dedupeSources`/`assembleContext` so it's byte-identical/drop-in). Config: `CF_ACCOUNT_ID` / `AI_SEARCH_INSTANCE` / `AI_SEARCH_TOKEN`.
3. **Provider switch** (`src/lib/server/rag/provider.ts`) — `RETRIEVAL_PROVIDER=vectorize|ai-search` (default `vectorize`), honored by `answer.ts` and the eval. Default behavior unchanged.

## Confirmed AI Search REST endpoint

`POST https://api.cloudflare.com/client/v4/accounts/{CF_ACCOUNT_ID}/ai-search/instances/{AI_SEARCH_INSTANCE}/search` — the **retrieval-only** `/search` (ranked chunks), **not** the generative `/ai-search`. Per the current Cloudflare AI Search REST docs this supersedes the older `…/autorag/rags/{name}/search` path (deprecated). Generation stays ours (answer.ts keeps the Claude grounding policy on top). The response is mapped defensively (both the `data[]`/`content[]` and `chunks[]`/`text` shapes) and the base URL is injectable — the exact path is verifiable only live (#62).

## Bun S3 custom-metadata caveat

The brief suggested reusing `worker/storage.ts`'s Bun `S3Client` and setting metadata via its put options. Bun's `S3Options` (confirmed against bun-types `s3.d.ts` / the Bun S3 docs) expose `acl`/`type`/`storageClass`/`contentDisposition` but have **no field for custom `x-amz-meta-*` metadata**. The exporter therefore uses **aws4fetch** (a signed PUT) — already a dependency and already the app's R2 signer (`src/lib/server/blob.ts`) — documented inline.

## Acceptance criteria

- [x] Exporter writes cleaned text + `source-url`/`title`/`kind` metadata to R2 `index/`; non-`ok`/oversize skipped + logged — verified against a stub S3 server.
- [x] `search()` conforms to `retrieve()`'s interface, calls the REST retrieval endpoint via an injectable `fetch`, maps results incl. real source-URL attribution — unit-tested with a fake fetch.
- [x] `RETRIEVAL_PROVIDER` cleanly switches custom vs AI Search across `retrieve()` and the eval; default (vectorize) unchanged.
- [x] `bun run check` + lint clean; offline tests pass.

## Offline verify coverage

- `bun run check` + `bun run lint` clean; full server unit suite green (+24 new tests).
- **Exporter**: `buildIndexObject`/`sanitizeMetaValue` unit tests (skip non-ok, skip >4 MB, ≤500-char truncation, header sanitization); `makeR2IndexWriter` against a stub S3 HTTP server (asserts the real aws4fetch-signed PUT carries body + `x-amz-meta-*` headers); DB-driven `executeIndexExport` with an injected capturing writer.
- **End-to-end CLI**: ran the real `--mode index-export` against a seeded local DB + stub S3 — 2 `ok` resources written with correct keys + metadata, 1 non-ok skipped, run finalized.
- **`search()`**: fake-fetch tests for mapping, source-URL attribution, endpoint/auth/body shape, per-source cap, blank-question short-circuit, missing-config + non-ok errors.
- **Switch**: `provider.test.ts` (default vectorize, ai-search selection, unknown → default). `bun run eval` and `RETRIEVAL_PROVIDER=ai-search bun run eval` both pass offline at 100% (ai-search via a deterministic fake AI Search endpoint built from the fixture corpus).

## Reviewer must-checks

- **Endpoint path is plausible-not-confirmed** — verifiable only with live creds (#62). It's injectable via `apiBase`; the response mapping tolerates both documented wire shapes.
- **Minor scope note**: per-resource write failures also insert a `crawl_event` (`kind: 'index_export_error'`), mirroring extract/embed's error channel — no schema change.

No schema/migration change. Squash-merge only.